### PR TITLE
build the example project as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ scala:
     - 2.12.1
 jdk:
     - oraclejdk8
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION test
+  - (cd example ; sbt ++$TRAVIS_SCALA_VERSION test)


### PR DESCRIPTION
This will build the example project as part of CI to ensure it stays working.

I've been experimenting with this in my fork of pureconfig. 

Here's a failed Travis job with the example project (before #166 was merged): https://travis-ci.org/derekmorr/pureconfig/jobs/212421774

If I apply the fixes in #166  to the code, it now builds: https://travis-ci.org/derekmorr/pureconfig/jobs/212423114
