### PR TITLE
Prefer Scala's Duration string conversion to Typesafe Config's.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ could not find implicit value for parameter conv: pureconfig.ConfigConvert[Foo]
 `ConfigConvert` typeclass must be provided implicitly, like
 
 ```scala
-> implicit val foocc = ConfigConvert.stringConvert[Foo](x => new Foo(x.toInt), foo => foo.bar.toString)
+> implicit val foocc = ConfigConvert.stringConvert[Foo](s => Try(new Foo(s.toInt)), foo => foo.bar.toString)
 > loadConfig[Foo]
 Foo(1)
 ```
@@ -204,7 +204,7 @@ Now let's say that we want to override this behaviour such that `String`s are
 always read lower case. We can do:
 
 ```scala
-> implicit val overridestrcc = ConfigConvert.fromString(_.toLowerCase)
+> implicit val overridestrcc = ConfigConvert.fromString(s => Try(s.toLowerCase))
 > ConfigConvert[String].from(ConfigValueFactory.fromAnyRef("FooBar"))
 util.Try[String] = Success(foobar)
 ```
@@ -247,7 +247,7 @@ import pureconfig._
 import java.nio.file.Paths
 import scala.util.Try
 
-implicit val deriveStringConvertForPath = fromString[Path](Paths.get)
+implicit val deriveStringConvertForPath = fromString[Path](s => Try(Paths.get(s)))
 ```
 
 And then we load the configuration

--- a/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/src/main/scala/pureconfig/ConfigConvert.scala
@@ -53,13 +53,11 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
       } else {
         // Because we can't trust `fromF` or Typesafe Config not to throw, we wrap the
         // evaluation in one more `Try` to prevent an unintentional exception from escaping.
-        Try {
-          val configValueAsString = config.valueType match {
-            case ConfigValueType.STRING => config.unwrapped.toString
-            case _ => config.render(ConfigRenderOptions.concise)
-          }
-          fromF(configValueAsString)
-        }.flatten
+        // `Try.flatMap(f)` captures any non-fatal exceptions thrown by `f`.
+        Try(config.valueType match {
+          case ConfigValueType.STRING => config.unwrapped.toString
+          case _ => config.render(ConfigRenderOptions.concise)
+        }).flatMap(fromF)
       }
     }
 

--- a/src/main/scala/pureconfig/DurationConvert.scala
+++ b/src/main/scala/pureconfig/DurationConvert.scala
@@ -1,30 +1,50 @@
 package pureconfig
 
-import com.typesafe.config.ConfigFactory
-
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.util.Try
+import scala.reflect.ClassTag
 
 /**
  * Utility functions for converting a Duration to a String and vice versa.
  */
 private[pureconfig] object DurationConvert {
   /**
-   * Convert a string to a Duration using Typesafe Config's algorithm.
-   * Typesafe Config has a really nice duration parsing algorithm; unfortunately it's private.
-   * We jump through hoops to reuse that for compatibility.
+   * Convert a string to a Duration while trying to maintain compatibility with Typesafe's abbreviations.
    */
-  def from(durationString: String): Try[Duration] = Try {
-    val phonyKey = "k"
-    val phonyConfigString = s"$phonyKey: $durationString"
-    val javaDuration = ConfigFactory.parseString(phonyConfigString).getDuration(phonyKey)
-    Duration.fromNanos(javaDuration.toNanos)
+  def fromString[D](durationString: String, ct: ClassTag[D]): Try[Duration] = {
+    Try { Duration(justAMinute(itsGreekToMe(durationString))) }
+      .recoverWith {
+        case ex: NumberFormatException =>
+          val err = s"Could not parse a ${ct.runtimeClass.getSimpleName} from '$durationString'. (try ns, us, ms, s, m, h, d)"
+          new util.Failure(new IllegalArgumentException(err, ex))
+      }
+  }
+
+  private val fauxMuRegex = "([0-9])(\\s*)us(\\s*)$".r
+  private val shortMinuteRegex = "([0-9])(\\s*)m(\\s*)$".r
+
+  // To maintain compatibility with Typesafe Config, replace "us" with "µs".
+  private val itsGreekToMe = fauxMuRegex.replaceSomeIn(_: String, m => Some(s"${m.group(1)}${m.group(2)}µs${m.group(3)}"))
+
+  // To maintain compatibility with Typesafe Config, replace "m" with "minutes".
+  private val justAMinute = shortMinuteRegex.replaceSomeIn(_: String, m => Some(s"${m.group(1)}${m.group(2)}minutes${m.group(3)}"))
+
+  /**
+   * Format a possibily infinite duration as a string with a suitable time unit using units TypesafeConfig understands.
+   * Caveat: TypesafeConfig doesn't undersand infinite durations
+   */
+  def fromDuration(d: Duration): String = {
+    d match {
+      case i: Duration.Infinite if i == Duration.MinusInf => "MinusInf"
+      case i: Duration.Infinite => "Inf"
+      case f: FiniteDuration => fromFiniteDuration(f)
+    }
   }
 
   /**
-   * Format a duration as a string with a suitable time unit using units TypesafeConfig understands.
+   * Format a FiniteDuration as a string with a suitable time unit using units TypesafeConfig understands.
    */
-  def from(d: Duration): String = {
+  def fromFiniteDuration(d: FiniteDuration): String = {
     d.toNanos match {
       case 0L => "0"
       case n =>
@@ -34,6 +54,7 @@ private[pureconfig] object DurationConvert {
         }.getOrElse(s"${n}ns")
     }
   }
+
   private final val microsecondInNanos = 1000L
   private final val millisecondInNanos = 1000L * microsecondInNanos
   private final val secondInNanos = 1000L * millisecondInNanos

--- a/src/test/scala/pureconfig/DurationConvertTest.scala
+++ b/src/test/scala/pureconfig/DurationConvertTest.scala
@@ -6,41 +6,51 @@ import com.typesafe.config.ConfigValueFactory
 import org.scalatest.{ FlatSpec, Matchers, TryValues }
 
 import scala.concurrent.duration.Duration
-import DurationConvert.from
+import scala.reflect.ClassTag
 
 import scala.util.{ Failure, Success }
 
 class DurationConvertTest extends FlatSpec with Matchers with TryValues {
+  import DurationConvert.{ fromDuration => fromD }
   "Converting a Duration to a String" should "pick an appropriate unit when dealing with whole units less than the next step up" in {
-    from(Duration(14, TimeUnit.DAYS)) shouldBe "14d"
-    from(Duration(16, TimeUnit.HOURS)) shouldBe "16h"
-    from(Duration(1, TimeUnit.MINUTES)) shouldBe "1m"
-    from(Duration(33, TimeUnit.SECONDS)) shouldBe "33s"
-    from(Duration(555, TimeUnit.MILLISECONDS)) shouldBe "555ms"
-    from(Duration(999, TimeUnit.MICROSECONDS)) shouldBe "999us"
-    from(Duration(222, TimeUnit.NANOSECONDS)) shouldBe "222ns"
+    fromD(Duration(14, TimeUnit.DAYS)) shouldBe "14d"
+    fromD(Duration(16, TimeUnit.HOURS)) shouldBe "16h"
+    fromD(Duration(1, TimeUnit.MINUTES)) shouldBe "1m"
+    fromD(Duration(33, TimeUnit.SECONDS)) shouldBe "33s"
+    fromD(Duration(555, TimeUnit.MILLISECONDS)) shouldBe "555ms"
+    fromD(Duration(999, TimeUnit.MICROSECONDS)) shouldBe "999us"
+    fromD(Duration(222, TimeUnit.NANOSECONDS)) shouldBe "222ns"
   }
   it should "pick an appropriate unit when dealing with whole units more than, but fractional in, the next step up" in {
-    from(Duration(1, TimeUnit.DAYS)) shouldBe "1d"
-    from(Duration(47, TimeUnit.HOURS)) shouldBe "47h"
-    from(Duration(123, TimeUnit.MINUTES)) shouldBe "123m"
-    from(Duration(489, TimeUnit.SECONDS)) shouldBe "489s"
-    from(Duration(11555, TimeUnit.MILLISECONDS)) shouldBe "11555ms"
-    from(Duration(44999, TimeUnit.MICROSECONDS)) shouldBe "44999us"
-    from(Duration(88222, TimeUnit.NANOSECONDS)) shouldBe "88222ns"
+    fromD(Duration(1, TimeUnit.DAYS)) shouldBe "1d"
+    fromD(Duration(47, TimeUnit.HOURS)) shouldBe "47h"
+    fromD(Duration(123, TimeUnit.MINUTES)) shouldBe "123m"
+    fromD(Duration(489, TimeUnit.SECONDS)) shouldBe "489s"
+    fromD(Duration(11555, TimeUnit.MILLISECONDS)) shouldBe "11555ms"
+    fromD(Duration(44999, TimeUnit.MICROSECONDS)) shouldBe "44999us"
+    fromD(Duration(88222, TimeUnit.NANOSECONDS)) shouldBe "88222ns"
   }
   it should "write 0 without units" in {
-    from(Duration(0, TimeUnit.DAYS)) shouldBe "0"
+    fromD(Duration(0, TimeUnit.DAYS)) shouldBe "0"
+  }
+  it should "handle an infinite duration" in {
+    fromD(Duration.Inf) shouldBe "Inf"
+  }
+  it should "round trip negative infinity" in {
+    val expected = Duration.MinusInf
+    fromS(fromD(expected)).success.value shouldBe expected
   }
 
+  val fromS = DurationConvert.fromString(_: String, implicitly[ClassTag[Duration]])
   "Converting a String to a Duration" should "succeed for known units" in {
-    from("1d") shouldBe Success(Duration(1, TimeUnit.DAYS))
-    from("47h") shouldBe Success(Duration(47, TimeUnit.HOURS))
-    from("123m") shouldBe Success(Duration(123, TimeUnit.MINUTES))
-    from("489s") shouldBe Success(Duration(489, TimeUnit.SECONDS))
-    from("11555ms") shouldBe Success(Duration(11555, TimeUnit.MILLISECONDS))
-    from("44999us") shouldBe Success(Duration(44999, TimeUnit.MICROSECONDS))
-    from("88222ns") shouldBe Success(Duration(88222, TimeUnit.NANOSECONDS))
+    fromS("1d") shouldBe Success(Duration(1, TimeUnit.DAYS))
+    fromS("47h") shouldBe Success(Duration(47, TimeUnit.HOURS))
+    fromS("123m") shouldBe Success(Duration(123, TimeUnit.MINUTES))
+    fromS("489s") shouldBe Success(Duration(489, TimeUnit.SECONDS))
+    fromS("11555ms") shouldBe Success(Duration(11555, TimeUnit.MILLISECONDS))
+    fromS("44999us") shouldBe Success(Duration(44999, TimeUnit.MICROSECONDS))
+    fromS("44999µs") shouldBe Success(Duration(44999, TimeUnit.MICROSECONDS))
+    fromS("88222ns") shouldBe Success(Duration(88222, TimeUnit.NANOSECONDS))
   }
   it should "report a helpful error message when failing to convert a bad duration" in {
     val badDuration = "10 lordsALeaping"

--- a/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/src/test/scala/pureconfig/PureconfSuite.scala
@@ -197,7 +197,8 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   // a slightly more complex configuration
   implicit val dateConfigConvert = stringConvert[DateTime](
     str => Try(ISODateTimeFormat.dateTime().parseDateTime(str)),
-    t => Try(ISODateTimeFormat.dateTime().print(t)))
+    t => ISODateTimeFormat.dateTime().print(t)
+  )
 
   type ConfigCoproduct = Float :+: Boolean :+: CNil
   case class Config(d: DateTime, l: List[Int], s: Set[Int], subConfig: FlatConfig, coproduct: ConfigCoproduct)
@@ -403,7 +404,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   case class ConfWithFoo(foo: Foo)
 
   it should "be able to use a local ConfigConvert without getting an ImplicitResolutionFailure error" in {
-    implicit val custom: ConfigConvert[Foo] = stringConvert(s => Try(Foo(s.toInt)), f => Try(f.i.toString))
+    implicit val custom: ConfigConvert[Foo] = stringConvert(s => Try(Foo(s.toInt)), _.i.toString)
     saveAndLoadIsIdentity(ConfWithFoo(Foo(100)))
   }
 

--- a/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/src/test/scala/pureconfig/PureconfSuite.scala
@@ -612,7 +612,6 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     loadConfig[ConfWithConfigList](emptyConf).failure.exception shouldEqual KeyNotFoundException("conf")
     loadConfig[ConfWithDuration](emptyConf).failure.exception shouldEqual KeyNotFoundException("i")
     loadConfig[SparkNetwork](emptyConf).failure.exception shouldEqual KeyNotFoundException("timeout")
-    loadConfig[ConfWithDuration](emptyConf).failure.exception shouldEqual KeyNotFoundException("i")
   }
 
   it should s"return a ${classOf[WrongTypeForKeyException]} when a key has a wrong type" in {
@@ -682,6 +681,6 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   }
   it should "fail for a FiniteDuration" in {
     val conf = ConfigFactory.parseString("""{ timeout: Inf }""")
-    loadConfig[SparkNetwork](conf).failure.exception.getMessage shouldBe "Couldn't parse 'Inf' into a finite duration because it's infinite."
+    loadConfig[SparkNetwork](conf).failure.exception.getMessage shouldBe "Couldn't parse 'Inf' into a FiniteDuration because it's infinite."
   }
 }

--- a/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/src/test/scala/pureconfig/PureconfSuite.scala
@@ -90,12 +90,12 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   }
 
   it should s"be able to override locally all of the ConfigConvert instances used to parse ${classOf[FlatConfig]}" in {
-    implicit val readBoolean = fromString[Boolean](_ != "0")
-    implicit val readDouble = fromString[Double](_.toDouble * -1)
-    implicit val readFloat = fromString[Float](_.toFloat * -1)
-    implicit val readInt = fromString[Int](_.toInt * -1)
-    implicit val readLong = fromString[Long](_.toLong * -1)
-    implicit val readString = fromString[String](_.toUpperCase)
+    implicit val readBoolean = fromString[Boolean](s => Try(s != "0"))
+    implicit val readDouble = fromString[Double](s => Try(s.toDouble * -1))
+    implicit val readFloat = fromString[Float](s => Try(s.toFloat * -1))
+    implicit val readInt = fromString[Int](s => Try(s.toInt * -1))
+    implicit val readLong = fromString[Long](s => Try(s.toLong * -1))
+    implicit val readString = fromString[String](s => Try(s.toUpperCase))
     val config = loadConfig[FlatConfig](ConfigValueFactory.fromMap(Map(
       "b" -> 0,
       "d" -> 234.234,
@@ -196,8 +196,8 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
 
   // a slightly more complex configuration
   implicit val dateConfigConvert = stringConvert[DateTime](
-    str => ISODateTimeFormat.dateTime().parseDateTime(str),
-    t => ISODateTimeFormat.dateTime().print(t))
+    str => Try(ISODateTimeFormat.dateTime().parseDateTime(str)),
+    t => Try(ISODateTimeFormat.dateTime().print(t)))
 
   type ConfigCoproduct = Float :+: Boolean :+: CNil
   case class Config(d: DateTime, l: List[Int], s: Set[Int], subConfig: FlatConfig, coproduct: ConfigCoproduct)
@@ -403,14 +403,14 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   case class ConfWithFoo(foo: Foo)
 
   it should "be able to use a local ConfigConvert without getting an ImplicitResolutionFailure error" in {
-    implicit val custom: ConfigConvert[Foo] = stringConvert(s => Foo(s.toInt), _.i.toString)
+    implicit val custom: ConfigConvert[Foo] = stringConvert(s => Try(Foo(s.toInt)), f => Try(f.i.toString))
     saveAndLoadIsIdentity(ConfWithFoo(Foo(100)))
   }
 
   case class ConfWithInt(i: Int)
 
   it should "be able to use a local ConfigConvert instead of the ones in ConfigConvert companion object" in {
-    implicit val readInt = fromString[Int](_.toInt.abs)
+    implicit val readInt = fromString[Int](s => Try(s.toInt.abs))
     loadConfig(ConfigValueFactory.fromMap(Map("i" -> "-100").asJava).toConfig)(ConfigConvert[ConfWithInt]).success.value shouldBe ConfWithInt(100)
   }
 
@@ -418,7 +418,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
 
   it should "be able to supersede the default Duration ConfigConvert with a locally defined ConfigConvert from fromString" in {
     val expected = Duration(110, TimeUnit.DAYS)
-    implicit val readDurationBadly = fromString[Duration](_ => expected)
+    implicit val readDurationBadly = fromString[Duration](_ => Try(expected))
     loadConfig(ConfigValueFactory.fromMap(Map("i" -> "23 s").asJava).toConfig)(ConfigConvert[ConfWithDuration]).success.value shouldBe ConfWithDuration(expected)
   }
 
@@ -455,7 +455,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
 
   it should "allow a custom ConfigConvert[URL] to override our definition" in {
     val expected = "http://bad/horse/will?make=you&his=mare"
-    implicit val readURLBadly = fromString[URL](_ => new URL(expected))
+    implicit val readURLBadly = fromString[URL](_ => Try(new URL(expected)))
     val config = loadConfig[ConfWithURL](ConfigValueFactory.fromMap(Map("url" -> "https://ignored/url").asJava).toConfig)
     config.toOption.value.url shouldBe new URL(expected)
   }


### PR DESCRIPTION
Fixes #59

- The primary intention is to reduce compexity in Pureconfig by making the
  duration `ConfigConvert` instances more similar to the others.
- A secondary benefit is that Pureconfig in a Spark 1.x app should be able
  to parse Duration and FiniteDuration because it no longer depends on a
  newer version of typesafe config than spark ships with.
- Also add a few tests around error messages.
- Also handle infinite durations.