### PR TITLE
Add integration with Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: scala
 scala:
-    - 2.11.8
     - 2.10.5
+    - 2.11.8
     - 2.12.1
 jdk:
     - oraclejdk8
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test
+  - sbt ++$TRAVIS_SCALA_VERSION coverage test
   - (cd example ; sbt ++$TRAVIS_SCALA_VERSION test)
+after_success:
+  - sbt ++$TRAVIS_SCALA_VERSION coverageReport coverageAggregate coveralls

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")


### PR DESCRIPTION
This PR adds integration with Coveralls - Travis will start sending coverage data to Coveralls on each successful build.

After that, we can optionally make Coveralls:

- comment on each PR with its coverage percentage;
- use the GitHub status API to make a PR "fail" when the coverage is below a certain threshold or when the PR makes the coverage decrease below a certain threshold (relative to `master`).

Right now, I just enabled the comments part. Let me know what you prefer :)
