### PR TITLE
Modify ConfigValueLocation to use URL instead of String

### DIFF
--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -4,6 +4,7 @@
 package pureconfig.error
 
 import com.typesafe.config.{ ConfigOrigin, ConfigValue }
+import java.nio.file.{ Path, Paths }
 
 /**
  * The physical location of a ConfigValue, represented by a file name and a line
@@ -14,8 +15,8 @@ import com.typesafe.config.{ ConfigOrigin, ConfigValue }
  * @param lineNumber the line number (starting at 0), where the given
  *                   ConfigValue definition starts
  */
-case class ConfigValueLocation(filename: String, lineNumber: Int) {
-  def description: String = s"($filename:$lineNumber)"
+case class ConfigValueLocation(path: Path, lineNumber: Int) {
+  def description: String = s"($path:$lineNumber)"
 }
 
 object ConfigValueLocation {
@@ -49,7 +50,7 @@ object ConfigValueLocation {
   def apply(co: ConfigOrigin): Option[ConfigValueLocation] =
     Option(co).flatMap { origin =>
       if (origin.filename != null && origin.lineNumber != -1)
-        Some(ConfigValueLocation(origin.filename, origin.lineNumber))
+        Some(ConfigValueLocation(Paths.get(origin.filename), origin.lineNumber))
       else
         None
     }

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -3,20 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package pureconfig.error
 
+import java.net.URL
+
 import com.typesafe.config.{ ConfigOrigin, ConfigValue }
-import java.nio.file.{ Path, Paths }
 
 /**
- * The physical location of a ConfigValue, represented by a file name and a line
+ * The physical location of a ConfigValue, represented by a url and a line
  * number
  *
- * @param filename the complete pathname to the file that contains a given
- *                 ConfigValue
+ * @param url the URL describing the origin of the ConfigValue
  * @param lineNumber the line number (starting at 0), where the given
  *                   ConfigValue definition starts
  */
-case class ConfigValueLocation(path: Path, lineNumber: Int) {
-  def description: String = s"($path:$lineNumber)"
+case class ConfigValueLocation(url: URL, lineNumber: Int) {
+  def description: String = s"($url:$lineNumber)"
 }
 
 object ConfigValueLocation {
@@ -49,8 +49,8 @@ object ConfigValueLocation {
    */
   def apply(co: ConfigOrigin): Option[ConfigValueLocation] =
     Option(co).flatMap { origin =>
-      if (origin.filename != null && origin.lineNumber != -1)
-        Some(ConfigValueLocation(Paths.get(origin.filename), origin.lineNumber))
+      if (origin.url != null && origin.lineNumber != -1)
+        Some(ConfigValueLocation(origin.url, origin.lineNumber))
       else
         None
     }

--- a/core/src/test/scala/pureconfig/ConfigReaderFailureLocationSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderFailureLocationSuite.scala
@@ -3,9 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package pureconfig
 
-import com.typesafe.config.ConfigFactory
+import java.nio.file.Paths
 
+import com.typesafe.config.ConfigFactory
 import org.scalatest._
+
 import pureconfig.error._
 
 /**
@@ -22,23 +24,23 @@ class ConfigReaderFailureLocationSuite extends FlatSpec with Matchers with Eithe
 
     val failures1 = conf.get("conf").to[Conf].left.value.toList
     failures1 should have size 2
-    failures1 should contain(KeyNotFound("a", Some(ConfigValueLocation(workingDir + file, 1))))
+    failures1 should contain(KeyNotFound("a", Some(ConfigValueLocation(Paths.get(workingDir, file), 1))))
     failures1 should contain(CannotConvert(
       "hello",
       "Int",
       """java.lang.NumberFormatException: For input string: "hello"""",
-      Some(ConfigValueLocation(workingDir + file, 3)),
+      Some(ConfigValueLocation(Paths.get(workingDir, file), 3)),
       Some("c")))
 
     val failures2 = conf.get("other-conf").to[Conf].left.value.toList
     failures2 should have size 3
-    failures2 should contain(KeyNotFound("a", Some(ConfigValueLocation(workingDir + file, 7))))
-    failures2 should contain(KeyNotFound("b", Some(ConfigValueLocation(workingDir + file, 7))))
+    failures2 should contain(KeyNotFound("a", Some(ConfigValueLocation(Paths.get(workingDir, file), 7))))
+    failures2 should contain(KeyNotFound("b", Some(ConfigValueLocation(Paths.get(workingDir, file), 7))))
     failures2 should contain(CannotConvert(
       "hello",
       "Int",
       """java.lang.NumberFormatException: For input string: "hello"""",
-      Some(ConfigValueLocation(workingDir + file, 9)),
+      Some(ConfigValueLocation(Paths.get(workingDir, file), 9)),
       Some("c")))
   }
 
@@ -57,7 +59,7 @@ class ConfigReaderFailureLocationSuite extends FlatSpec with Matchers with Eithe
       "string",
       "Int",
       """java.lang.NumberFormatException: For input string: "string"""",
-      Some(ConfigValueLocation(workingDir + file2, 2)),
+      Some(ConfigValueLocation(Paths.get(workingDir, file2), 2)),
       Some("a")))
   }
 }

--- a/core/src/test/scala/pureconfig/ConfigReaderFailureLocationSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderFailureLocationSuite.scala
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package pureconfig
 
-import java.nio.file.Paths
+import java.net.URL
 
 import com.typesafe.config.ConfigFactory
 import org.scalatest._
@@ -24,23 +24,23 @@ class ConfigReaderFailureLocationSuite extends FlatSpec with Matchers with Eithe
 
     val failures1 = conf.get("conf").to[Conf].left.value.toList
     failures1 should have size 2
-    failures1 should contain(KeyNotFound("a", Some(ConfigValueLocation(Paths.get(workingDir, file), 1))))
+    failures1 should contain(KeyNotFound("a", Some(ConfigValueLocation(new URL("file", "", workingDir + file), 1))))
     failures1 should contain(CannotConvert(
       "hello",
       "Int",
       """java.lang.NumberFormatException: For input string: "hello"""",
-      Some(ConfigValueLocation(Paths.get(workingDir, file), 3)),
+      Some(ConfigValueLocation(new URL("file", "", workingDir + file), 3)),
       Some("c")))
 
     val failures2 = conf.get("other-conf").to[Conf].left.value.toList
     failures2 should have size 3
-    failures2 should contain(KeyNotFound("a", Some(ConfigValueLocation(Paths.get(workingDir, file), 7))))
-    failures2 should contain(KeyNotFound("b", Some(ConfigValueLocation(Paths.get(workingDir, file), 7))))
+    failures2 should contain(KeyNotFound("a", Some(ConfigValueLocation(new URL("file", "", workingDir + file), 7))))
+    failures2 should contain(KeyNotFound("b", Some(ConfigValueLocation(new URL("file", "", workingDir + file), 7))))
     failures2 should contain(CannotConvert(
       "hello",
       "Int",
       """java.lang.NumberFormatException: For input string: "hello"""",
-      Some(ConfigValueLocation(Paths.get(workingDir, file), 9)),
+      Some(ConfigValueLocation(new URL("file", "", workingDir + file), 9)),
       Some("c")))
   }
 
@@ -59,7 +59,7 @@ class ConfigReaderFailureLocationSuite extends FlatSpec with Matchers with Eithe
       "string",
       "Int",
       """java.lang.NumberFormatException: For input string: "string"""",
-      Some(ConfigValueLocation(Paths.get(workingDir, file2), 2)),
+      Some(ConfigValueLocation(new URL("file", "", workingDir + file2), 2)),
       Some("a")))
   }
 }


### PR DESCRIPTION
As suggested by @derekmorr in #178, this PR modifies `ConfigValueLocation` to use `Path` instead of `String` to encode the location of failures.