### PR TITLE
Add functionality to parse collections from objects with numeric keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   - Add support for `LocalDate`, `LocalDateTime` and `LocalTime` from the `java.time` package via
     configurable instances. See the [README](https://github.com/melrief/pureconfig#configurable-converters)
     for more details.
+  - Add support for converting objects with numeric keys into lists. This is a functionallity also supported
+    by typesafe config since version [1.0.1](https://github.com/typesafehub/config/blob/f6680a5dad51d992139d45a84fad734f1778bf50/NEWS.md#101-may-19-2013)
+    and discussed in the following [issue](https://github.com/typesafehub/config/issues/69).
 
 ### 0.5.0 (Jan 3, 2017)
 

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -254,7 +254,7 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
 
     private def reportBadIndex(keyString: String): PartialFunction[Throwable, Failure[Nothing]] = {
       case NonFatal(e) =>
-        val message = s"Cannot interpet $keyString as a numeric index. Tried to read the object as an indexed sequence. " +
+        val message = s"Cannot interpet '$keyString' as a numeric index. Tried to read the object as an indexed sequence. " +
           "Expecting syntax like (a.0=0, a.1=1, ...) when loading a sequence called 'a'"
         Failure(new IllegalArgumentException(message))
     }

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -781,7 +781,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
       intSet.a: 2
     }""")
 
-    assert(loadConfig[Set[Int]](conf, "pure.conf.intSet").failure.exception.getMessage.startsWith("Cannot interpet a as a numeric index"))
+    assert(loadConfig[Set[Int]](conf, "pure.conf.intSet").failure.exception.getMessage.startsWith("Cannot interpet 'a' as a numeric index"))
   }
 
   "Converting from an empty string to a duration" should "complain about an empty string" in {

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -781,7 +781,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
       intSet.a: 2
     }""")
 
-    assert(loadConfig[Set[Int]](conf, "pure.conf.intSet").failure.exception.getMessage.contains("Cannot parse this object as list! Expecting syntax like"))
+    assert(loadConfig[Set[Int]](conf, "pure.conf.intSet").failure.exception.getMessage.startsWith("Cannot interpet a as a numeric index"))
   }
 
   "Converting from an empty string to a duration" should "complain about an empty string" in {

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -436,6 +436,17 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     loadConfig[List[Int]](conf, "pure.conf.intList") shouldBe Success(expected)
   }
 
+  it should "be able to load a list of Ints from the system properties in correct order when one element is missing" in {
+    val conf = ConfigFactory.parseString("""
+    pure.conf: {
+      intList.2: 3
+      intList.0: 1
+    }""")
+
+    val expected = List(1, 3)
+    loadConfig[List[Int]](conf, "pure.conf.intList") shouldBe Success(expected)
+  }
+
   case class ConfWithStreamOfFoo(stream: Stream[Foo])
 
   it should s"be able to save and load configurations containing immutable.Stream" in {

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -413,7 +413,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     loadConfig[ConfWithListOfFoo](conf) shouldBe Success(expected)
   }
 
-  it should "be able to load a set of Ints from the system properties" in {
+  it should "be able to load a set of Ints from an object with numeric keys" in {
     val conf = ConfigFactory.parseString("""
     pure.conf: {
       intSet.0: 1
@@ -424,7 +424,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     loadConfig[Set[Int]](conf, "pure.conf.intSet") shouldBe Success(expected)
   }
 
-  it should "be able to load a list of Ints from the system properties in correct order" in {
+  it should "be able to load a list of Ints from an object with numeric keys (in correct order)" in {
     val conf = ConfigFactory.parseString("""
     pure.conf: {
       intList.2: 1
@@ -436,7 +436,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     loadConfig[List[Int]](conf, "pure.conf.intList") shouldBe Success(expected)
   }
 
-  it should "be able to load a list of Ints from the system properties in correct order when one element is missing" in {
+  it should "be able to load a list of Ints from an object with numeric keys in correct order when one element is missing" in {
     val conf = ConfigFactory.parseString("""
     pure.conf: {
       intList.2: 3
@@ -774,7 +774,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     loadConfig[ConfigWithDouble](conf).failure.exception.getMessage shouldEqual "Cannot read a Double from an empty string."
   }
 
-  "Converting from a wrong system properties list" should "complain about having the wrong sytem properties list syntax" in {
+  "Converting from a wrong list object that has non-numeric keys" should "complain about having the wrong list syntax" in {
     val conf = ConfigFactory.parseString("""
     pure.conf: {
       intSet.0: 1

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -414,26 +414,26 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   }
 
   it should "be able to load a set of Ints from the system properties" in {
-    System.setProperty("pure.conf.intSet.0", "1")
-    System.setProperty("pure.conf.intSet.1", "2")
-    val expected = Set(1, 2)
-    loadConfig[Set[Int]]("pure.conf.intSet") shouldBe Success(expected)
+    val conf = ConfigFactory.parseString("""
+    pure.conf: {
+      intSet.0: 1
+      intSet.1: 2
+    }""")
 
-    System.clearProperty("pure.conf.intSet.0")
-    System.clearProperty("pure.conf.intSet.1")
+    val expected = Set(1, 2)
+    loadConfig[Set[Int]](conf, "pure.conf.intSet") shouldBe Success(expected)
   }
 
   it should "be able to load a list of Ints from the system properties in correct order" in {
-    System.setProperty("pure.conf.intList.2", "1")
-    System.setProperty("pure.conf.intList.0", "2")
-    System.setProperty("pure.conf.intList.1", "3")
+    val conf = ConfigFactory.parseString("""
+    pure.conf: {
+      intList.2: 1
+      intList.0: 2
+      intList.1: 3
+    }""")
 
     val expected = List(2, 3, 1)
-    loadConfig[List[Int]]("pure.conf.intList") shouldBe Success(expected)
-
-    System.clearProperty("pure.conf.intList.0")
-    System.clearProperty("pure.conf.intList.1")
-    System.clearProperty("pure.conf.intList.2")
+    loadConfig[List[Int]](conf, "pure.conf.intList") shouldBe Success(expected)
   }
 
   case class ConfWithStreamOfFoo(stream: Stream[Foo])
@@ -764,14 +764,13 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   }
 
   "Converting from a wrong system properties list" should "complain about having the wrong sytem properties list syntax" in {
-    System.setProperty("pure.conf.intSet.0", "1")
-    System.setProperty("pure.conf.intSet.a", "2")
-    val expected = Set(1, 2)
+    val conf = ConfigFactory.parseString("""
+    pure.conf: {
+      intSet.0: 1
+      intSet.a: 2
+    }""")
 
-    assert(loadConfig[Set[Int]]("pure.conf.intSet").failure.exception.getMessage.contains("Cannot parse this object as list! Expecting syntax like"))
-
-    System.clearProperty("pure.conf.intSet.0")
-    System.clearProperty("pure.conf.intSet.a")
+    assert(loadConfig[Set[Int]](conf, "pure.conf.intSet").failure.exception.getMessage.contains("Cannot parse this object as list! Expecting syntax like"))
   }
 
   "Converting from an empty string to a duration" should "complain about an empty string" in {


### PR DESCRIPTION
I propose to make it possible to parse objects with numeric keys as lists. 
This functionality exists in typesafe config and can help when overwriting list items through the command line or properties files. 

As example a configuration like the following could be parsed:
```
a.0=1
a.1=2
```