### PR TITLE
Explain how to use coproduct hints in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A boilerplate-free Scala library for loading configuration files
 - [Customizing naming conventions](#customizing-naming-conventions)
 - [Extends the library to support new types](#extend-the-library-to-support-new-types)
 - [Override behaviour for types](#override-behaviour-for-types)
+- [Override behaviour for sealed families](#override-behaviour-for-sealed-families)
 - [Example](#example)
 - [Whence the config files](#whence-the-config-files)
 - [Contribute](#contribute)
@@ -208,6 +209,8 @@ always read lower case. We can do:
 > ConfigConvert[String].from(ConfigValueFactory.fromAnyRef("FooBar"))
 util.Try[String] = Success(foobar)
 ```
+
+## Override behaviour for sealed families
 
 In order for `pureconfig` to disambiguate between different options of a sealed
 family of case classes, it must read and write additional information in

--- a/README.md
+++ b/README.md
@@ -209,7 +209,85 @@ always read lower case. We can do:
 util.Try[String] = Success(foobar)
 ```
 
+In order for `pureconfig` to disambiguate between different options of a sealed
+family of case classes, it must read and write additional information in
+configurations. By default it uses the additional field `type`, encoding the
+concrete class represented in the configuration:
 
+```scala
+sealed trait AnimalConf
+case class DogConf(age: Int) extends AnimalConf
+case class BirdConf(canFly: Boolean) extends AnimalConf
+
+loadConfig[AnimalConf](parseString("""{ type: "dogconf", age: 4 }"""))
+// returns Success(DogConf(4))
+```
+
+For sealed families, `pureconfig` provides a way to customize the conversion
+without replacing the default `ConfigConvert`. By putting in scope an instance
+of `CoproductHint` for that sealed family, we can customize how the
+disambiguation is made. For example, if `type` clashes with one of the fields
+of a case class option, we can use another field:
+
+```scala
+implicit val animalConfHint = new FieldCoproductHint[AnimalConf]("kind")
+loadConfig[AnimalConf](parseString("""{ kind: "dogconf", age: 4 }"""))
+// returns Success(DogConf(4))
+```
+
+`FieldCoproductHint` can also be adapted to write class names in a different
+way:
+
+```scala
+implicit val animalConfHint = new FieldCoproductHint[AnimalConf]("type") {
+  override def fieldValue(name: String) = name.dropRight("Conf".length)
+}
+loadConfig[AnimalConf](parseString("""{ type: "Bird", canFly: true }"""))
+// returns Success(BirdConf(true))
+```
+
+With a `CoproductHint` you can even opt not to use any extra field at all. For
+example, if you encode enumerations using sealed traits, you can just write the
+name of the class:
+
+```scala
+import com.typesafe.config.{ConfigFactory,ConfigValue}
+import pureconfig.syntax._
+import scala.util.Success
+
+sealed trait Season
+case object Spring extends Season
+case object Summer extends Season
+case object Autumn extends Season
+case object Winter extends Season
+
+implicit val seasonHint = new CoproductHint[Season] {
+
+  // Reads a config for Season (`cv`).
+  // - If `name` is the name of the concrete season `cv` refers to, returns
+  //   `Success(Some(conf))`, where `conf` is the config for the concrete class
+  //   (in this case, an empty object).
+  // - If `name` is not the name of the class for `cv`, returns
+  //   `Success(None)`.
+  // - If `cv` is an invalid config for Season (in this case, if it isn't a
+  //   string), returns a `Failure`.
+  def from(cv: ConfigValue, name: String) = cv.to[String].map { strConf =>
+    if(strConf == name) Some(ConfigFactory.empty.root) else None
+  }
+  
+  // Writes a config for a Season. `cv` is a config for the concrete season
+  // `name` (in this case, `cv` is always an empty object).
+  def to(cv: ConfigValue, name: String) = Success(name.toConfig)
+  
+  // If `from` returns a `Failure` for a concrete class, should we try other
+  // concrete classes?
+  def tryNextOnFail(name: String) = false
+}
+
+case class MyConf(list: List[Season])
+loadConfig[MyConf](parseString("""list = [Spring, Summer, Autumn, Winter]"""))
+// returns Success(MyConf(List(Spring, Summer, Autumn, Winter)))
+```
 
 ## Example
 


### PR DESCRIPTION
This pull request adds a mini-tutorial for using `CoproductHints` to README.

I'm not sure of the best section to put this explanation. "Override behaviour for types" seemed the best section of the existing ones, but we can also have a dedicated section for this. Let me know your thoughts!
