### PR TITLE
Support loading 0 without units as a Duration and FiniteDuration

### DIFF
--- a/core/src/main/scala/pureconfig/DurationConvert.scala
+++ b/core/src/main/scala/pureconfig/DurationConvert.scala
@@ -12,7 +12,7 @@ private[pureconfig] object DurationConvert {
    * Convert a string to a Duration while trying to maintain compatibility with Typesafe's abbreviations.
    */
   def fromString[D](durationString: String, ct: ClassTag[D]): Try[Duration] = {
-    Try { Duration(justAMinute(itsGreekToMe(durationString))) }
+    Try { Duration(addZeroUnit(justAMinute(itsGreekToMe(durationString)))) }
       .recoverWith {
         case ex: NumberFormatException =>
           val err = s"Could not parse a ${ct.runtimeClass.getSimpleName} from '$durationString'. (try ns, us, ms, s, m, h, d)"
@@ -20,8 +20,11 @@ private[pureconfig] object DurationConvert {
       }
   }
 
+  private val zeroRegex = "\\s*[+-]?0+\\s*$".r
   private val fauxMuRegex = "([0-9])(\\s*)us(\\s*)$".r
   private val shortMinuteRegex = "([0-9])(\\s*)m(\\s*)$".r
+
+  private val addZeroUnit = { s: String => if (zeroRegex.unapplySeq(s).isDefined) "0d" else s }
 
   // To maintain compatibility with Typesafe Config, replace "us" with "µs".
   private val itsGreekToMe = fauxMuRegex.replaceSomeIn(_: String, m => Some(s"${m.group(1)}${m.group(2)}µs${m.group(3)}"))

--- a/core/src/test/scala/pureconfig/DurationConvertTest.scala
+++ b/core/src/test/scala/pureconfig/DurationConvertTest.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import com.typesafe.config.ConfigValueFactory
 import org.scalatest.{ FlatSpec, Matchers, TryValues }
+import org.scalatest.Inspectors._
 
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
@@ -51,6 +52,27 @@ class DurationConvertTest extends FlatSpec with Matchers with TryValues {
     fromS("44999us") shouldBe Success(Duration(44999, TimeUnit.MICROSECONDS))
     fromS("44999µs") shouldBe Success(Duration(44999, TimeUnit.MICROSECONDS))
     fromS("88222ns") shouldBe Success(Duration(88222, TimeUnit.NANOSECONDS))
+  }
+  it should "succeed when loading 0 without units" in {
+    val signs = Set("", "-", "+")
+    val leftSpacing = Set("", " ")
+    val rightSpacing = Set("", " ")
+    val leftSpacingSize = Set((0 to 2): _*)
+    val rightSpacingSize = Set((0 to 2): _*)
+    val zeroRepeatSize = Set((1 to 2): _*)
+    forAll(signs) { sign =>
+      forAll(leftSpacing) { lsc =>
+        forAll(rightSpacing) { rsc =>
+          forAll(leftSpacingSize) { ls =>
+            forAll(rightSpacingSize) { rs =>
+              forAll(zeroRepeatSize) { zr =>
+                fromS(lsc * ls + sign + "0" * zr + rsc * rs) shouldBe Success(Duration(0, TimeUnit.DAYS))
+              }
+            }
+          }
+        }
+      }
+    }
   }
   it should "report a helpful error message when failing to convert a bad duration" in {
     val badDuration = "10 lordsALeaping"


### PR DESCRIPTION
This PR adds support for loading "0" (without units) as a `Duration` and `FiniteDuration`, something that was supported in PureConfig 0.3.x but throws a parsing error in 0.4.0, since it is not supported by `scala.concurrent.duration.Duration`'s apply method.

This fixes #71.