### PR TITLE
Catch typesafeconfig exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+### 0.6.1 (undefined)
+
+- New features
+  - add `ConfigFactoryWrapper` to control exceptions from typesafe `ConfigFactory`
+
+- Breaking changes
+  - `loadConfigFromFiles` works on `Path` instead of `File` for consistency
+
+- Bug fixes
+  - `pureconfig.load*` methods don't throw exceptions on malformed configuration anymore
+     and wrap errors in `ConfigReaderFailures`
+
 ### 0.6.0 (Feb 14, 2017)
 
 - New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Bug fixes
   - `pureconfig.load*` methods don't throw exceptions on malformed configuration anymore
-     and wrap errors in `ConfigReaderFailures`
+     and wrap errors in `ConfigReaderFailures` [[#148](https://github.com/melrief/pureconfig/issues/148)]
 
 ### 0.6.0 (Feb 14, 2017)
 

--- a/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
+++ b/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
@@ -2,8 +2,8 @@ package pureconfig.backend
 
 import java.nio.file.Path
 
-import com.typesafe.config.{Config, ConfigException, ConfigFactory}
-import pureconfig.error.{CannotParse, ConfigReaderFailures, ConfigValueLocation, ThrowableFailure}
+import com.typesafe.config.{ Config, ConfigException, ConfigFactory }
+import pureconfig.error.{ CannotParse, ConfigReaderFailures, ConfigValueLocation, ThrowableFailure }
 
 import scala.util.control.NonFatal
 

--- a/core/src/main/scala/pureconfig/backend/TypesafeConfigWrapper.scala
+++ b/core/src/main/scala/pureconfig/backend/TypesafeConfigWrapper.scala
@@ -27,7 +27,7 @@ object ConfigFactoryWrapper {
 
   /** Utility methods that parse a file and then calls `ConfigFactory.load` */
   def loadFile(path: Path): Either[ConfigReaderFailures, Config] =
-    parseFile(path).flatMap(rawConfig => unsafeToEither(ConfigFactory.load(rawConfig)))
+    parseFile(path).right.flatMap(rawConfig => unsafeToEither(ConfigFactory.load(rawConfig)))
 
   private def unsafeToEither[A](f: => A): Either[ConfigReaderFailures, A] = {
     try (Right(f)) catch {

--- a/core/src/main/scala/pureconfig/backend/TypesafeConfigWrapper.scala
+++ b/core/src/main/scala/pureconfig/backend/TypesafeConfigWrapper.scala
@@ -1,0 +1,38 @@
+package pureconfig.backend
+
+import java.nio.file.Path
+
+import com.typesafe.config.{ Config, ConfigFactory }
+import pureconfig.error.{ ConfigReaderFailures, ThrowableFailure }
+
+import scala.util.control.NonFatal
+
+/**
+ * A wrapper of [[com.typesafe.config.ConfigFactory]] whose methods return `Either` instead
+ * of throwing exceptions
+ */
+object ConfigFactoryWrapper {
+
+  /** @see [[ConfigFactory.invalidateCaches()]] */
+  def invalidateCaches(): Either[ConfigReaderFailures, Unit] =
+    unsafeToEither(ConfigFactory.invalidateCaches())
+
+  /** @see [[ConfigFactory.load()]] */
+  def load(): Either[ConfigReaderFailures, Config] =
+    unsafeToEither(ConfigFactory.load())
+
+  /** @see [[ConfigFactory.parseFile()]] */
+  def parseFile(path: Path): Either[ConfigReaderFailures, Config] =
+    unsafeToEither(ConfigFactory.parseFile(path.toFile))
+
+  /** Utility methods that parse a file and then calls `ConfigFactory.load` */
+  def loadFile(path: Path): Either[ConfigReaderFailures, Config] =
+    parseFile(path).flatMap(rawConfig => unsafeToEither(ConfigFactory.load(rawConfig)))
+
+  private def unsafeToEither[A](f: => A): Either[ConfigReaderFailures, A] = {
+    try (Right(f)) catch {
+      case NonFatal(e) =>
+        Left(ConfigReaderFailures(ThrowableFailure(e, None)))
+    }
+  }
+}

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package pureconfig.error
 
-import com.typesafe.config.{ConfigOrigin, ConfigValue}
+import com.typesafe.config.{ ConfigOrigin, ConfigValue }
 
 /**
  * The physical location of a ConfigValue, represented by a file name and a line

--- a/core/src/main/scala/pureconfig/package.scala
+++ b/core/src/main/scala/pureconfig/package.scala
@@ -268,9 +268,8 @@ package object pureconfig {
           case (c1, c2) =>
             ConfigConvert.combineResults(c1, c2)(_ :+ _)
         }
-        .right
-        .map(_.reduce(_.withFallback(_)).resolve)
-        .flatMap(loadConfig[Config])
+        .right.map(_.reduce(_.withFallback(_)).resolve)
+        .right.flatMap(loadConfig[Config])
     }
   }
 

--- a/core/src/main/scala/pureconfig/package.scala
+++ b/core/src/main/scala/pureconfig/package.scala
@@ -166,7 +166,13 @@ package object pureconfig {
    */
   @throws[ConfigReaderException[_]]
   def loadConfigOrThrow[Config](path: Path)(implicit conv: ConfigConvert[Config], ct: ClassTag[Config]): Config = {
-    getResultOrThrow[Config](loadConfig[Config](path)(conv))
+    val errorOrConfig =
+      for {
+        _ <- invalidateCaches().right
+        rawConfig <- loadFile(path).right
+        config <- loadConfig[Config](rawConfig)(conv).right
+      } yield config
+    getResultOrThrow[Config](errorOrConfig)
   }
 
   /**

--- a/core/src/main/scala/pureconfig/package.scala
+++ b/core/src/main/scala/pureconfig/package.scala
@@ -166,13 +166,7 @@ package object pureconfig {
    */
   @throws[ConfigReaderException[_]]
   def loadConfigOrThrow[Config](path: Path)(implicit conv: ConfigConvert[Config], ct: ClassTag[Config]): Config = {
-    val errorOrConfig =
-      for {
-        _ <- invalidateCaches().right
-        rawConfig <- loadFile(path).right
-        config <- loadConfig[Config](rawConfig)(conv).right
-      } yield config
-    getResultOrThrow[Config](errorOrConfig)
+    getResultOrThrow[Config](loadConfig[Config](path)(conv))
   }
 
   /**

--- a/core/src/main/scala/pureconfig/syntax/package.scala
+++ b/core/src/main/scala/pureconfig/syntax/package.scala
@@ -1,7 +1,7 @@
 package pureconfig
 
-import com.typesafe.config.{ConfigValue, Config => TypesafeConfig}
-import pureconfig.error.{ConfigReaderException, ConfigReaderFailures}
+import com.typesafe.config.{ ConfigValue, Config => TypesafeConfig }
+import pureconfig.error.{ ConfigReaderException, ConfigReaderFailures }
 
 import scala.reflect.ClassTag
 
@@ -19,12 +19,11 @@ package object syntax {
 
   implicit class PimpedConfigValue(val conf: ConfigValue) extends AnyVal {
     def to[T](implicit configConvert: ConfigConvert[T]): Either[ConfigReaderFailures, T] = configConvert.from(conf)
-    def toOrThrow[T](implicit configConvert: ConfigConvert[T], cl:ClassTag[T]): T = getResultOrThrow(configConvert.from(conf))(cl)
+    def toOrThrow[T](implicit configConvert: ConfigConvert[T], cl: ClassTag[T]): T = getResultOrThrow(configConvert.from(conf))(cl)
   }
-
 
   implicit class PimpedConfig(val conf: TypesafeConfig) extends AnyVal {
     def to[T: ConfigConvert]: Either[ConfigReaderFailures, T] = conf.root().to[T]
-    def toOrThrow[T](implicit configConvert: ConfigConvert[T], cl:ClassTag[T]): T = getResultOrThrow(conf.root().to[T])(cl)
+    def toOrThrow[T](implicit configConvert: ConfigConvert[T], cl: ClassTag[T]): T = getResultOrThrow(conf.root().to[T])(cl)
   }
 }

--- a/core/src/test/scala/pureconfig/PureconfSuite.scala
+++ b/core/src/test/scala/pureconfig/PureconfSuite.scala
@@ -4,16 +4,16 @@
 package pureconfig
 
 import java.io.PrintWriter
-import java.net.{URI, URL}
-import java.nio.file.{Files, Path, Paths}
+import java.net.{ URI, URL }
+import java.nio.file.{ Files, Path, Paths }
 import java.time._
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable._
-import scala.concurrent.duration.{Duration, FiniteDuration}
-import com.typesafe.config.{ConfigFactory, Config => TypesafeConfig, _}
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+import com.typesafe.config.{ ConfigFactory, Config => TypesafeConfig, _ }
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.scalacheck.Arbitrary
@@ -21,8 +21,8 @@ import org.scalacheck.Gen.uuid
 import org.scalacheck.Shapeless._
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
-import pureconfig.ConfigConvert.{catchReadError, fromStringConvert, fromStringReader}
-import pureconfig.error.{ConfigReaderException, _}
+import pureconfig.ConfigConvert.{ catchReadError, fromStringConvert, fromStringReader }
+import pureconfig.error.{ ConfigReaderException, _ }
 
 /**
  * @author Mario Pastorelli
@@ -34,8 +34,8 @@ object PureconfSuite {
     Files.delete(configFile)
   }
 
-  def fileList(names: String*): Seq[java.io.File] = {
-    names.map(new java.io.File(_)).toVector
+  def fileList(names: String*): Seq[Path] = {
+    names.map(Paths.get(_)).toVector
   }
 }
 

--- a/core/src/test/scala/pureconfig/backend/ConfigFactoryWrapperSpec.scala
+++ b/core/src/test/scala/pureconfig/backend/ConfigFactoryWrapperSpec.scala
@@ -34,7 +34,7 @@ class ConfigFactoryWrapperSpec extends FlatSpec with Matchers {
   }
 
   it should "not throw exception but return Left when it finds unresolved placeholders" in {
-    val tmpPath = createTempConfPath("parseFileTest", """{ foo1: "bla", foo2: ${charlie}}""")
+    val tmpPath = createTempConfPath("parseFileTest", f"""{ foo1: "bla", foo2: $${charlie}}""")
     intercept[ConfigException](ConfigFactory.load(ConfigFactory.parseFile(tmpPath.toFile)))
     ConfigFactoryWrapper.loadFile(tmpPath) shouldBe a[Left[_, _]]
   }

--- a/core/src/test/scala/pureconfig/backend/ConfigFactoryWrapperSpec.scala
+++ b/core/src/test/scala/pureconfig/backend/ConfigFactoryWrapperSpec.scala
@@ -1,0 +1,42 @@
+package pureconfig.backend
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Path }
+
+import com.typesafe.config.{ ConfigException, ConfigFactory }
+import org.scalatest.{ FlatSpec, Matchers }
+
+class ConfigFactoryWrapperSpec extends FlatSpec with Matchers {
+
+  def createTempConfPath(prefix: String, content: String): Path = {
+    val tmpPath = Files.createTempFile(prefix, ".conf")
+    tmpPath.toFile.deleteOnExit()
+    val buffer = Files.newBufferedWriter(tmpPath, StandardCharsets.UTF_8)
+    buffer.write(content)
+    buffer.close()
+    tmpPath
+  }
+
+  behavior of "ConfigFactoryWrapper.parseFile"
+
+  it should "not throw exception but return Left on error" in {
+    val tmpPath = createTempConfPath("parseFile", "{foo:")
+    intercept[ConfigException](ConfigFactory.parseFile(tmpPath.toFile))
+    ConfigFactoryWrapper.parseFile(tmpPath) shouldBe a[Left[_, _]]
+  }
+
+  behavior of "ConfigFactoryWrapper.loadFile"
+
+  it should "not throw exception but return Left on error" in {
+    val tmpPath = createTempConfPath("parseFile", "{foo:")
+    intercept[ConfigException](ConfigFactory.load(ConfigFactory.parseFile(tmpPath.toFile)))
+    ConfigFactoryWrapper.parseFile(tmpPath) shouldBe a[Left[_, _]]
+  }
+
+  it should "not throw exception but return Left when it finds unresolved placeholders" in {
+    val tmpPath = createTempConfPath("parseFileTest", """{ foo1: "bla", foo2: ${charlie}}""")
+    intercept[ConfigException](ConfigFactory.load(ConfigFactory.parseFile(tmpPath.toFile)))
+    ConfigFactoryWrapper.loadFile(tmpPath) shouldBe a[Left[_, _]]
+  }
+
+}


### PR DESCRIPTION
Solves #148 

This PR is an attempt to catch and wrap inside failures the exception thrown by the typesafe config parser and loader. Changes:

- add `ConfigFactoryWrapper` as safer version of the typesafe `ConfigFactory`
- change the `pureconfig.load*` methods to use the `ConfigFactoryWrapper` methods instead of the `ConfigFactory` ones
- change `pureconfig.loadConfigFromFiles` to work on `Path` instead of `File`. Not sure why I accepted a PR working on something different but we are using `Path` everywhere and I'd like to be consistent

p.s. I've noticed in this and another PR that there are some changes on the styles of the files. Something is not working properly but I'm not sure what. I'll leave the style changes in the PR because we should have well formatted code...