### PR TITLE
Compiler warnings and linting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,5 +71,6 @@ OsgiKeys.privatePackage := Seq()
 OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
 
 scalacOptions ++= Seq(
-  "-deprecation"
+  "-deprecation",
+  "-encoding", "UTF-8" // yes, this is 2 args
 )

--- a/build.sbt
+++ b/build.sbt
@@ -73,5 +73,6 @@ OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.
 scalacOptions ++= Seq(
   "-deprecation",
   "-encoding", "UTF-8", // yes, this is 2 args
+  "-feature",
   "-unchecked"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -72,5 +72,6 @@ OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.
 
 scalacOptions ++= Seq(
   "-deprecation",
-  "-encoding", "UTF-8" // yes, this is 2 args
+  "-encoding", "UTF-8", // yes, this is 2 args
+  "-unchecked"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -77,15 +77,17 @@ val allVersionCompilerLintSwitches = Seq(
   "-unchecked",
   "-Xfatal-warnings",
   "-Xlint",
-  "-Yno-adapted-args"
+  "-Yno-adapted-args",
+  "-Ywarn-dead-code"
 )
 
 val newerCompilerLintSwitches = Seq(
+  "-Ywarn-unused-import", // Not available in 2.10
   "-Ywarn-numeric-widen" // In 2.10 this produces a some strange spurious error
 )
 
 scalacOptions ++= allVersionCompilerLintSwitches
 
-scalacOptions ++= scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
+scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
     case Some((2, scalaMajor)) if scalaMajor >= 11 => newerCompilerLintSwitches
 }.toList.flatten

--- a/build.sbt
+++ b/build.sbt
@@ -69,3 +69,7 @@ OsgiKeys.exportPackage := Seq("pureconfig", "pureconfig.conf", "pureconfig.conf.
 OsgiKeys.privatePackage := Seq()
 
 OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+
+scalacOptions ++= Seq(
+  "-deprecation"
+)

--- a/build.sbt
+++ b/build.sbt
@@ -70,9 +70,22 @@ OsgiKeys.privatePackage := Seq()
 
 OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
 
-scalacOptions ++= Seq(
+val allVersionCompilerLintSwitches = Seq(
   "-deprecation",
   "-encoding", "UTF-8", // yes, this is 2 args
   "-feature",
-  "-unchecked"
+  "-unchecked",
+  "-Xfatal-warnings",
+  "-Xlint",
+  "-Yno-adapted-args"
 )
+
+val newerCompilerLintSwitches = Seq(
+  "-Ywarn-numeric-widen" // In 2.10 this produces a some strange spurious error
+)
+
+scalacOptions ++= allVersionCompilerLintSwitches
+
+scalacOptions ++= scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
+    case Some((2, scalaMajor)) if scalaMajor >= 11 => newerCompilerLintSwitches
+}.toList.flatten

--- a/src/main/scala/pureconfig/package.scala
+++ b/src/main/scala/pureconfig/package.scala
@@ -10,7 +10,7 @@ import java.nio.file.{ Files, Path }
 import com.typesafe.config.ConfigFactory
 import pureconfig.conf.RawConfig
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.Try
 
 package object pureconfig {
 

--- a/src/test/scala/pureconfig/DurationConvertTest.scala
+++ b/src/test/scala/pureconfig/DurationConvertTest.scala
@@ -9,7 +9,7 @@ import DurationConvert.from
 
 import scala.util.{ Failure, Success }
 
-class DurationConvertTest extends FlatSpec with Matchers {
+class DurationConvertTest extends FlatSpec with Matchers with TryValues {
   "Converting a Duration to a String" should "pick an appropriate unit when dealing with whole units less than the next step up" in {
     from(Duration(14, TimeUnit.DAYS)) shouldBe "14d"
     from(Duration(16, TimeUnit.HOURS)) shouldBe "16h"

--- a/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/src/test/scala/pureconfig/PureconfSuite.scala
@@ -216,10 +216,10 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues {
     saveAndLoadIsIdentity(ConfWithQueueOfFoo(Queue(Foo(1), Foo(2))))
   }
 
-  case class ConfWithStackOfFoo(stack: Stack[Foo])
+  case class ConfWithStackOfFoo(stack: collection.mutable.Stack[Foo])
 
-  it should s"be able to save and load configurations containing immutable.Stack" in {
-    saveAndLoadIsIdentity(ConfWithStackOfFoo(Stack(Foo(1))))
+  it should s"be able to save and load configurations containing mutable.Stack" in {
+    saveAndLoadIsIdentity(ConfWithStackOfFoo(collection.mutable.Stack(Foo(1))))
   }
 
   case class ConfWithHashSetOfFoo(hashSet: HashSet[Foo])

--- a/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/src/test/scala/pureconfig/PureconfSuite.scala
@@ -32,7 +32,7 @@ object PureconfSuite {
 
 import PureconfSuite._
 
-class PureconfSuite extends FlatSpec with Matchers with OptionValues {
+class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryValues {
 
   // checks if saving and loading a configuration from file returns the configuration itself
   def saveAndLoadIsIdentity[C](config: C)(implicit configConvert: ConfigConvert[C]): Unit = {
@@ -251,7 +251,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues {
 
   it should "be able to use a local StringConvert instead of the ones in StringConvert companion object" in {
     implicit val readInt = StringConvert.fromUnsafe[Int](_.toInt.abs, _.toString)
-    loadConfig(Map("i" -> "-100"))(ConfigConvert[ConfWithInt]).toOption.value shouldBe ConfWithInt(100)
+    loadConfig(Map("i" -> "-100"))(ConfigConvert[ConfWithInt]).success.value shouldBe ConfWithInt(100)
   }
 
   case class ConfWithDuration(i: Duration)
@@ -259,7 +259,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues {
   it should "be able to supersede the default Duration ConfigConvert with a locally defined StringConvert" in {
     val expected = Duration(110, TimeUnit.DAYS)
     implicit val readDurationBadly = StringConvert.fromUnsafe[Duration](_ => expected, _ => throw new Exception("Not Implemented"))
-    loadConfig(Map("i" -> "23 s"))(ConfigConvert[ConfWithDuration]).toOption.value shouldBe ConfWithDuration(expected)
+    loadConfig(Map("i" -> "23 s"))(ConfigConvert[ConfWithDuration]).success.value shouldBe ConfWithDuration(expected)
   }
 
   it should "be able to supersede the default Duration ConfigConvert with a locally defined ConfigConvert" in {
@@ -268,7 +268,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues {
       override def from(config: RawConfig, namespace: String): Try[Duration] = Success(expected)
       override def to(t: Duration, namespace: String): RawConfig = throw new Exception("Not Implemented")
     }
-    loadConfig(Map("i" -> "42 h"))(ConfigConvert[ConfWithDuration]).toOption.value shouldBe ConfWithDuration(expected)
+    loadConfig(Map("i" -> "42 h"))(ConfigConvert[ConfWithDuration]).success.value shouldBe ConfWithDuration(expected)
   }
 
   it should "custom ConfigConvert should not cause implicit resolution failure and should be used." in {
@@ -279,7 +279,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues {
       }
       def to(foo: Foo, namespace: String): RawConfig = Map(namespace -> foo.i.toString)
     }
-    loadConfig(Map("foo.i" -> "-100"))(ConfigConvert[ConfWithFoo]).toOption.value shouldBe ConfWithFoo(Foo(-99))
+    loadConfig(Map("foo.i" -> "-100"))(ConfigConvert[ConfWithFoo]).success.value shouldBe ConfWithFoo(Foo(-99))
   }
 
 }

--- a/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/src/test/scala/pureconfig/PureconfSuite.scala
@@ -35,10 +35,10 @@ import PureconfSuite._
 class PureconfSuite extends FlatSpec with Matchers with OptionValues {
 
   // checks if saving and loading a configuration from file returns the configuration itself
-  def saveAndLoadIsIdentity[Config](config: Config)(implicit configConvert: ConfigConvert[Config]): Unit = {
+  def saveAndLoadIsIdentity[C](config: C)(implicit configConvert: ConfigConvert[C]): Unit = {
     withTempFile { configFile =>
       saveConfigAsPropertyFile(config, configFile, overrideOutputPath = true)
-      loadConfig[Config](configFile) shouldEqual Success(config)
+      loadConfig[C](configFile) shouldEqual Success(config)
     }
   }
 

--- a/src/test/scala/pureconfig/RawConfigSuite.scala
+++ b/src/test/scala/pureconfig/RawConfigSuite.scala
@@ -1,11 +1,9 @@
 package pureconfig
 
-import com.typesafe.config.{ Config, ConfigFactory, ConfigValueType }
+import com.typesafe.config.{ ConfigFactory, ConfigValueType }
 import org.scalatest._
 import java.io.PrintWriter
 import java.nio.file.Files
-
-import scala.collection.JavaConversions._
 
 import pureconfig.conf.typesafeConfigToConfig
 


### PR DESCRIPTION
- Enable deprecation warnings. Use mutable Stack; immutable is deprecated.
- Files should be read as UTF-8
- Enable unchecked warnings
- Enable feature warnings
- scalac with fatal warnings, no-adapted-args, no numeric widening, lint.
- In test needed to rename a `Config` type parameter to `C` to avoid shadowing.
- Add data-code, adapted-args, and unused-import warnings.
- Use scalatest's `TryValues` when getting a value out of a `Try`.
