### PR TITLE
Add support for default arguments

### DIFF
--- a/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/src/main/scala/pureconfig/ConfigConvert.scala
@@ -75,11 +75,6 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
     override def to(t: T): ConfigValue = ConfigValueFactory.fromAnyRef(toF(t))
   }
 
-  implicit def hNilConfigConvert = new ConfigConvert[HNil] {
-    override def from(config: ConfigValue): Try[HNil] = Success(HNil)
-    override def to(t: HNil): ConfigValue = ConfigFactory.parseMap(Map().asJava).root()
-  }
-
   private[pureconfig] def improveFailure[Z](result: Try[Z], keyStr: String): Try[Z] =
     result recoverWith {
       case CannotConvertNullException => Failure(KeyNotFoundException(keyStr))
@@ -87,6 +82,11 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
       case WrongTypeException(typ) => Failure(WrongTypeForKeyException(typ, keyStr))
       case WrongTypeForKeyException(typ, suffix) => Failure(WrongTypeForKeyException(typ, keyStr + "." + suffix))
     }
+
+  implicit def hNilConfigConvert = new ConfigConvert[HNil] {
+    override def from(config: ConfigValue): Try[HNil] = Success(HNil)
+    override def to(t: HNil): ConfigValue = ConfigFactory.parseMap(Map().asJava).root()
+  }
 
   implicit def hConsConfigConvert[K <: Symbol, V, T <: HList](
     implicit key: Witness.Aux[K],

--- a/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/src/main/scala/pureconfig/ConfigConvert.scala
@@ -87,7 +87,7 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
     def fromWithDefault(config: ConfigValue, default: DefaultRepr): Try[Repr]
     override def from(config: ConfigValue): Try[Repr] =
       Failure(
-        new UnsupportedOperationException("Cannot call 'from' from a DefaultValueConfigConvert."))
+        new UnsupportedOperationException("Cannot call 'from' on a DefaultValueConfigConvert."))
   }
 
   implicit def hNilConfigConvert = new DefaultValueConfigConvert[HNil, HNil] {

--- a/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/src/test/scala/pureconfig/PureconfSuite.scala
@@ -580,5 +580,8 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
 
     val conf5 = ConfigFactory.parseMap(Map("a" -> 2, "d.e" -> 5, "d.g" -> 6).asJava)
     loadConfig[Conf](conf5).success.value shouldBe Conf(2, "default", 42, InnerConf(5, 6))
+
+    val conf6 = ConfigFactory.parseMap(Map("a" -> 2, "d" -> "notAnInnerConf").asJava)
+    loadConfig[Conf](conf6).failure.exception shouldEqual WrongTypeForKeyException("STRING", "d")
   }
 }


### PR DESCRIPTION
This PR adds support for default arguments in types derived using shapeless' `LabelledGeneric`. This allows one to load a config missing some values into a type that has those values as default arguments in its constructor:

``` scala
scala> case class Foo(a: Int, b: String = "default")
defined class Foo

scala> loadConfig[Foo](ConfigFactory.parseString("{ a = 2 }"))
res0: scala.util.Try[Foo] = Success(Foo(2,default))
```
