### PR TITLE
(re)add coverage badge to README

### DIFF
--- a/core/src/main/tut/README.md
+++ b/core/src/main/tut/README.md
@@ -3,6 +3,7 @@
 A boilerplate-free Scala library for loading configuration files.
 
 [![Build Status](https://travis-ci.org/melrief/pureconfig.svg?branch=master)](https://travis-ci.org/melrief/pureconfig)
+[![Coverage Status](https://coveralls.io/repos/github/melrief/pureconfig/badge.svg?branch=master)](https://coveralls.io/github/melrief/pureconfig?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.melrief/pureconfig_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.melrief/pureconfig_2.11)
 [![Join the chat at https://gitter.im/melrief/pureconfig](https://badges.gitter.im/melrief/pureconfig.svg)](https://gitter.im/melrief/pureconfig?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
The coveralls badge got dropped from the README when #163 was merged. This adds it back.