### PR TITLE
Add CoproductHint for customization of sealed family conversions

### DIFF
--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -84,7 +84,9 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
     stringConvert(ensureNonEmpty(ct)(_).flatMap(fromF), toF)
   }
 
-  private[pureconfig] trait WrappedDefaultValueConfigConvert[Wrapped, SubRepr <: HList, DefaultRepr <: HList] extends ConfigConvert[SubRepr] {
+  private[pureconfig] trait WrappedConfigConvert[Wrapped, SubRepr] extends ConfigConvert[SubRepr]
+
+  private[pureconfig] trait WrappedDefaultValueConfigConvert[Wrapped, SubRepr <: HList, DefaultRepr <: HList] extends WrappedConfigConvert[Wrapped, SubRepr] {
     final def from(config: ConfigValue): Try[SubRepr] =
       Failure(
         new UnsupportedOperationException("Cannot call 'from' on a WrappedDefaultValueConfigConvert."))
@@ -155,27 +157,42 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
   case class NoValidCoproductChoiceFound(config: ConfigValue)
     extends RuntimeException(s"No valid coproduct type choice found for configuration $config.")
 
-  implicit def cNilConfigConvert: ConfigConvert[CNil] = new ConfigConvert[CNil] {
+  implicit def cNilConfigConvert[Wrapped]: WrappedConfigConvert[Wrapped, CNil] = new WrappedConfigConvert[Wrapped, CNil] {
     override def from(config: ConfigValue): Try[CNil] =
       Failure(NoValidCoproductChoiceFound(config))
 
     override def to(t: CNil): ConfigValue = ConfigFactory.parseMap(Map().asJava).root()
   }
 
-  implicit def coproductConfigConvert[V, T <: Coproduct](
-    implicit vFieldConvert: Lazy[ConfigConvert[V]],
-    tConfigConvert: Lazy[ConfigConvert[T]]): ConfigConvert[V :+: T] =
-    new ConfigConvert[V :+: T] {
+  implicit def coproductConfigConvert[Wrapped, Name <: Symbol, V, T <: Coproduct](
+    implicit coproductHint: CoproductHint[Wrapped],
+    vName: Witness.Aux[Name],
+    vFieldConvert: Lazy[ConfigConvert[V]],
+    tConfigConvert: Lazy[WrappedConfigConvert[Wrapped, T]]): WrappedConfigConvert[Wrapped, FieldType[Name, V] :+: T] =
+    new WrappedConfigConvert[Wrapped, FieldType[Name, V]:+: T] {
 
-      override def from(config: ConfigValue): Try[V :+: T] = {
-        vFieldConvert.value.from(config)
-          .map(s => Inl[V, T](s))
-          .orElse(tConfigConvert.value.from(config).map(s => Inr[V, T](s)))
+      override def from(config: ConfigValue): Try[FieldType[Name, V] :+: T] = {
+        coproductHint.from(config, vName.value.name) match {
+          case Success(Some(hintConfig)) =>
+            vFieldConvert.value.from(hintConfig) match {
+              case Failure(_) if coproductHint.tryNextOnFail(vName.value.name) =>
+                tConfigConvert.value.from(config).map(s => Inr(s))
+
+              case vTry => vTry.map(v => Inl(field[Name](v)))
+            }
+
+          case Success(None) => tConfigConvert.value.from(config).map(s => Inr(s))
+          case Failure(ex) => Failure(ex)
+        }
       }
 
-      override def to(t: V :+: T): ConfigValue = t match {
-        case Inl(l) => vFieldConvert.value.to(l)
-        case Inr(r) => tConfigConvert.value.to(r)
+      override def to(t: FieldType[Name, V] :+: T): ConfigValue = t match {
+        case Inl(l) =>
+          // Writing a coproduct to a config can fail. Is it worth it to make `to` return a `Try`?
+          coproductHint.to(vFieldConvert.value.to(l), vName.value.name).get
+
+        case Inr(r) =>
+          tConfigConvert.value.to(r)
       }
     }
 
@@ -254,7 +271,7 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
   }
 
   // used for products
-  implicit def deriveInstanceWithLabelledGeneric[F, Repr <: HList, DefaultRepr <: HList](
+  implicit def deriveProductInstance[F, Repr <: HList, DefaultRepr <: HList](
     implicit gen: LabelledGeneric.Aux[F, Repr],
     default: Default.AsOptions.Aux[F, DefaultRepr],
     cc: Lazy[WrappedDefaultValueConfigConvert[F, Repr, DefaultRepr]]): ConfigConvert[F] = new ConfigConvert[F] {
@@ -269,9 +286,9 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
   }
 
   // used for coproducts
-  implicit def deriveInstanceWithGeneric[F, Repr <: Coproduct](
-    implicit gen: Generic.Aux[F, Repr],
-    cc: Lazy[ConfigConvert[Repr]]): ConfigConvert[F] = new ConfigConvert[F] {
+  implicit def deriveCoproductInstance[F, Repr <: Coproduct](
+    implicit gen: LabelledGeneric.Aux[F, Repr],
+    cc: Lazy[WrappedConfigConvert[F, Repr]]): ConfigConvert[F] = new ConfigConvert[F] {
     override def from(config: ConfigValue): Try[F] = {
       cc.value.from(config).map(gen.from)
     }

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -171,8 +171,10 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
     tConfigConvert: Lazy[WrappedConfigConvert[Wrapped, T]]): WrappedConfigConvert[Wrapped, FieldType[Name, V] :+: T] =
     new WrappedConfigConvert[Wrapped, FieldType[Name, V]:+: T] {
 
-      override def from(config: ConfigValue): Try[FieldType[Name, V] :+: T] = {
-        coproductHint.from(config, vName.value.name) match {
+      override def from(config: ConfigValue): Try[FieldType[Name, V] :+: T] = config match {
+        case null => Failure(CannotConvertNullException)
+
+        case _ => coproductHint.from(config, vName.value.name) match {
           case Success(Some(hintConfig)) =>
             vFieldConvert.value.from(hintConfig) match {
               case Failure(_) if coproductHint.tryNextOnFail(vName.value.name) =>

--- a/core/src/main/scala/pureconfig/CoproductHint.scala
+++ b/core/src/main/scala/pureconfig/CoproductHint.scala
@@ -1,0 +1,108 @@
+package pureconfig
+
+import scala.util.{ Failure, Success, Try }
+
+import com.typesafe.config.{ ConfigObject, ConfigValue }
+import pureconfig.error.{ CollidingKeysException, KeyNotFoundException, WrongTypeException }
+import pureconfig.syntax._
+
+/**
+ * A trait that can be implemented to disambiguate between the different options of a coproduct or sealed family.
+ *
+ * @tparam T the type of the coproduct or sealed family for which this hint applies
+ */
+trait CoproductHint[T] {
+
+  /**
+   * Given a `ConfigValue` for the sealed family, disambiguate and extract the `ConfigValue` associated to the
+   * implementation for the given class or coproduct option name.
+   *
+   * If `cv` is a config for the given class name, this method returns `Success(Some(v))`, where `v` is the config
+   * related to the specific class (possibly the same as `cv`). If it determines that `cv` is a config for a different
+   * class, it returns `Success(None)`. If `cv` is missing information for disambiguation or has a wrong type, a
+   * `Failure` is returned.
+   *
+   * @param cv the `ConfigValue` of the sealed family
+   * @param name the name of the class or coproduct option to try
+   * @return a `Try[Option[ConfigValue]]` as defined above.
+   */
+  def from(cv: ConfigValue, name: String): Try[Option[ConfigValue]]
+
+  /**
+   * Given the `ConfigValue` for a specific class or coproduct option, encode disambiguation information and return a
+   * config for the sealed family or coproduct.
+   *
+   * @param cv the `ConfigValue` of the class or coproduct option
+   * @param name the name of the class or coproduct option
+   * @return the config for the sealed family or coproduct wrapped in a `Success`, or a `Failure` if some error
+   *         occurred.
+   */
+  def to(cv: ConfigValue, name: String): Try[ConfigValue]
+
+  /**
+   * Defines what to do if `from` returns `Success(Some(_))` for a class or coproduct option, but its `ConfigConvert`
+   * fails to deserialize the config.
+   *
+   * @param name the name of the class or coproduct option
+   * @return `true` if the next class or coproduct option should be tried, `false` otherwise.
+   */
+  def tryNextOnFail(name: String): Boolean
+}
+
+/**
+ * Hint where the options are disambiguated by a `key = "value"` field inside the config.
+ *
+ * This hint will cause derived `ConfigConvert` instance to fail to convert configs to objects if the object has a
+ * field with the same name as the disambiguation key.
+ *
+ * By default, the field value written is the class or coproduct option name converted to lower case. This mapping can
+ * be changed by overriding the method `fieldValue` of this class.
+ */
+class FieldCoproductHint[T](key: String) extends CoproductHint[T] {
+
+  /**
+   * Returns the field name for a class or coproduct option name.
+   *
+   * @param name the name of the class or coproduct option
+   * @return the field value associated with the given class or coproduct option name.
+   */
+  protected def fieldValue(name: String): String = name.toLowerCase
+
+  def from(cv: ConfigValue, name: String): Try[Option[ConfigValue]] = cv match {
+    case co: ConfigObject =>
+      Option(co.get(key)) match {
+        case Some(fv) => fv.unwrapped match {
+          case v: String if v == fieldValue(name) => Success(Some(cv))
+          case _: String => Success(None)
+          case _ => Failure(WrongTypeException(fv.valueType.toString))
+        }
+        case None => Failure(KeyNotFoundException(key))
+      }
+    case _ => Failure(WrongTypeException(cv.valueType.toString))
+  }
+
+  def to(cv: ConfigValue, name: String): Try[ConfigValue] = cv match {
+    case co: ConfigObject =>
+      if (co.containsKey(key)) Failure(CollidingKeysException(key, co.get(key).toString))
+      else Success(Map(key -> fieldValue(name)).toConfig.withFallback(co.toConfig))
+
+    case _ =>
+      Failure(WrongTypeException(cv.valueType.toString))
+  }
+
+  def tryNextOnFail(name: String) = false
+}
+
+/**
+ * Hint where all coproduct options are tried in order. `from` will choose the first option able to deserialize
+ * the config without errors, while `to` will write the config as is, with no disambiguation information.
+ */
+class FirstSuccessCoproductHint[T] extends CoproductHint[T] {
+  def from(cv: ConfigValue, name: String) = Success(Some(cv))
+  def to(cv: ConfigValue, name: String) = Success(cv)
+  def tryNextOnFail(name: String) = true
+}
+
+object CoproductHint {
+  implicit def default[T]: CoproductHint[T] = new FieldCoproductHint[T]("type")
+}

--- a/core/src/main/scala/pureconfig/error/CollidingKeysException.scala
+++ b/core/src/main/scala/pureconfig/error/CollidingKeysException.scala
@@ -1,0 +1,4 @@
+package pureconfig.error
+
+case class CollidingKeysException(key: String, existingValue: String)
+  extends IllegalArgumentException(s"The coproduct hint key '$key' collides with existing field '$existingValue'")

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -11,13 +11,12 @@ import java.util.concurrent.TimeUnit
 import com.typesafe.config.{ Config => TypesafeConfig, _ }
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
-import shapeless.{ :+:, CNil, Coproduct }
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable._
 import scala.util.{ Failure, Success, Try }
 import com.typesafe.config.ConfigFactory
-import org.scalacheck.{ Arbitrary }
+import org.scalacheck.Arbitrary
 import org.scalatest._
 import prop.PropertyChecks
 import pureconfig.ConfigConvert.{ fromString, stringConvert }
@@ -200,12 +199,11 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     t => ISODateTimeFormat.dateTime().print(t)
   )
 
-  type ConfigCoproduct = Float :+: Boolean :+: CNil
-  case class Config(d: DateTime, l: List[Int], s: Set[Int], subConfig: FlatConfig, coproduct: ConfigCoproduct)
+  case class Config(d: DateTime, l: List[Int], s: Set[Int], subConfig: FlatConfig)
 
   it should s"be able to save and load ${classOf[Config]}" in {
     withTempFile { configFile =>
-      val expectedConfig = Config(new DateTime(1), List(1, 2, 3), Set(4, 5, 6), FlatConfig(false, 1d, 2f, 3, 4l, "5", Option("6")), Coproduct[ConfigCoproduct](false))
+      val expectedConfig = Config(new DateTime(1), List(1, 2, 3), Set(4, 5, 6), FlatConfig(false, 1d, 2f, 3, 4l, "5", Option("6")))
       saveConfigAsPropertyFile(expectedConfig, configFile, overrideOutputPath = true)
       val config = loadConfig[Config](configFile)
 
@@ -218,12 +216,57 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
 
   it should s"be able to save ${classOf[Config2]} and load ${classOf[Config]} when namespace is set to config" in {
     withTempFile { configFile =>
-      val expectedConfig = Config(new DateTime(1), List(1, 2, 3), Set(4, 5, 6), FlatConfig(false, 1d, 2f, 3, 4l, "5", Option("6")), Coproduct[ConfigCoproduct](false))
+      val expectedConfig = Config(new DateTime(1), List(1, 2, 3), Set(4, 5, 6), FlatConfig(false, 1d, 2f, 3, 4l, "5", Option("6")))
       val configToSave = Config2(expectedConfig)
       saveConfigAsPropertyFile(configToSave, configFile, overrideOutputPath = true)
       val config = loadConfig[Config](configFile, "config")
 
       config should be(Success(expectedConfig))
+    }
+  }
+
+  sealed trait AnimalConfig
+  case class DogConfig(age: Int) extends AnimalConfig
+  case class CatConfig(age: Int) extends AnimalConfig
+  case class BirdConfig(canFly: Boolean) extends AnimalConfig
+
+  it should s"be able to save and load ${classOf[AnimalConfig]}" in {
+    List(DogConfig(12), CatConfig(3), BirdConfig(true)).foreach { expectedConfig =>
+      saveAndLoadIsIdentity[AnimalConfig](expectedConfig)
+    }
+  }
+
+  it should s"read and write disambiguation information on sealed families by default" in {
+    withTempFile { configFile =>
+      val conf = ConfigFactory.parseString("{ type = dogconfig, age = 2 }")
+      loadConfig[AnimalConfig](conf) should be(Success(DogConfig(2)))
+
+      saveConfigAsPropertyFile[AnimalConfig](DogConfig(2), configFile, overrideOutputPath = true)
+      loadConfig[TypesafeConfig](configFile).map(_.getString("type")) should be(Success("dogconfig"))
+    }
+  }
+
+  it should s"allow using different strategies for disambiguating between options in a sealed family" in {
+    withTempFile { configFile =>
+      implicit val hint = new FieldCoproductHint[AnimalConfig]("which-animal") {
+        override def fieldValue(name: String) = name.dropRight("Config".length)
+      }
+
+      val conf = ConfigFactory.parseString("{ which-animal = Dog, age = 2 }")
+      loadConfig[AnimalConfig](conf) should be(Success(DogConfig(2)))
+
+      saveConfigAsPropertyFile[AnimalConfig](DogConfig(2), configFile, overrideOutputPath = true)
+      loadConfig[TypesafeConfig](configFile).map(_.getString("which-animal")) should be(Success("Dog"))
+    }
+
+    withTempFile { configFile =>
+      implicit val hint = new FirstSuccessCoproductHint[AnimalConfig]
+
+      val conf = ConfigFactory.parseString("{ canFly = true }")
+      loadConfig[AnimalConfig](conf) should be(Success(BirdConfig(true)))
+
+      saveConfigAsPropertyFile[AnimalConfig](DogConfig(2), configFile, overrideOutputPath = true)
+      loadConfig[TypesafeConfig](configFile).map(_.hasPath("type")) should be(Success(false))
     }
   }
 

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -21,7 +21,7 @@ import org.scalacheck.Shapeless._
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 import pureconfig.ConfigConvert.{ fromString, stringConvert }
-import pureconfig.error.{ CollidingKeysException, KeyNotFoundException, WrongTypeForKeyException }
+import pureconfig.error._
 
 /**
  * @author Mario Pastorelli
@@ -274,9 +274,14 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     a[CollidingKeysException] should be thrownBy cc.to(DogConfig(2))
   }
 
-  it should "return a Failure with a proper exception if the hint field is missing" in {
+  it should "return a Failure with a proper exception if the hint field in a coproduct is missing" in {
     val conf = ConfigFactory.parseString("{ canFly = true }")
     loadConfig[AnimalConfig](conf) should be(Failure(KeyNotFoundException("type")))
+  }
+
+  it should "return a Failure with a proper exception when a coproduct config is missing" in {
+    case class AnimalCage(animal: AnimalConfig)
+    loadConfig[AnimalCage](ConfigFactory.empty()) should be(Failure(KeyNotFoundException("animal")))
   }
 
   // a realistic example of configuration: common available Spark properties


### PR DESCRIPTION
This pull request adds a new `CoproductHint` trait that allows easy customization of the serialization of sealed families. The general idea was taken from [spray-json-shapeless](https://github.com/fommil/spray-json-shapeless), with a handful of improvements and tweaks to better match the API patterns in pureconfig.

A `CoproductHint` decides, for a given `Config` and the name of a coproduct option (such as the name of a subclass of the sealed trait), if the received config should be deserialized as an instance of the specific option. In most cases, it uses disambiguation information, such as an extra `type` field, to encode and decode the concrete instance to create.

Two implementations of `CoproductHint` are added. The most common in my view, and the default in spray-json-shapeless, is a `FieldCoproductHint`, which writes configs with an extra field (`type` by default) and reads it to instantiate concrete models. The name of the field and the mapping between class names and field values can be customized as described in the Scaladoc. I also added `FirstSuccessCoproductHint`, which doesn't encode any extra information and defines the current pureconfig behavior.

I opted to change the default serialization of sealed families to use `FieldCoproductHint`. It's a breaking change, but the current behavior is arguably flawed (in fact, this fixes #13). People relying on the old behavior can easily put in scope an instance of `FirstSuccessCoproductHint`, though.

With this change, pureconfig stopped supporting pure `Coproduct` instances, as it now requires coproducts to be `LabelledGeneric` in order to retrieve the names of the various options. I don't think it is common for people to use `Coproducts`, particularly in configs; however, if you think otherwise I think I can rewrite this to keep support for non-labelled coproducts (at the cost of having some code duplicated, I guess).
