### PR TITLE
Add ENSIME specific files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ project/plugins/project/
 
 # IntelliJ specific
 .idea/
+
+# ENSIME specific
+.ensime
+.ensime_cache


### PR DESCRIPTION
This PR adds [ENSIME](http://ensime.github.io/) specific files (`.ensime` and the `.ensime_cache` folder) to `.gitignore`.
