### PR TITLE
Add a ConfigConvert for FiniteDuration

### DIFF
--- a/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/src/main/scala/pureconfig/ConfigConvert.scala
@@ -230,7 +230,7 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
  * Implicit [[ConfigConvert]] instances defined such that they can be overriden by library consumer via a locally defined implementation.
  */
 trait LowPriorityConfigConvertImplicits {
-  import scala.concurrent.duration.Duration
+  import scala.concurrent.duration.{ Duration, FiniteDuration }
   implicit val durationConfigConvert: ConfigConvert[Duration] = new ConfigConvert[Duration] {
     override def from(config: ConfigValue): Try[Duration] = {
       Some(config.render(ConfigRenderOptions.concise())).fold[Try[Duration]](Failure(new Exception(s"Couldn't read duration from $config."))) { durationString =>
@@ -242,6 +242,14 @@ trait LowPriorityConfigConvertImplicits {
     override def to(t: Duration): ConfigValue = {
       ConfigValueFactory.fromAnyRef(DurationConvert.from(t))
     }
+  }
+
+  implicit val finiteDurationConfigConvert: ConfigConvert[FiniteDuration] = new ConfigConvert[FiniteDuration] {
+    override def from(config: ConfigValue): Try[FiniteDuration] = durationConfigConvert.from(config) match {
+      case Success(v) if v.isFinite() => Success(Duration(v.length, v.unit))
+      case _ => Failure(new Exception(s"Couldn't derive a finite duration from '$config'"))
+    }
+    override def to(t: FiniteDuration): ConfigValue = durationConfigConvert.to(t)
   }
 
   implicit val readString = fromString[String](identity)

--- a/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/src/test/scala/pureconfig/PureconfSuite.scala
@@ -22,7 +22,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest._
 import pureconfig.ConfigConvert.{ fromString, stringConvert }
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 /**
  * @author Mario Pastorelli
@@ -157,7 +157,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   case class ExecutorConf(memory: String, extraJavaOptions: String)
   case class SparkAppConf(name: String)
   case class SparkLocalConf(dir: String)
-  case class SparkNetwork(timeout: Duration)
+  case class SparkNetwork(timeout: FiniteDuration)
   case class SparkConf(master: String, app: SparkAppConf, local: SparkLocalConf, driver: DriverConf, executor: ExecutorConf, extraListeners: Seq[String], network: SparkNetwork)
   case class SparkRootConf(spark: SparkConf)
 
@@ -174,7 +174,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
       writer.println("""spark.master="local[*]"""")
       writer.println("""spark.executor.memory="2g"""")
       writer.println("""spark.local.dir="/tmp/"""")
-      writer.println("""spark.network.timeout="45s"""")
+      writer.println("""spark.network.timeout=45s""")
       // unused configuration
       writer.println("""akka.loggers = ["akka.event.Logging$DefaultLogger"]""")
       writer.close()
@@ -195,7 +195,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
       config.spark.master should be("local[*]")
       config.spark.executor.memory should be("2g")
       config.spark.local.dir should be("/tmp/")
-      config.spark.network.timeout should be(Duration(45, TimeUnit.SECONDS))
+      config.spark.network.timeout should be(FiniteDuration(45, TimeUnit.SECONDS))
     }
   }
 


### PR DESCRIPTION
This PR adds a `ConfigConvert` for [`scala.concurrent.duration.FiniteDuration`](http://www.scala-lang.org/api/current/#scala.concurrent.duration.FiniteDuration), based on the one for [`scala.concurrent.duration.Duration`](http://www.scala-lang.org/api/current/#scala.concurrent.duration.Duration).
