### PR TITLE
add macro paradise; set crossScalaVersions; enable compile flags

### DIFF
--- a/example/build.sbt
+++ b/example/build.sbt
@@ -5,5 +5,23 @@ version := "1.0"
 scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
-  "com.github.melrief" %% "pureconfig" % "0.5.1"
+  "com.github.melrief" %% "pureconfig" % "0.5.1",
+
+  // needed for Scala 2.10
+  compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+)
+
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1")
+
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-encoding", "UTF-8",
+  "-language:experimental.macros",
+  "-feature",
+  "-unchecked",
+  "-Xfuture",
+  "-Xlint",
+  "-Yno-adapted-args",
+  "-Ywarn-numeric-widen",
+  "-Ywarn-value-discard"
 )

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -19,6 +19,7 @@ scalacOptions ++= Seq(
   "-language:experimental.macros",
   "-feature",
   "-unchecked",
+  "-Xfatal-warnings",
   "-Xfuture",
   "-Xlint",
   "-Yno-adapted-args",

--- a/example/src/main/scala/pureconfig/example/conf/Main.scala
+++ b/example/src/main/scala/pureconfig/example/conf/Main.scala
@@ -6,13 +6,35 @@
  */
 package pureconfig.example
 
+import java.nio.file.Path
+
 import pureconfig._
 import pureconfig.example.conf._
-
 import scala.util.{Failure, Success}
 
+/*
+This is an example of configuration for our directory watcher. The configuration needs:
+- the path that is the directory to watch
+- a filter that will be used to decide if a path should be notified or not
+- the email configuration used to send emails
 
+The root namespace will be "dirwatch". For instance, valid property file for this
+configuration will contain:
+
+dirwatch.path="/path/to/observe"
+dirwatch.filter="*"
+dirwatch.email.host=host_of_email_service
+dirwatch.email.port=12345
+dirwatch.email.message="Dirwatch new path found report"
+dirwatch.email.recipients=["recipient1@domain.tld","recipient2@domain.tld"]
+dirwatch.email.sender="sender@domain.tld"
+*/
 object Main extends App {
+
+  case class Config(dirwatch: DirWatchConfig)
+  case class DirWatchConfig(path: Path, filter: String, email: EmailConfig)
+  case class EmailConfig(host: String, port: Int, message: String, recipients: Set[Email], sender: Email)
+
 
   val config = loadConfig[Config] match {
     case Failure(f) => throw f

--- a/example/src/main/scala/pureconfig/example/conf/package.scala
+++ b/example/src/main/scala/pureconfig/example/conf/package.scala
@@ -13,28 +13,8 @@ import pureconfig.ConfigConvert.fromString
 
 import scala.util.Try
 
-/*
-This is an example of configuration for our directory watcher. The configuration needs:
-- the path that is the directory to watch
-- a filter that will be used to decide if a path should be notified or not
-- the email configuration used to send emails
 
-The root namespace will be "dirwatch". For instance, valid property file for this
-configuration will contain:
-
-dirwatch.path="/path/to/observe"
-dirwatch.filter="*"
-dirwatch.email.host=host_of_email_service
-dirwatch.email.port=12345
-dirwatch.email.message="Dirwatch new path found report"
-dirwatch.email.recipients=["recipient1@domain.tld","recipient2@domain.tld"]
-dirwatch.email.sender="sender@domain.tld"
-*/
 package object conf {
-
-  case class Config(dirwatch: DirWatchConfig)
-  case class DirWatchConfig(path: Path, filter: String, email: EmailConfig)
-  case class EmailConfig(host: String, port: Int, message: String, recipients: Set[Email], sender: Email)
 
   // Email doesn't have a Convert instance, we are going to create it here
   implicit val emailConvert: ConfigConvert[Email] = fromString[Email](Email.fromString)


### PR DESCRIPTION
This updates `build.sbt` in the example project to:

* add macro paradise
* explicitly set crossScalaVersions
* enable more stringent compiler flags.

This resolves #125 .