### PR TITLE
Improve Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: scala
 scala:
-    - 2.11.7
+    - 2.11.8
+    - 2.10.5
 jdk:
     - oraclejdk8


### PR DESCRIPTION
This PR improves the `.travis.yml` configuration by compiling against Scala 2.11.8 (which is the one defined in `build.sbt`) and also against Scala 2.10.5, which is also defined as a cross Scala version in `build.sbt`.
