### PR TITLE
Product hints

### DIFF
--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -135,7 +135,8 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
             case (null, converter: AllowMissingKey) =>
               converter.from(co.get(keyStr))
             case (null, _) =>
-              default.head.fold[Try[V]](Failure(CannotConvertNullException))(Success(_))
+              val defaultValue = if (hint.useDefaultArgs) default.head else None
+              defaultValue.fold[Try[V]](Failure(CannotConvertNullException))(Success(_))
             case (value, converter) =>
               converter.from(value)
           },

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -125,10 +125,10 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
     implicit key: Witness.Aux[K],
     vFieldConvert: Lazy[ConfigConvert[V]],
     tConfigConvert: Lazy[WrappedDefaultValueConfigConvert[Wrapped, T, U]],
-    mapping: ConfigFieldMapping[Wrapped]): WrappedDefaultValueConfigConvert[Wrapped, FieldType[K, V] :: T, Option[V] :: U] = new WrappedDefaultValueConfigConvert[Wrapped, FieldType[K, V]:: T, Option[V]:: U] {
+    hint: ProductHint[Wrapped]): WrappedDefaultValueConfigConvert[Wrapped, FieldType[K, V] :: T, Option[V] :: U] = new WrappedDefaultValueConfigConvert[Wrapped, FieldType[K, V]:: T, Option[V]:: U] {
 
     override def fromConfigObject(co: ConfigObject, default: Option[V] :: U): Try[FieldType[K, V] :: T] = {
-      val keyStr = mapping(key.value.toString().tail)
+      val keyStr = hint.fieldMapping(key.value.toString().tail)
       for {
         v <- improveFailure[V](
           (co.get(keyStr), vFieldConvert.value) match {
@@ -145,7 +145,7 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
     }
 
     override def to(t: FieldType[K, V] :: T): ConfigValue = {
-      val keyStr = mapping(key.value.toString().tail)
+      val keyStr = hint.fieldMapping(key.value.toString().tail)
       val rem = tConfigConvert.value.to(t.tail)
       // TODO check that all keys are unique
       vFieldConvert.value match {

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -134,7 +134,7 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
     hint: ProductHint[Wrapped]): WrappedDefaultValueConfigConvert[Wrapped, FieldType[K, V] :: T, Option[V] :: U] = new WrappedDefaultValueConfigConvert[Wrapped, FieldType[K, V]:: T, Option[V]:: U] {
 
     override def fromConfigObject(co: ConfigObject, default: Option[V] :: U): Try[FieldType[K, V] :: T] = {
-      val keyStr = hint.fieldMapping(key.value.toString().tail)
+      val keyStr = hint.configKey(key.value.toString().tail)
       for {
         v <- improveFailure[V](
           (co.get(keyStr), vFieldConvert.value) match {
@@ -156,7 +156,7 @@ object ConfigConvert extends LowPriorityConfigConvertImplicits {
     }
 
     override def to(t: FieldType[K, V] :: T): ConfigValue = {
-      val keyStr = hint.fieldMapping(key.value.toString().tail)
+      val keyStr = hint.configKey(key.value.toString().tail)
       val rem = tConfigConvert.value.to(t.tail)
       // TODO check that all keys are unique
       vFieldConvert.value match {

--- a/core/src/main/scala/pureconfig/ConfigFieldMapping.scala
+++ b/core/src/main/scala/pureconfig/ConfigFieldMapping.scala
@@ -1,10 +1,10 @@
 package pureconfig
 
-trait ConfigFieldMapping[T] extends (String => String) {
+trait ConfigFieldMapping extends (String => String) {
   def apply(fieldName: String): String
 }
 
-object ConfigFieldMapping extends LowPriorityConfigFieldMappingImplicits {
+object ConfigFieldMapping {
   /**
    * Creates a ConfigFieldMapping from the provided function, mapping names in
    * the object that will receive config values to names in the configuration
@@ -14,7 +14,7 @@ object ConfigFieldMapping extends LowPriorityConfigFieldMappingImplicits {
    *        values to names in the configuration file
    * @return a ConfigFieldMapping created from the provided function.
    */
-  def apply[T](f: String => String): ConfigFieldMapping[T] = new ConfigFieldMapping[T] {
+  def apply(f: String => String): ConfigFieldMapping = new ConfigFieldMapping {
     def apply(fieldName: String): String = f(fieldName)
   }
 
@@ -30,17 +30,11 @@ object ConfigFieldMapping extends LowPriorityConfigFieldMappingImplicits {
    * @return a ConfigFieldMapping created according to the provided naming
    *         conventions.
    */
-  def apply[T](typeFieldConvention: NamingConvention, configFieldConvention: NamingConvention): ConfigFieldMapping[T] = {
+  def apply(typeFieldConvention: NamingConvention, configFieldConvention: NamingConvention): ConfigFieldMapping = {
     if (typeFieldConvention == configFieldConvention) {
       apply(identity(_))
     } else {
       apply(typeFieldConvention.toTokens _ andThen configFieldConvention.fromTokens _)
     }
   }
-
-  def default[T]: ConfigFieldMapping[T] = apply(CamelCase, CamelCase)
-}
-
-trait LowPriorityConfigFieldMappingImplicits {
-  implicit def configFieldMapping[T]: ConfigFieldMapping[T] = ConfigFieldMapping.default[T]
 }

--- a/core/src/main/scala/pureconfig/ProductHint.scala
+++ b/core/src/main/scala/pureconfig/ProductHint.scala
@@ -2,16 +2,19 @@ package pureconfig
 
 trait ProductHint[T] {
   def fieldMapping: ConfigFieldMapping
+  def useDefaultArgs: Boolean
 }
 
 private[pureconfig] case class ProductHintImpl[T](
-  fieldMapping: ConfigFieldMapping) extends ProductHint[T]
+  fieldMapping: ConfigFieldMapping,
+  useDefaultArgs: Boolean) extends ProductHint[T]
 
 object ProductHint {
 
   def apply[T](
-    fieldMapping: ConfigFieldMapping = ConfigFieldMapping(CamelCase, CamelCase)): ProductHint[T] =
-    ProductHintImpl[T](fieldMapping)
+    fieldMapping: ConfigFieldMapping = ConfigFieldMapping(CamelCase, CamelCase),
+    useDefaultArgs: Boolean = true): ProductHint[T] =
+    ProductHintImpl[T](fieldMapping, useDefaultArgs)
 
   implicit def default[T]: ProductHint[T] = apply()
 }

--- a/core/src/main/scala/pureconfig/ProductHint.scala
+++ b/core/src/main/scala/pureconfig/ProductHint.scala
@@ -8,9 +8,12 @@ package pureconfig
 trait ProductHint[T] {
 
   /**
-   * The mapping used to map field names to config keys
+   * Returns the key in the config object associated with a given case class field.
+   *
+   * @param fieldName the case class field
+   * @return the key in the config object associated with the given case class field.
    */
-  def fieldMapping: ConfigFieldMapping
+  def configKey(fieldName: String): String
 
   /**
    * A boolean indicating if the default arguments of the case class should be used when fields are missing
@@ -24,9 +27,12 @@ trait ProductHint[T] {
 }
 
 private[pureconfig] case class ProductHintImpl[T](
-  fieldMapping: ConfigFieldMapping,
-  useDefaultArgs: Boolean,
-  allowUnknownKeys: Boolean) extends ProductHint[T]
+    fieldMapping: ConfigFieldMapping,
+    useDefaultArgs: Boolean,
+    allowUnknownKeys: Boolean) extends ProductHint[T] {
+
+  def configKey(fieldName: String) = fieldMapping(fieldName)
+}
 
 object ProductHint {
 

--- a/core/src/main/scala/pureconfig/ProductHint.scala
+++ b/core/src/main/scala/pureconfig/ProductHint.scala
@@ -1,8 +1,25 @@
 package pureconfig
 
+/**
+ * A trait that can be implemented to customize how case classes are read from and written to a config.
+ *
+ * @tparam T the type of case class for which this hint applies
+ */
 trait ProductHint[T] {
+
+  /**
+   * The mapping used to map field names to config keys
+   */
   def fieldMapping: ConfigFieldMapping
+
+  /**
+   * A boolean indicating if the default arguments of the case class should be used when fields are missing
+   */
   def useDefaultArgs: Boolean
+
+  /**
+   * A boolean indicating if config keys that do not map to a case class field are allowed in config objects
+   */
   def allowUnknownKeys: Boolean
 }
 

--- a/core/src/main/scala/pureconfig/ProductHint.scala
+++ b/core/src/main/scala/pureconfig/ProductHint.scala
@@ -1,0 +1,17 @@
+package pureconfig
+
+trait ProductHint[T] {
+  def fieldMapping: ConfigFieldMapping
+}
+
+private[pureconfig] case class ProductHintImpl[T](
+  fieldMapping: ConfigFieldMapping) extends ProductHint[T]
+
+object ProductHint {
+
+  def apply[T](
+    fieldMapping: ConfigFieldMapping = ConfigFieldMapping(CamelCase, CamelCase)): ProductHint[T] =
+    ProductHintImpl[T](fieldMapping)
+
+  implicit def default[T]: ProductHint[T] = apply()
+}

--- a/core/src/main/scala/pureconfig/ProductHint.scala
+++ b/core/src/main/scala/pureconfig/ProductHint.scala
@@ -3,18 +3,21 @@ package pureconfig
 trait ProductHint[T] {
   def fieldMapping: ConfigFieldMapping
   def useDefaultArgs: Boolean
+  def allowUnknownKeys: Boolean
 }
 
 private[pureconfig] case class ProductHintImpl[T](
   fieldMapping: ConfigFieldMapping,
-  useDefaultArgs: Boolean) extends ProductHint[T]
+  useDefaultArgs: Boolean,
+  allowUnknownKeys: Boolean) extends ProductHint[T]
 
 object ProductHint {
 
   def apply[T](
     fieldMapping: ConfigFieldMapping = ConfigFieldMapping(CamelCase, CamelCase),
-    useDefaultArgs: Boolean = true): ProductHint[T] =
-    ProductHintImpl[T](fieldMapping, useDefaultArgs)
+    useDefaultArgs: Boolean = true,
+    allowUnknownKeys: Boolean = true): ProductHint[T] =
+    ProductHintImpl[T](fieldMapping, useDefaultArgs, allowUnknownKeys)
 
   implicit def default[T]: ProductHint[T] = apply()
 }

--- a/core/src/main/scala/pureconfig/ProductHint.scala
+++ b/core/src/main/scala/pureconfig/ProductHint.scala
@@ -31,7 +31,7 @@ private[pureconfig] case class ProductHintImpl[T](
 object ProductHint {
 
   def apply[T](
-    fieldMapping: ConfigFieldMapping = ConfigFieldMapping(CamelCase, CamelCase),
+    fieldMapping: ConfigFieldMapping = ConfigFieldMapping(CamelCase, KebabCase),
     useDefaultArgs: Boolean = true,
     allowUnknownKeys: Boolean = true): ProductHint[T] =
     ProductHintImpl[T](fieldMapping, useDefaultArgs, allowUnknownKeys)

--- a/core/src/main/scala/pureconfig/error/UnknownKeyException.scala
+++ b/core/src/main/scala/pureconfig/error/UnknownKeyException.scala
@@ -1,0 +1,4 @@
+package pureconfig.error
+
+final case class UnknownKeyException(key: String)
+  extends IllegalArgumentException(s"Found unknown key $key")

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -625,21 +625,39 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     loadConfig[SampleConf](conf) shouldBe Success(SampleConf(2, "two"))
   }
 
-  it should "allow customizing the field mapping with word delimiters" in {
+  it should "allow customizing the field mapping with different naming conventions" in {
     import pureconfig.syntax._
 
-    implicit def productHint[T] = ProductHint[T](ConfigFieldMapping(CamelCase, CamelCase))
+    {
+      implicit def productHint[T] = ProductHint[T](ConfigFieldMapping(CamelCase, CamelCase))
 
-    val conf = ConfigFactory.parseString("""{
-      camelCaseInt = 1
-      camelCaseString = "bar"
-      camelCaseConf {
-        thisIsAnInt = 3
-        thisIsAnotherInt = 10
-      }
-    }""")
+      val conf = ConfigFactory.parseString("""{
+        camelCaseInt = 1
+        camelCaseString = "bar"
+        camelCaseConf {
+          thisIsAnInt = 3
+          thisIsAnotherInt = 10
+        }
+      }""")
 
-    conf.to[ConfWithCamelCase] shouldBe Success(ConfWithCamelCase(1, "bar", ConfWithCamelCaseInner(3, 10)))
+      conf.to[ConfWithCamelCase] shouldBe Success(ConfWithCamelCase(1, "bar", ConfWithCamelCaseInner(3, 10)))
+    }
+
+    {
+      implicit def productHint[T] = ProductHint[T](ConfigFieldMapping(CamelCase, PascalCase))
+
+      val conf = ConfigFactory.parseString(
+        """{
+          CamelCaseInt = 1
+          CamelCaseString = "bar"
+          CamelCaseConf {
+            ThisIsAnInt = 3
+            ThisIsAnotherInt = 10
+          }
+        }""")
+
+      conf.to[ConfWithCamelCase] shouldBe Success(ConfWithCamelCase(1, "bar", ConfWithCamelCaseInner(3, 10)))
+    }
   }
 
   it should "allow customizing the field mapping only for specific types" in {

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -784,7 +784,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     loadConfig[ConfWithConfigList](conf4).failure.exception shouldEqual WrongTypeForKeyException("OBJECT", "conf")
   }
 
-  it should "be able to consider default arguments" in {
+  it should "consider default arguments by default" in {
     case class InnerConf(e: Int, g: Int)
     case class Conf(a: Int, b: String = "default", c: Int = 42, d: InnerConf = InnerConf(43, 44))
 
@@ -805,6 +805,16 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
 
     val conf6 = ConfigFactory.parseMap(Map("a" -> 2, "d" -> "notAnInnerConf").asJava)
     loadConfig[Conf](conf6).failure.exception shouldEqual WrongTypeForKeyException("STRING", "d")
+  }
+
+  it should "not use default arguments if specified through a product hint" in {
+    case class InnerConf(e: Int, g: Int)
+    case class Conf(a: Int, b: String = "default", c: Int = 42, d: InnerConf = InnerConf(43, 44))
+
+    implicit val productHint = ProductHint[Conf](useDefaultArgs = false)
+
+    val conf1 = ConfigFactory.parseMap(Map("a" -> 2).asJava)
+    loadConfig[Conf](conf1).failure.exception shouldEqual KeyNotFoundException("b")
   }
 
   "Converting from an empty string to a double" should "complain about an empty string" in {

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -5,22 +5,22 @@ package pureconfig
 
 import java.io.PrintWriter
 import java.net.URL
-import java.nio.file.{Files, Path}
+import java.nio.file.{ Files, Path }
 import java.time._
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable._
-import scala.concurrent.duration.{Duration, FiniteDuration}
-import scala.util.{Failure, Success, Try}
-import com.typesafe.config.{ConfigFactory, Config => TypesafeConfig, _}
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.util.{ Failure, Success, Try }
+import com.typesafe.config.{ ConfigFactory, Config => TypesafeConfig, _ }
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.scalacheck.Arbitrary
 import org.scalacheck.Shapeless._
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
-import pureconfig.ConfigConvert.{fromString, stringConvert}
+import pureconfig.ConfigConvert.{ fromString, stringConvert }
 import pureconfig.error._
 
 /**

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -658,6 +658,25 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     conf.to[ConfWithCamelCase] shouldBe Success(ConfWithCamelCase(1, "bar", ConfWithCamelCaseInner(3, 10)))
   }
 
+  it should "disallow unknown keys if specified through a product hint" in {
+    import pureconfig.syntax._
+
+    case class Conf1(a: Int)
+    case class Conf2(a: Int)
+
+    implicit val productHint = ProductHint[Conf2](allowUnknownKeys = false)
+
+    val conf = ConfigFactory.parseString("""{
+      conf {
+        a = 1
+        b = 2
+      }
+    }""")
+
+    conf.getConfig("conf").to[Conf1] shouldBe Success(Conf1(1))
+    conf.getConfig("conf").to[Conf2] shouldBe Failure(UnknownKeyException("b"))
+  }
+
   val expectedValueForResolveFilesPriority2 = FlatConfig(
     false,
     0.001d,

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -610,7 +610,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     conf.to[ConfWithCamelCase] shouldBe Success(ConfWithCamelCase(1, "bar", ConfWithCamelCaseInner(3, 10)))
   }
 
-  it should "allow customizing the field mapping" in {
+  it should "allow customizing the field mapping through a product hint" in {
     val conf = ConfigFactory.parseString("""{
       A = 2
       B = "two"
@@ -619,9 +619,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     case class SampleConf(a: Int, b: String)
     loadConfig[SampleConf](conf).failure.exception shouldEqual KeyNotFoundException("a")
 
-    implicit val mapping = new ConfigFieldMapping[SampleConf] {
-      def apply(fieldName: String) = fieldName.toUpperCase
-    }
+    implicit val productHint = ProductHint[SampleConf](ConfigFieldMapping(_.toUpperCase))
 
     loadConfig[SampleConf](conf) shouldBe Success(SampleConf(2, "two"))
   }
@@ -629,7 +627,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   it should "allow customizing the field mapping with word delimiters" in {
     import pureconfig.syntax._
 
-    implicit def conv[T] = ConfigFieldMapping.apply[T](CamelCase, KebabCase)
+    implicit def productHint[T] = ProductHint[T](ConfigFieldMapping(CamelCase, KebabCase))
 
     val conf = ConfigFactory.parseString("""{
       camel-case-int = 1
@@ -646,7 +644,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   it should "allow customizing the field mapping only for specific types" in {
     import pureconfig.syntax._
 
-    implicit val conv = ConfigFieldMapping.apply[ConfWithCamelCase](CamelCase, KebabCase)
+    implicit val productHint = ProductHint[ConfWithCamelCase](ConfigFieldMapping(CamelCase, KebabCase))
 
     val conf = ConfigFactory.parseString("""{
       camel-case-int = 1

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -260,7 +260,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
     withTempFile { configFile =>
       implicit val hint = new FirstSuccessCoproductHint[AnimalConfig]
 
-      val conf = ConfigFactory.parseString("{ canFly = true }")
+      val conf = ConfigFactory.parseString("{ can-fly = true }")
       loadConfig[AnimalConfig](conf) should be(Success(BirdConfig(true)))
 
       saveConfigAsPropertyFile[AnimalConfig](DogConfig(2), configFile, overrideOutputPath = true)
@@ -275,7 +275,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   }
 
   it should "return a Failure with a proper exception if the hint field in a coproduct is missing" in {
-    val conf = ConfigFactory.parseString("{ canFly = true }")
+    val conf = ConfigFactory.parseString("{ can-fly = true }")
     loadConfig[AnimalConfig](conf) should be(Failure(KeyNotFoundException("type")))
   }
 
@@ -311,6 +311,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
       writer.println("""akka.loggers = ["akka.event.Logging$DefaultLogger"]""")
       writer.close()
 
+      implicit def productHint[T] = ProductHint[T](ConfigFieldMapping(CamelCase, CamelCase))
       val configOrError = loadConfig[SparkRootConf](configFile)
 
       val config = configOrError match {
@@ -534,7 +535,7 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
 
   it should "be able to read a config with a ZoneId" in {
     val expected = ZoneId.systemDefault()
-    val config = ConfigFactory.parseString(s"""{ "zoneId":"${expected.toString}" }""")
+    val config = ConfigFactory.parseString(s"""{ "zone-id":"${expected.toString}" }""")
     loadConfig[ConfWithZoneId](config).success.value shouldBe ConfWithZoneId(expected)
   }
 
@@ -595,15 +596,15 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   case class ConfWithCamelCaseInner(thisIsAnInt: Int, thisIsAnotherInt: Int)
   case class ConfWithCamelCase(camelCaseInt: Int, camelCaseString: String, camelCaseConf: ConfWithCamelCaseInner)
 
-  it should "use the fields as is by default" in {
+  it should "read kebab case config keys to camel case fields by default" in {
     import pureconfig.syntax._
 
     val conf = ConfigFactory.parseString("""{
-      camelCaseInt = 1
-      camelCaseString = "bar"
-      camelCaseConf {
-        thisIsAnInt = 3
-        thisIsAnotherInt = 10
+      camel-case-int = 1
+      camel-case-string = "bar"
+      camel-case-conf {
+        this-is-an-int = 3
+        this-is-another-int = 10
       }
     }""")
 
@@ -627,14 +628,14 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   it should "allow customizing the field mapping with word delimiters" in {
     import pureconfig.syntax._
 
-    implicit def productHint[T] = ProductHint[T](ConfigFieldMapping(CamelCase, KebabCase))
+    implicit def productHint[T] = ProductHint[T](ConfigFieldMapping(CamelCase, CamelCase))
 
     val conf = ConfigFactory.parseString("""{
-      camel-case-int = 1
-      camel-case-string = "bar"
-      camel-case-conf {
-        this-is-an-int = 3
-        this-is-another-int = 10
+      camelCaseInt = 1
+      camelCaseString = "bar"
+      camelCaseConf {
+        thisIsAnInt = 3
+        thisIsAnotherInt = 10
       }
     }""")
 
@@ -644,14 +645,14 @@ class PureconfSuite extends FlatSpec with Matchers with OptionValues with TryVal
   it should "allow customizing the field mapping only for specific types" in {
     import pureconfig.syntax._
 
-    implicit val productHint = ProductHint[ConfWithCamelCase](ConfigFieldMapping(CamelCase, KebabCase))
+    implicit val productHint = ProductHint[ConfWithCamelCase](ConfigFieldMapping(CamelCase, CamelCase))
 
     val conf = ConfigFactory.parseString("""{
-      camel-case-int = 1
-      camel-case-string = "bar"
-      camel-case-conf {
-        thisIsAnInt = 3
-        thisIsAnotherInt = 10
+      camelCaseInt = 1
+      camelCaseString = "bar"
+      camelCaseConf {
+        this-is-an-int = 3
+        this-is-another-int = 10
       }
     }""")
 

--- a/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
+++ b/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
@@ -36,7 +36,7 @@ class ConfigurableSuite extends FlatSpec with Matchers with TryValues with Prope
 
   it should "parse LocalDateTime" in forAll {
     (localDateTime: LocalDateTime) =>
-      val conf = ConfigFactory.parseString(s"""{dateTime:"${localDateTime.format(DateTimeFormatter.ISO_DATE_TIME)}"}""")
+      val conf = ConfigFactory.parseString(s"""{date-time:"${localDateTime.format(DateTimeFormatter.ISO_DATE_TIME)}"}""")
       case class Conf(dateTime: LocalDateTime)
       conf.to[Conf].success.value shouldEqual Conf(localDateTime)
   }
@@ -46,7 +46,7 @@ class ConfigurableSuite extends FlatSpec with Matchers with TryValues with Prope
 
   it should "parse MonthDay" in forAll {
     (monthDay: MonthDay) =>
-      val conf = ConfigFactory.parseString(s"""{monthDay:"${monthDay.format(monthDayFormat)}"}""")
+      val conf = ConfigFactory.parseString(s"""{month-day:"${monthDay.format(monthDayFormat)}"}""")
       case class Conf(monthDay: MonthDay)
       conf.to[Conf].success.value shouldEqual Conf(monthDay)
   }
@@ -55,7 +55,7 @@ class ConfigurableSuite extends FlatSpec with Matchers with TryValues with Prope
 
   it should "parse OffsetDateTime" in forAll {
     (offsetDateTime: OffsetDateTime) =>
-      val conf = ConfigFactory.parseString(s"""{offsetDateTime:"${offsetDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)}"}""")
+      val conf = ConfigFactory.parseString(s"""{offset-date-time:"${offsetDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)}"}""")
       case class Conf(offsetDateTime: OffsetDateTime)
       conf.to[Conf].success.value shouldEqual Conf(offsetDateTime)
   }
@@ -64,7 +64,7 @@ class ConfigurableSuite extends FlatSpec with Matchers with TryValues with Prope
 
   it should "parse OffsetTime" in forAll {
     (offsetTime: OffsetTime) =>
-      val conf = ConfigFactory.parseString(s"""{offsetTime:"${offsetTime.format(DateTimeFormatter.ISO_OFFSET_TIME)}"}""")
+      val conf = ConfigFactory.parseString(s"""{offset-time:"${offsetTime.format(DateTimeFormatter.ISO_OFFSET_TIME)}"}""")
       case class Conf(offsetTime: OffsetTime)
       conf.to[Conf].success.value shouldEqual Conf(offsetTime)
   }
@@ -74,7 +74,7 @@ class ConfigurableSuite extends FlatSpec with Matchers with TryValues with Prope
 
   it should "parse YearMonth" in forAll {
     (yearMonth: YearMonth) =>
-      val conf = ConfigFactory.parseString(s"""{yearMonth:"${yearMonth.format(yearMonthFormat)}"}""")
+      val conf = ConfigFactory.parseString(s"""{year-month:"${yearMonth.format(yearMonthFormat)}"}""")
       case class Conf(yearMonth: YearMonth)
       conf.to[Conf].success.value shouldEqual Conf(yearMonth)
   }
@@ -83,7 +83,7 @@ class ConfigurableSuite extends FlatSpec with Matchers with TryValues with Prope
 
   it should "parse ZonedDateTime" in forAll {
     (zonedDateTime: ZonedDateTime) =>
-      val conf = ConfigFactory.parseString(s"""{zonedDateTime:"${zonedDateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)}"}""")
+      val conf = ConfigFactory.parseString(s"""{zoned-date-time:"${zonedDateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)}"}""")
       case class Conf(zonedDateTime: ZonedDateTime)
       conf.to[Conf].success.value shouldEqual Conf(zonedDateTime)
   }

--- a/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
+++ b/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
@@ -5,7 +5,7 @@ import java.time._
 import java.time.format.DateTimeFormatter
 
 import org.scalatest._
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{ Arbitrary, Gen }
 import prop.PropertyChecks
 import pureconfig.syntax._
 import ConfigurableSuite._


### PR DESCRIPTION
This is an implementation of a `ProductHint`, as discussed in #76. It supports:

- Defining the mapping between field names and config keys (with `ConfigFieldMapping`);
- Controlling whether default arguments should be applied or not;
- Controlling whether unknown keys are allowed or not.

For easier reviewing, I added all those features in different commits.

Some random details:

- As much as I'd like it, there is a major problem with enabling "strict mode" as default: configs that are loaded using `ConfigFactory.load` and are read from the root will always have unknown keys, as Typesafe config mixes in environment variables and system properties;
- I could have created an implicit conversion from `ConfigFieldMapping` to `ProductHint` in order not to break existing code using implicit `ConfigFieldMappings`. However, that will lead to confusion in the long run if we want to use mappings for other things, like coproduct fields. I personally prefer to have users deal with breaking changes if the alternative is to introduce hacks and somewhat magical behaviors that will hinder future improvements;
- I'd like to take this opportunity to close #68, if we're all ok with it. If we're already changing the API for `ConfigFieldMapping` we could make users also do the transition to a new naming convention, dealing with breaking code only once;
- I did not touch README and CHANGELOG in this pull request to avoid being repeatedly updating it as changes are requested. I prefer to do a separate pull request updating all documentation once this is closed.
