### PR TITLE
make error-handling output stable

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -10,7 +10,7 @@ using the `ConfigReaderFailure` sealed family of case classes, you can use the
 `ConfigValueLocation.apply(cv: ConfigValue)` method to automatically create an
 optional location from a `ConfigValue`.
 
-Given this setup:
+If we load a config and try to load a missing key:
 
 ```scala
 import com.typesafe.config._
@@ -18,13 +18,11 @@ import pureconfig.error._
 import java.nio.file.{ Path, Paths }
 
 val cv = ConfigFactory.load.root().get("conf")
+val notFound = KeyNotFound("xpto", ConfigValueLocation(cv)).location.get
 ```
 
-We can try to load a missing key and get a useful error:
+We can extract useful error data:
 ```scala
-val notFound = KeyNotFound("xpto", ConfigValueLocation(cv)).location.get
-// notFound: pureconfig.error.ConfigValueLocation = ConfigValueLocation(file:/home/derek/pureconfig/docs/target/scala-2.12/classes/application.conf,11)
-
 // print the filename as a relative path
 Paths.get(System.getProperty("user.dir")).relativize(Paths.get(notFound.url.toURI))
 // res2: java.nio.file.Path = docs/target/scala-2.12/classes/application.conf

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -15,12 +15,20 @@ Given this setup:
 ```scala
 import com.typesafe.config._
 import pureconfig.error._
+import java.nio.file.{ Path, Paths }
 
 val cv = ConfigFactory.load.root().get("conf")
 ```
 
 We can try to load a missing key and get a useful error:
 ```scala
-KeyNotFound("xpto", ConfigValueLocation(cv))
-// res1: pureconfig.error.KeyNotFound = KeyNotFound(xpto,Some(ConfigValueLocation(/Users/dvm105/pureconfig/docs/target/scala-2.12/classes/application.conf,11)))
+val notFound = KeyNotFound("xpto", ConfigValueLocation(cv)).location.get
+// notFound: pureconfig.error.ConfigValueLocation = ConfigValueLocation(file:/home/derek/pureconfig/docs/target/scala-2.12/classes/application.conf,11)
+
+// print the filename as a relative path
+Paths.get(System.getProperty("user.dir")).relativize(Paths.get(notFound.url.toURI))
+// res2: java.nio.file.Path = docs/target/scala-2.12/classes/application.conf
+
+notFound.lineNumber
+// res3: Int = 11
 ```

--- a/docs/src/main/tut/error-handling.md
+++ b/docs/src/main/tut/error-handling.md
@@ -10,7 +10,7 @@ using the `ConfigReaderFailure` sealed family of case classes, you can use the
 `ConfigValueLocation.apply(cv: ConfigValue)` method to automatically create an
 optional location from a `ConfigValue`.
 
-Given this setup:
+If we load a config and try to load a missing key:
 
 ```tut:silent
 import com.typesafe.config._
@@ -18,12 +18,11 @@ import pureconfig.error._
 import java.nio.file.{ Path, Paths }
 
 val cv = ConfigFactory.load.root().get("conf")
+val notFound = KeyNotFound("xpto", ConfigValueLocation(cv)).location.get
 ```
 
-We can try to load a missing key and get a useful error:
+We can extract useful error data:
 ```tut:book
-val notFound = KeyNotFound("xpto", ConfigValueLocation(cv)).location.get
-
 // print the filename as a relative path
 Paths.get(System.getProperty("user.dir")).relativize(Paths.get(notFound.url.toURI))
 

--- a/docs/src/main/tut/error-handling.md
+++ b/docs/src/main/tut/error-handling.md
@@ -15,11 +15,17 @@ Given this setup:
 ```tut:silent
 import com.typesafe.config._
 import pureconfig.error._
+import java.nio.file.{ Path, Paths }
 
 val cv = ConfigFactory.load.root().get("conf")
 ```
 
 We can try to load a missing key and get a useful error:
 ```tut:book
-KeyNotFound("xpto", ConfigValueLocation(cv))
+val notFound = KeyNotFound("xpto", ConfigValueLocation(cv)).location.get
+
+// print the filename as a relative path
+Paths.get(System.getProperty("user.dir")).relativize(Paths.get(notFound.url.toURI))
+
+notFound.lineNumber
 ```


### PR DESCRIPTION
This fixes the last bit of tut output that wasn't stable between runs.

I relativized the path using Paths. This may be over complicated.