### PR TITLE
add configurable instances for date, time and datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - New features
   - More consistent handling of missing keys: if a config key is missing pureconfig always throws a
     `KeyNotFoundException` now, unless the `ConfigConvert` extends the new `AllowMissingKey` trait.
+  - Add support for `LocalDate`, `LocalDateTime` and `LocalTime` from the `java.time` package via
+    configurable instances. See the [README](https://github.com/melrief/pureconfig#configurable-converters)
+    for more details.
 
 ### 0.5.0 (Jan 3, 2017)
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ import pureconfig.configurable._
 
 case class Conf(date: LocalDate)
 
-implicit val localDateInstance = makeLocalDateConfigConvert(DateTimeFormatter.ISO_DATE)
+implicit val localDateInstance = localDateConfigConvert(DateTimeFormatter.ISO_DATE)
 
 val conf = ConfigFactory.parseString(s"""{date:"2011-12-03"}""")
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ res0: util.Try[MyClass] = Success(MyClass(1,AdtB(1),List(1.0, 0.2),Map(key -> va
 
 For some types, pureconfig cannot automatically derive a converter because there are multiple ways to convert a configuration
 value to them. For instance, for [`LocalDate`](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html)
-pureconfig cannot derive a converter because there are multiple [`DateTimeFormatter`](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html)
+pureconfig cannot derive a converter because there are multiple [`DateTimeFormatter`](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html)s
 that can be used to convert a String into a `LocalDate`. Examples of different format are `yyyy-mm-dd`, e.g. `"2016-01-01"`,
 and `yyyymmdd`, e.g. `"20160101"`. For those types, pureconfig provides a way to create converters from the necessary parameters. These methods can be found under
 the package `pureconfig.configurable`. Once the output of a `pureconfig.configurable` method for a certain type is in scope,

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ res0: util.Try[MyClass] = Success(MyClass(1,AdtB(1),List(1.0, 0.2),Map(key -> va
 ## Configurable converters
 
 For some types, pureconfig cannot automatically derive a converter because there are multiple ways to convert a configuration
-value to them. For instance, for [`java.time.LocalDate`](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html)
-pureconfig cannot derive a converter because there are multiple [`java.time.format.DateTimeFormatter`](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html)
+value to them. For instance, for [`LocalDate`](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html)
+pureconfig cannot derive a converter because there are multiple [`DateTimeFormatter`](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html)
 that can be used to convert a String into a `LocalDate`. Examples of different format are `yyyy-mm-dd`, e.g. `"2016-01-01"`,
 and `yyyymmdd`, e.g. `"20160101"`. For those types, pureconfig provides a way to create converters from the necessary parameters. These methods can be found under
 the package `pureconfig.configurable`. Once the output of a `pureconfig.configurable` method for a certain type is in scope,

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -14,7 +14,7 @@ import java.time.format.DateTimeFormatter
  * }}}
  *
  * @example we cannot provide a [[ConfigConvert]] for [[java.time.LocalDate]] because traditionally there are many different
- * [[java.time.format.DateTimeFormatter]] to parse a [[java.time.LocalDate]] from a [[java.lang.String]]. This package
+ * [[java.time.format.DateTimeFormatter]]s to parse a [[java.time.LocalDate]] from a [[java.lang.String]]. This package
  * provides a method that takes an input [[java.time.format.DateTimeFormatter]] and returns a [[ConfigConvert]] for
  * [[java.time.LocalDate]] which will use that [[java.time.format.DateTimeFormatter]] to parse a [[java.time.LocalDate]].
  */

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -4,17 +4,31 @@ import scala.util.Try
 import java.time.{ LocalDate, LocalDateTime, LocalTime }
 import java.time.format.DateTimeFormatter
 
+/**
+ * Provides methods that create [[ConfigConvert]] instances from a set of parameters used to configure the instances.
+ *
+ * The result of calling one of the methods can be assigned to an `implicit val` so that `pureconfig` will be able to
+ * use it:
+ * {{{
+ *   implicit val localDateConfigConvert = makeLocalDateConfigConvert(DateTimeFormatter.ISO_TIME)
+ * }}}
+ *
+ * @example we cannot provide a [[ConfigConvert]] for [[java.time.LocalDate]] because traditionally there are many different
+ * [[java.time.format.DateTimeFormatter]] to parse a [[java.time.LocalDate]] from a [[java.lang.String]]. This package
+ * provides a method that takes in input a [[java.time.format.DateTimeFormatter]] and returns a [[ConfigConvert]] for
+ * [[java.time.LocalDate]] which will use that [[java.time.format.DateTimeFormatter]] to parse a [[java.time.LocalDate]].
+ */
 package object configurable {
 
-  def makeLocalDateInstance(formatter: DateTimeFormatter): ConfigConvert[LocalDate] =
+  def makeLocalDateConfigConvert(formatter: DateTimeFormatter): ConfigConvert[LocalDate] =
     ConfigConvert.nonEmptyStringConvert[LocalDate](
       s => Try(LocalDate.parse(s, formatter)), _.format(formatter))
 
-  def makeLocalTimeInstance(formatter: DateTimeFormatter): ConfigConvert[LocalTime] =
+  def makeLocalTimeConfigConvert(formatter: DateTimeFormatter): ConfigConvert[LocalTime] =
     ConfigConvert.nonEmptyStringConvert[LocalTime](
       s => Try(LocalTime.parse(s, formatter)), _.format(formatter))
 
-  def makeLocalDateTimeInstance(formatter: DateTimeFormatter): ConfigConvert[LocalDateTime] =
+  def makeLocalDateTimeConfigConvert(formatter: DateTimeFormatter): ConfigConvert[LocalDateTime] =
     ConfigConvert.nonEmptyStringConvert[LocalDateTime](
       s => Try(LocalDateTime.parse(s, formatter)), _.format(formatter))
 }

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -20,15 +20,15 @@ import java.time.format.DateTimeFormatter
  */
 package object configurable {
 
-  def makeLocalDateConfigConvert(formatter: DateTimeFormatter): ConfigConvert[LocalDate] =
+  def localDateConfigConvert(formatter: DateTimeFormatter): ConfigConvert[LocalDate] =
     ConfigConvert.nonEmptyStringConvert[LocalDate](
       s => Try(LocalDate.parse(s, formatter)), _.format(formatter))
 
-  def makeLocalTimeConfigConvert(formatter: DateTimeFormatter): ConfigConvert[LocalTime] =
+  def localTimeConfigConvert(formatter: DateTimeFormatter): ConfigConvert[LocalTime] =
     ConfigConvert.nonEmptyStringConvert[LocalTime](
       s => Try(LocalTime.parse(s, formatter)), _.format(formatter))
 
-  def makeLocalDateTimeConfigConvert(formatter: DateTimeFormatter): ConfigConvert[LocalDateTime] =
+  def localDateTimeConfigConvert(formatter: DateTimeFormatter): ConfigConvert[LocalDateTime] =
     ConfigConvert.nonEmptyStringConvert[LocalDateTime](
       s => Try(LocalDateTime.parse(s, formatter)), _.format(formatter))
 }

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -1,0 +1,20 @@
+package pureconfig
+
+import scala.util.Try
+import java.time.{ LocalDate, LocalDateTime, LocalTime }
+import java.time.format.DateTimeFormatter
+
+package object configurable {
+
+  def makeLocalDateInstance(formatter: DateTimeFormatter): ConfigConvert[LocalDate] =
+    ConfigConvert.nonEmptyStringConvert[LocalDate](
+      s => Try(LocalDate.parse(s, formatter)), _.format(formatter))
+
+  def makeLocalTimeInstance(formatter: DateTimeFormatter): ConfigConvert[LocalTime] =
+    ConfigConvert.nonEmptyStringConvert[LocalTime](
+      s => Try(LocalTime.parse(s, formatter)), _.format(formatter))
+
+  def makeLocalDateTimeInstance(formatter: DateTimeFormatter): ConfigConvert[LocalDateTime] =
+    ConfigConvert.nonEmptyStringConvert[LocalDateTime](
+      s => Try(LocalDateTime.parse(s, formatter)), _.format(formatter))
+}

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -15,7 +15,7 @@ import java.time.format.DateTimeFormatter
  *
  * @example we cannot provide a [[ConfigConvert]] for [[java.time.LocalDate]] because traditionally there are many different
  * [[java.time.format.DateTimeFormatter]] to parse a [[java.time.LocalDate]] from a [[java.lang.String]]. This package
- * provides a method that takes in input a [[java.time.format.DateTimeFormatter]] and returns a [[ConfigConvert]] for
+ * provides a method that takes an input [[java.time.format.DateTimeFormatter]] and returns a [[ConfigConvert]] for
  * [[java.time.LocalDate]] which will use that [[java.time.format.DateTimeFormatter]] to parse a [[java.time.LocalDate]].
  */
 package object configurable {

--- a/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
+++ b/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
@@ -12,7 +12,7 @@ import ConfigurableSuite._
 
 class ConfigurableSuite extends FlatSpec with Matchers with TryValues with PropertyChecks {
 
-  implicit val localTimeInstance = makeLocalTimeConfigConvert(DateTimeFormatter.ISO_TIME)
+  implicit val localTimeInstance = localTimeConfigConvert(DateTimeFormatter.ISO_TIME)
 
   "pureconfig" should "parse LocalTime" in forAll {
     (localTime: LocalTime) =>
@@ -21,7 +21,7 @@ class ConfigurableSuite extends FlatSpec with Matchers with TryValues with Prope
       conf.to[Conf].success.value shouldEqual Conf(localTime)
   }
 
-  implicit val localDateInstance = makeLocalDateConfigConvert(DateTimeFormatter.ISO_DATE)
+  implicit val localDateInstance = localDateConfigConvert(DateTimeFormatter.ISO_DATE)
 
   it should "parse LocalDate" in forAll {
     (localDate: LocalDate) =>
@@ -30,7 +30,7 @@ class ConfigurableSuite extends FlatSpec with Matchers with TryValues with Prope
       conf.to[Conf].success.value shouldEqual Conf(localDate)
   }
 
-  implicit val localDateTimeInstance = makeLocalDateTimeConfigConvert(DateTimeFormatter.ISO_DATE_TIME)
+  implicit val localDateTimeInstance = localDateTimeConfigConvert(DateTimeFormatter.ISO_DATE_TIME)
 
   it should "parse LocalDateTime" in forAll {
     (localDateTime: LocalDateTime) =>

--- a/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
+++ b/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
@@ -12,7 +12,7 @@ import ConfigurableSuite._
 
 class ConfigurableSuite extends FlatSpec with Matchers with TryValues with PropertyChecks {
 
-  implicit val localTimeInstance = makeLocalTimeInstance(DateTimeFormatter.ISO_TIME)
+  implicit val localTimeInstance = makeLocalTimeConfigConvert(DateTimeFormatter.ISO_TIME)
 
   "pureconfig" should "parse LocalTime" in forAll {
     (localTime: LocalTime) =>
@@ -21,7 +21,7 @@ class ConfigurableSuite extends FlatSpec with Matchers with TryValues with Prope
       conf.to[Conf].success.value shouldEqual Conf(localTime)
   }
 
-  implicit val localDateInstance = makeLocalDateInstance(DateTimeFormatter.ISO_DATE)
+  implicit val localDateInstance = makeLocalDateConfigConvert(DateTimeFormatter.ISO_DATE)
 
   it should "parse LocalDate" in forAll {
     (localDate: LocalDate) =>
@@ -30,7 +30,7 @@ class ConfigurableSuite extends FlatSpec with Matchers with TryValues with Prope
       conf.to[Conf].success.value shouldEqual Conf(localDate)
   }
 
-  implicit val localDateTimeInstance = makeLocalDateTimeInstance(DateTimeFormatter.ISO_DATE_TIME)
+  implicit val localDateTimeInstance = makeLocalDateTimeConfigConvert(DateTimeFormatter.ISO_DATE_TIME)
 
   it should "parse LocalDateTime" in forAll {
     (localDateTime: LocalDateTime) =>

--- a/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
+++ b/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
@@ -1,0 +1,73 @@
+package pureconfig.configurable
+
+import com.typesafe.config.ConfigFactory
+import java.time.{ LocalDate, LocalDateTime, LocalTime }
+import java.time.format.DateTimeFormatter
+import org.scalatest._
+import org.scalacheck.{ Arbitrary, Gen }
+import prop.PropertyChecks
+import pureconfig.syntax._
+
+import ConfigurableSuite._
+
+class ConfigurableSuite extends FlatSpec with Matchers with TryValues with PropertyChecks {
+
+  implicit val localTimeInstance = makeLocalTimeInstance(DateTimeFormatter.ISO_TIME)
+
+  "pureconfig" should "parse LocalTime" in forAll {
+    (localTime: LocalTime) =>
+      val conf = ConfigFactory.parseString(s"""{time:"${localTime.format(DateTimeFormatter.ISO_TIME)}"}""")
+      case class Conf(time: LocalTime)
+      conf.to[Conf].success.value shouldEqual Conf(localTime)
+  }
+
+  implicit val localDateInstance = makeLocalDateInstance(DateTimeFormatter.ISO_DATE)
+
+  it should "parse LocalDate" in forAll {
+    (localDate: LocalDate) =>
+      val conf = ConfigFactory.parseString(s"""{date:"${localDate.format(DateTimeFormatter.ISO_DATE)}"}""")
+      case class Conf(date: LocalDate)
+      conf.to[Conf].success.value shouldEqual Conf(localDate)
+  }
+
+  implicit val localDateTimeInstance = makeLocalDateTimeInstance(DateTimeFormatter.ISO_DATE_TIME)
+
+  it should "parse LocalDateTime" in forAll {
+    (localDateTime: LocalDateTime) =>
+      val conf = ConfigFactory.parseString(s"""{dateTime:"${localDateTime.format(DateTimeFormatter.ISO_DATE_TIME)}"}""")
+      case class Conf(dateTime: LocalDateTime)
+      conf.to[Conf].success.value shouldEqual Conf(localDateTime)
+  }
+}
+
+object ConfigurableSuite {
+
+  val genHour: Gen[Int] = Gen.chooseNum(0, 23)
+  val genMinute: Gen[Int] = Gen.chooseNum(0, 59)
+  val genSecond: Gen[Int] = Gen.chooseNum(0, 59)
+  val genNano: Gen[Int] = Gen.chooseNum(0, 999999999)
+
+  implicit val localTimeArbitrary: Arbitrary[LocalTime] =
+    Arbitrary[LocalTime](
+      for {
+        hour <- genHour
+        minute <- genMinute
+        second <- genSecond
+        nano <- genNano
+      } yield LocalTime.of(hour, minute, second, nano))
+
+  implicit val localDateArbitrary: Arbitrary[LocalDate] =
+    Arbitrary[LocalDate](
+      for {
+        year <- Gen.chooseNum(1970, 2999)
+        month <- Gen.chooseNum(1, 12)
+        day <- Gen.chooseNum(1, java.time.YearMonth.of(year, month).lengthOfMonth())
+      } yield LocalDate.of(year, month, day))
+
+  implicit val localDateTimeArbitrary: Arbitrary[LocalDateTime] =
+    Arbitrary[LocalDateTime](
+      for {
+        date <- localDateArbitrary.arbitrary
+        time <- localTimeArbitrary.arbitrary
+      } yield date.atTime(time))
+}


### PR DESCRIPTION
@leifwickland @jcazevedo an initial attempt to implement #65. I have implemented configurable instances for java 8's `LocalDate`, `LocalTime` and `LocalDateTime`. What is missing but I would like to do in another PR because I don't have time right now:

1. `TimeZone` and `Period` are not yet covered but they are easy to add because not configurable. I'll do that in another PR
2. `OffsetTime` and `OffsetDateTime` because I never used them. As above, another PR is the right place to put them, I think

I would like to add everything and add a section to the README.md before we release the next version.