### PR TITLE
Add support for loading Doubles and Floats from a percentage

### DIFF
--- a/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/src/main/scala/pureconfig/ConfigConvert.scala
@@ -90,7 +90,7 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
             tail <- tConfigConvert.value.from(config)
           } yield field[K](v) :: tail
         case other =>
-          Failure(new Exception(s"Couldn't derive hlist from $other."))
+          Failure(new IllegalArgumentException(s"Couldn't derive hlist from $other."))
       }
     }
 
@@ -114,7 +114,7 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
   }
 
   case class NoValidCoproductChoiceFound(config: ConfigValue)
-    extends RuntimeException(s"No valid coproduct type choice found for configuration $config")
+    extends RuntimeException(s"No valid coproduct type choice found for configuration $config.")
 
   implicit def cNilConfigConvert: ConfigConvert[CNil] = new ConfigConvert[CNil] {
     override def from(config: ConfigValue): Try[CNil] =
@@ -176,7 +176,7 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
 
           tryBuilder.map(_.result())
         case other =>
-          Failure(new Exception(s"Couldn't derive traversable from $other."))
+          Failure(new IllegalArgumentException(s"Couldn't derive traversable from $other."))
       }
     }
 
@@ -201,7 +201,7 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
               } yield acc + (key -> value)
           }
         case other =>
-          Failure(new Exception(s"Couldn't derive map from $other."))
+          Failure(new IllegalArgumentException(s"Couldn't derive map from $other."))
       }
     }
 
