### PR TITLE
Remove intrusive scalac options in console

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,6 +88,10 @@ val newerCompilerLintSwitches = Seq(
 
 scalacOptions ++= allVersionCompilerLintSwitches
 
+scalacOptions in (Compile, console) ~= (_ filterNot (Set("-Xfatal-warnings", "-Ywarn-unused-import").contains))
+
+scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
+
 scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
     case Some((2, scalaMajor)) if scalaMajor >= 11 => newerCompilerLintSwitches
 }.toList.flatten


### PR DESCRIPTION
This PR removes the `-Xfatal-warnings` and the `-Ywarn-unused-import` scalac options when using the sbt console. The two of them combined would render the console unusable, as every isolated import would raise an error, and not import anything. The latter, without the `-Xfatal-warnings` option would, in my opinion, contribute to an unnecessary level of warnings on the console.
