### PR TITLE
Add java.time support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 - New features
   - More consistent handling of missing keys: if a config key is missing pureconfig always throws a
     `KeyNotFoundException` now, unless the `ConfigConvert` extends the new `AllowMissingKey` trait.
-  - Add support for `LocalDate`, `LocalDateTime` and `LocalTime` from the `java.time` package via
-    configurable instances. See the [README](https://github.com/melrief/pureconfig#configurable-converters)
+  - Add support for the `java.time` package. Converters types which support different string formats, such as `LocalDate`,
+    must be configured before they can be used. See the [README](https://github.com/melrief/pureconfig#configurable-converters)
     for more details.
   - Add support for converting objects with numeric keys into lists. This is a functionallity also supported
     by typesafe config since version [1.0.1](https://github.com/typesafehub/config/blob/f6680a5dad51d992139d45a84fad734f1778bf50/NEWS.md#101-may-19-2013)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ and percentage format ending with `%`), `Float` (also supporting percentage),
 is in this list
 - `Option` for optional values, i.e. value that can or cannot be in the configuration
 - `Map` with `String` keys and any value type that is in this list
-- `LocalDate`, `LocalTime`, `LocalDatetime` (see [Configurable converters](#configurable-converters))
+- everything in [`java.time`](https://docs.oracle.com/javase/8/docs/api/java/time/package-summary.html).
+ Because different formats are supported, converters for types that support multiple formats must be configured
+ before they can be used (see [Configurable converters](#configurable-converters))
 - typesafe `ConfigValue`, `ConfigObject` and `ConfigList`
 - case classes
 - sealed families of case classes (ADTs)

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -14,12 +14,13 @@ import scala.collection.JavaConverters._
 import scala.collection.generic.CanBuildFrom
 import scala.language.higherKinds
 import scala.reflect.ClassTag
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 import java.net.URL
+import java.time.ZoneOffset
 
-import scala.concurrent.duration.{ Duration, FiniteDuration }
-import pureconfig.ConfigConvert.{ fromNonEmptyString, fromString, nonEmptyStringConvert, stringConvert }
-import pureconfig.error.{ CannotConvertNullException, KeyNotFoundException, WrongTypeException, WrongTypeForKeyException }
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import pureconfig.ConfigConvert.{fromNonEmptyString, fromString, nonEmptyStringConvert, stringConvert}
+import pureconfig.error.{CannotConvertNullException, KeyNotFoundException, WrongTypeException, WrongTypeForKeyException}
 
 import scala.collection.mutable.Builder
 import scala.util.control.NonFatal
@@ -339,6 +340,9 @@ trait LowPriorityConfigConvertImplicits {
     }
     nonEmptyStringConvert(fromString, DurationConvert.fromDuration)
   }
+
+  implicit val zoneOffsetConfigConvert: ConfigConvert[ZoneOffset] =
+    nonEmptyStringConvert[ZoneOffset](s => Try(ZoneOffset.of(s)), _.toString)
 
   implicit val readString = fromString[String](Success(_))
   implicit val readBoolean = fromNonEmptyString[Boolean](s => Try(s.toBoolean))

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -16,7 +16,7 @@ import scala.language.higherKinds
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 import java.net.URL
-import java.time.ZoneOffset
+import java.time.{Period, ZoneOffset}
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import pureconfig.ConfigConvert.{fromNonEmptyString, fromString, nonEmptyStringConvert, stringConvert}
@@ -343,6 +343,9 @@ trait LowPriorityConfigConvertImplicits {
 
   implicit val zoneOffsetConfigConvert: ConfigConvert[ZoneOffset] =
     nonEmptyStringConvert[ZoneOffset](s => Try(ZoneOffset.of(s)), _.toString)
+
+  implicit val periodConfigConvert: ConfigConvert[Period] =
+    nonEmptyStringConvert[Period](s => Try(Period.parse(s)), _.toString)
 
   implicit val readString = fromString[String](Success(_))
   implicit val readBoolean = fromNonEmptyString[Boolean](s => Try(s.toBoolean))

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -16,7 +16,7 @@ import scala.language.higherKinds
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 import java.net.URL
-import java.time.{Period, ZoneOffset}
+import java.time.{Period, Year, ZoneOffset}
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import pureconfig.ConfigConvert.{fromNonEmptyString, fromString, nonEmptyStringConvert, stringConvert}
@@ -346,6 +346,9 @@ trait LowPriorityConfigConvertImplicits {
 
   implicit val periodConfigConvert: ConfigConvert[Period] =
     nonEmptyStringConvert[Period](s => Try(Period.parse(s)), _.toString)
+
+  implicit val yearConfigConvert: ConfigConvert[Year] =
+    nonEmptyStringConvert[Year](s => Try(Year.parse(s)), _.toString)
 
   implicit val readString = fromString[String](Success(_))
   implicit val readBoolean = fromNonEmptyString[Boolean](s => Try(s.toBoolean))

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -16,7 +16,7 @@ import scala.language.higherKinds
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 import java.net.URL
-import java.time.{Period, Year, ZoneId, ZoneOffset}
+import java.time._
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import pureconfig.ConfigConvert.{fromNonEmptyString, fromString, nonEmptyStringConvert, stringConvert}
@@ -340,6 +340,9 @@ trait LowPriorityConfigConvertImplicits {
     }
     nonEmptyStringConvert(fromString, DurationConvert.fromDuration)
   }
+
+  implicit val instantConfigConvert: ConfigConvert[Instant] =
+    nonEmptyStringConvert[Instant](s => Try(Instant.parse(s)), _.toString)
 
   implicit val zoneOffsetConfigConvert: ConfigConvert[ZoneOffset] =
     nonEmptyStringConvert[ZoneOffset](s => Try(ZoneOffset.of(s)), _.toString)

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -16,7 +16,7 @@ import scala.language.higherKinds
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 import java.net.URL
-import java.time.{Period, Year, ZoneOffset}
+import java.time.{Period, Year, ZoneId, ZoneOffset}
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import pureconfig.ConfigConvert.{fromNonEmptyString, fromString, nonEmptyStringConvert, stringConvert}
@@ -343,6 +343,9 @@ trait LowPriorityConfigConvertImplicits {
 
   implicit val zoneOffsetConfigConvert: ConfigConvert[ZoneOffset] =
     nonEmptyStringConvert[ZoneOffset](s => Try(ZoneOffset.of(s)), _.toString)
+
+  implicit val zoneIdConfigConvert: ConfigConvert[ZoneId] =
+    nonEmptyStringConvert[ZoneId](s => Try(ZoneId.of(s)), _.toString)
 
   implicit val periodConfigConvert: ConfigConvert[Period] =
     nonEmptyStringConvert[Period](s => Try(Period.parse(s)), _.toString)

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -1,7 +1,7 @@
 package pureconfig
 
 import scala.util.Try
-import java.time.{LocalDate, LocalDateTime, LocalTime, MonthDay}
+import java.time._
 import java.time.format.DateTimeFormatter
 
 /**
@@ -35,4 +35,12 @@ package object configurable {
   def monthDayConfigConvert(formatter: DateTimeFormatter): ConfigConvert[MonthDay] =
     ConfigConvert.nonEmptyStringConvert[MonthDay](
       s => Try(MonthDay.parse(s, formatter)), _.format(formatter))
+
+  def offsetDateTimeConfigConvert(formatter: DateTimeFormatter): ConfigConvert[OffsetDateTime] =
+    ConfigConvert.nonEmptyStringConvert[OffsetDateTime](
+      s => Try(OffsetDateTime.parse(s, formatter)), _.format(formatter))
+
+  def offsetTimeConfigConvert(formatter: DateTimeFormatter): ConfigConvert[OffsetTime] =
+    ConfigConvert.nonEmptyStringConvert[OffsetTime](
+      s => Try(OffsetTime.parse(s, formatter)), _.format(formatter))
 }

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -43,4 +43,8 @@ package object configurable {
   def offsetTimeConfigConvert(formatter: DateTimeFormatter): ConfigConvert[OffsetTime] =
     ConfigConvert.nonEmptyStringConvert[OffsetTime](
       s => Try(OffsetTime.parse(s, formatter)), _.format(formatter))
+
+  def yearMonthConfigConvert(formatter: DateTimeFormatter): ConfigConvert[YearMonth] =
+    ConfigConvert.nonEmptyStringConvert[YearMonth](
+      s => Try(YearMonth.parse(s, formatter)), _.format(formatter))
 }

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -47,4 +47,8 @@ package object configurable {
   def yearMonthConfigConvert(formatter: DateTimeFormatter): ConfigConvert[YearMonth] =
     ConfigConvert.nonEmptyStringConvert[YearMonth](
       s => Try(YearMonth.parse(s, formatter)), _.format(formatter))
+
+  def zonedDateTimeConfigConvert(formatter: DateTimeFormatter): ConfigConvert[ZonedDateTime] =
+    ConfigConvert.nonEmptyStringConvert[ZonedDateTime](
+      s => Try(ZonedDateTime.parse(s, formatter)), _.format(formatter))
 }

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -1,7 +1,7 @@
 package pureconfig
 
 import scala.util.Try
-import java.time.{ LocalDate, LocalDateTime, LocalTime }
+import java.time.{LocalDate, LocalDateTime, LocalTime, MonthDay}
 import java.time.format.DateTimeFormatter
 
 /**
@@ -31,4 +31,8 @@ package object configurable {
   def localDateTimeConfigConvert(formatter: DateTimeFormatter): ConfigConvert[LocalDateTime] =
     ConfigConvert.nonEmptyStringConvert[LocalDateTime](
       s => Try(LocalDateTime.parse(s, formatter)), _.format(formatter))
+
+  def monthDayConfigConvert(formatter: DateTimeFormatter): ConfigConvert[MonthDay] =
+    ConfigConvert.nonEmptyStringConvert[MonthDay](
+      s => Try(MonthDay.parse(s, formatter)), _.format(formatter))
 }

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -5,22 +5,22 @@ package pureconfig
 
 import java.io.PrintWriter
 import java.net.URL
-import java.nio.file.{ Files, Path }
+import java.nio.file.{Files, Path}
+import java.time.ZoneOffset
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable._
-import scala.concurrent.duration.{ Duration, FiniteDuration }
-import scala.util.{ Failure, Success, Try }
-
-import com.typesafe.config.{ ConfigFactory, Config => TypesafeConfig, _ }
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.util.{Failure, Success, Try}
+import com.typesafe.config.{ConfigFactory, Config => TypesafeConfig, _}
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.scalacheck.Arbitrary
 import org.scalacheck.Shapeless._
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
-import pureconfig.ConfigConvert.{ fromString, stringConvert }
+import pureconfig.ConfigConvert.{fromString, stringConvert}
 import pureconfig.error._
 
 /**
@@ -512,6 +512,14 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     val expected = Duration(110, TimeUnit.DAYS)
     implicit val readDurationBadly = fromString[Duration](_ => Try(expected))
     loadConfig(ConfigValueFactory.fromMap(Map("i" -> "23 s").asJava).toConfig)(ConfigConvert[ConfWithDuration]).success.value shouldBe ConfWithDuration(expected)
+  }
+
+  case class ConfWithZoneOffset(offset: ZoneOffset)
+
+  it should "be able to read a config with a ZoneOffset" in {
+    val expected = ZoneOffset.ofHours(10)
+    val config = ConfigFactory.parseString(s"""{ "offset":"${expected.toString}" }""")
+    loadConfig[ConfWithZoneOffset](config).success.value shouldBe ConfWithZoneOffset(expected)
   }
 
   it should "be able to supersede the default Duration ConfigConvert with a locally defined ConfigConvert" in {

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -6,7 +6,7 @@ package pureconfig
 import java.io.PrintWriter
 import java.net.URL
 import java.nio.file.{Files, Path}
-import java.time.{Period, ZoneOffset}
+import java.time.{Period, Year, ZoneOffset}
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
@@ -528,6 +528,14 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     val expected = Period.of(2016, 1, 1)
     val config = ConfigFactory.parseString(s"""{ "period":"${expected.toString}" }""")
     loadConfig[ConfWithPeriod](config).success.value shouldBe ConfWithPeriod(expected)
+  }
+
+  case class ConfWithYear(year: Year)
+
+  it should "be able to read a config with a Year" in {
+    val expected = Year.now()
+    val config = ConfigFactory.parseString(s"""{ "year":"${expected.toString}" }""")
+    loadConfig[ConfWithYear](config).success.value shouldBe ConfWithYear(expected)
   }
 
   it should "be able to supersede the default Duration ConfigConvert with a locally defined ConfigConvert" in {

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -6,7 +6,7 @@ package pureconfig
 import java.io.PrintWriter
 import java.net.URL
 import java.nio.file.{Files, Path}
-import java.time.{Period, Year, ZoneOffset}
+import java.time.{Period, Year, ZoneId, ZoneOffset}
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
@@ -520,6 +520,14 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     val expected = ZoneOffset.ofHours(10)
     val config = ConfigFactory.parseString(s"""{ "offset":"${expected.toString}" }""")
     loadConfig[ConfWithZoneOffset](config).success.value shouldBe ConfWithZoneOffset(expected)
+  }
+
+  case class ConfWithZoneId(zoneId: ZoneId)
+
+  it should "be able to read a config with a ZoneId" in {
+    val expected = ZoneId.systemDefault()
+    val config = ConfigFactory.parseString(s"""{ "zoneId":"${expected.toString}" }""")
+    loadConfig[ConfWithZoneId](config).success.value shouldBe ConfWithZoneId(expected)
   }
 
   case class ConfWithPeriod(period: Period)

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -6,7 +6,7 @@ package pureconfig
 import java.io.PrintWriter
 import java.net.URL
 import java.nio.file.{Files, Path}
-import java.time.{Period, Year, ZoneId, ZoneOffset}
+import java.time._
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
@@ -512,6 +512,14 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     val expected = Duration(110, TimeUnit.DAYS)
     implicit val readDurationBadly = fromString[Duration](_ => Try(expected))
     loadConfig(ConfigValueFactory.fromMap(Map("i" -> "23 s").asJava).toConfig)(ConfigConvert[ConfWithDuration]).success.value shouldBe ConfWithDuration(expected)
+  }
+
+  case class ConfWithInstant(instant: Instant)
+
+  it should "be able to read a config with an Instant" in {
+    val expected = Instant.now()
+    val config = ConfigFactory.parseString(s"""{ "instant":"${expected.toString}" }""")
+    loadConfig[ConfWithInstant](config).success.value shouldEqual ConfWithInstant(expected)
   }
 
   case class ConfWithZoneOffset(offset: ZoneOffset)

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -6,7 +6,7 @@ package pureconfig
 import java.io.PrintWriter
 import java.net.URL
 import java.nio.file.{Files, Path}
-import java.time.ZoneOffset
+import java.time.{Period, ZoneOffset}
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
@@ -520,6 +520,14 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     val expected = ZoneOffset.ofHours(10)
     val config = ConfigFactory.parseString(s"""{ "offset":"${expected.toString}" }""")
     loadConfig[ConfWithZoneOffset](config).success.value shouldBe ConfWithZoneOffset(expected)
+  }
+
+  case class ConfWithPeriod(period: Period)
+
+  it should "be able to read a config with a Period" in {
+    val expected = Period.of(2016, 1, 1)
+    val config = ConfigFactory.parseString(s"""{ "period":"${expected.toString}" }""")
+    loadConfig[ConfWithPeriod](config).success.value shouldBe ConfWithPeriod(expected)
   }
 
   it should "be able to supersede the default Duration ConfigConvert with a locally defined ConfigConvert" in {

--- a/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
+++ b/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
@@ -1,13 +1,13 @@
 package pureconfig.configurable
 
 import com.typesafe.config.ConfigFactory
-import java.time.{ LocalDate, LocalDateTime, LocalTime }
+import java.time.{LocalDate, LocalDateTime, LocalTime, MonthDay}
 import java.time.format.DateTimeFormatter
+
 import org.scalatest._
-import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.{Arbitrary, Gen}
 import prop.PropertyChecks
 import pureconfig.syntax._
-
 import ConfigurableSuite._
 
 class ConfigurableSuite extends FlatSpec with Matchers with TryValues with PropertyChecks {
@@ -37,6 +37,16 @@ class ConfigurableSuite extends FlatSpec with Matchers with TryValues with Prope
       val conf = ConfigFactory.parseString(s"""{dateTime:"${localDateTime.format(DateTimeFormatter.ISO_DATE_TIME)}"}""")
       case class Conf(dateTime: LocalDateTime)
       conf.to[Conf].success.value shouldEqual Conf(localDateTime)
+  }
+
+  val monthDayFormat = DateTimeFormatter.ofPattern("MM-dd")
+  implicit val monthDayInstance = monthDayConfigConvert(monthDayFormat)
+
+  it should "parse MonthDay" in forAll {
+    (monthDay: MonthDay) =>
+      val conf = ConfigFactory.parseString(s"""{monthDay:"${monthDay.format(monthDayFormat)}"}""")
+      case class Conf(monthDay: MonthDay)
+      conf.to[Conf].success.value shouldEqual Conf(monthDay)
   }
 }
 
@@ -70,4 +80,8 @@ object ConfigurableSuite {
         date <- localDateArbitrary.arbitrary
         time <- localTimeArbitrary.arbitrary
       } yield date.atTime(time))
+
+  implicit val monthDayArbitrary: Arbitrary[MonthDay] =
+    Arbitrary[MonthDay](
+      localDateArbitrary.arbitrary.map(date => MonthDay.of(date.getMonthValue, date.getDayOfMonth)))
 }


### PR DESCRIPTION
This PR adds support for the entire [`java.time` package](https://docs.oracle.com/javase/8/docs/api/java/time/package-summary.html) via either configurable converters or standard converters when no format is required to parse/format a type. This PR follows #66 in style and should resolve the issue #65.