@@ -243,9 +243,9 @@ trait LowPriorityConfigConvertImplicits {
   import scala.concurrent.duration.Duration
   implicit val durationConfigConvert: ConfigConvert[Duration] = new ConfigConvert[Duration] {
     override def from(config: ConfigValue): Try[Duration] = {
-      Some(config.render(ConfigRenderOptions.concise())).fold[Try[Duration]](Failure(new Exception(s"Couldn't read duration from $config."))) { durationString =>
+      Some(config.render(ConfigRenderOptions.concise())).fold[Try[Duration]](Failure(new IllegalArgumentException(s"Couldn't read duration from $config."))) { durationString =>
         DurationConvert.from(durationString).recoverWith {
-          case ex => Failure(new Exception(s"Could not parse a duration from '$durationString'. (try ns, us, ms, s, m, h, d)"))
+          case ex => Failure(new IllegalArgumentException(s"Could not parse a duration from '$durationString'. (try ns, us, ms, s, m, h, d)"))
         }
       }
     }

--- a/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/src/main/scala/pureconfig/ConfigConvert.scala
@@ -57,10 +57,9 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
     override def to(t: T): ConfigValue = ConfigValueFactory.fromAnyRef(t)
   }
 
-  def fromNonEmptyString[T: ClassTag](fromF: String => T): ConfigConvert[T] = new ConfigConvert[T] {
-    lazy val typeName = implicitly[ClassTag[T]]
+  def fromNonEmptyString[T](fromF: String => T)(implicit ct: ClassTag[T]): ConfigConvert[T] = new ConfigConvert[T] {
     override def from(config: ConfigValue): Try[T] = fromFConvert {
-      case "" => throw new IllegalArgumentException(s"Cannot read a $typeName from an empty string.")
+      case "" => throw new IllegalArgumentException(s"Cannot read a $ct from an empty string.")
       case x => fromF(x)
     }(config)
     override def to(t: T): ConfigValue = ConfigValueFactory.fromAnyRef(t)

--- a/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/src/main/scala/pureconfig/ConfigConvert.scala
@@ -246,7 +246,9 @@ trait LowPriorityConfigConvertImplicits {
 
   implicit val readString = fromString[String](identity)
   implicit val readBoolean = fromString[Boolean](_.toBoolean)
-  implicit val readDouble = fromString[Double](_.toDouble)
+  implicit val readDouble = fromString[Double]({
+    v => if (v.last == '%') v.dropRight(1).toDouble / 100.0 else v.toDouble
+  })
   implicit val readFloat = fromString[Float](_.toFloat)
   implicit val readInt = fromString[Int](_.toInt)
   implicit val readLong = fromString[Long](_.toLong)

--- a/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/src/main/scala/pureconfig/ConfigConvert.scala
@@ -245,13 +245,31 @@ trait LowPriorityConfigConvertImplicits {
   }
 
   implicit val readString = fromString[String](identity)
-  implicit val readBoolean = fromString[Boolean](_.toBoolean)
-  implicit val readDouble = fromString[Double]({
-    v => if (v.last == '%') v.dropRight(1).toDouble / 100.0 else v.toDouble
+  implicit val readBoolean = fromString[Boolean](_ match {
+    case "" => throw new Exception("Cannot read a Boolean from an empty string")
+    case v => v.toBoolean
   })
-  implicit val readFloat = fromString[Float](_.toFloat)
-  implicit val readInt = fromString[Int](_.toInt)
-  implicit val readLong = fromString[Long](_.toLong)
-  implicit val readShort = fromString[Short](_.toShort)
+  implicit val readDouble = fromString[Double](_ match {
+    case "" => throw new Exception("Cannot read a Double from an empty string")
+    case v if v.last == '%' => v.dropRight(1).toDouble / 100d
+    case v => v.toDouble
+  })
+  implicit val readFloat = fromString[Float](_ match {
+    case "" => throw new Exception("Cannot read a Float from an empty string")
+    case v if v.last == '%' => v.dropRight(1).toFloat / 100f
+    case v => v.toFloat
+  })
+  implicit val readInt = fromString[Int](_ match {
+    case "" => throw new Exception("Cannot read an Int from an empty string")
+    case v => v.toInt
+  })
+  implicit val readLong = fromString[Long](_ match {
+    case "" => throw new Exception("Cannot read a Long from an empty string")
+    case v => v.toLong
+  })
+  implicit val readShort = fromString[Short](_ match {
+    case "" => throw new Exception("Cannot read a Short from an empty string")
+    case v => v.toShort
+  })
   implicit val readURL = stringConvert[URL](new URL(_), _.toString)
 }

--- a/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/src/test/scala/pureconfig/PureconfSuite.scala
@@ -104,6 +104,18 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     config.success.value shouldBe FlatConfig(false, -234.234d, -34.34f, -56, 88L, "QWERTY", None)
   }
 
+  it should "fail when trying to convert to basic types from an empty string" in {
+    import pureconfig.syntax._
+
+    val conf = ConfigFactory.parseString("""{ v: "" }""")
+    conf.getValue("v").to[Boolean].isFailure shouldBe true
+    conf.getValue("v").to[Double].isFailure shouldBe true
+    conf.getValue("v").to[Float].isFailure shouldBe true
+    conf.getValue("v").to[Int].isFailure shouldBe true
+    conf.getValue("v").to[Long].isFailure shouldBe true
+    conf.getValue("v").to[Short].isFailure shouldBe true
+  }
+
   it should "be able to load a Double from a percentage" in {
     import pureconfig.syntax._
 

--- a/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/src/test/scala/pureconfig/PureconfSuite.scala
@@ -104,6 +104,14 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     config.success.value shouldBe FlatConfig(false, -234.234d, -34.34f, -56, 88L, "QWERTY", None)
   }
 
+  it should "be able to load a Double from a percentage" in {
+    import pureconfig.syntax._
+
+    val conf = ConfigFactory.parseString("""{ v: 52% }""")
+    case class ConfigWithDouble(v: Double)
+    conf.to[ConfigWithDouble] shouldBe Success(ConfigWithDouble(0.52))
+  }
+
   // load HOCON-style lists
   case class ConfigWithHoconList(xs: List[Int])
 


### PR DESCRIPTION
This PR adds support for `Doubles` to be loaded from strings representing a percentage (i.e. that end with a `%`).
