### PR TITLE
remove extraneous import in javax build.sbt

### DIFF
--- a/modules/javax/build.sbt
+++ b/modules/javax/build.sbt
@@ -1,5 +1,3 @@
-import sbt.IvyConsole.Dependencies
-
 name := "pureconfig-javax"
 
 organization := "com.github.melrief"


### PR DESCRIPTION
At some point my IDE inserted a bogus import into javax's build.sbt. I should have caught this earlier, apologies.