### PR TITLE
Change scalaVersion to 2.12.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In the sbt configuration file:
 use scala `2.10`, `2.11` or `2.12`:
 
 ```scala
-scalaVersion := "2.11.8" // or "2.10.5"
+scalaVersion := "2.12.0" // or "2.11.8", "2.10.5"
 ```
 
 Add the library. For scala `2.11` and `2.12`


### PR DESCRIPTION
A minor fix; I suppose it was forgotten when the update to 2.12 was made.
