### PR TITLE
Update CHANGELOG to include the changes introduced by PRs #156, #180 and #181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-### 0.6.1 (undefined)
+### 0.7.0 (undefined)
 
 - New features
-  - add `ConfigFactoryWrapper` to control exceptions from typesafe `ConfigFactory`
+  - Add `ConfigFactoryWrapper` to control exceptions from typesafe `ConfigFactory`
+  - Modify the message of `ConfigReaderException` to group errors by keys in the configuration, instead of by type of error
+  - Add a path (`Option[String]`) to `ConfigReaderFailure`, in order to expose more information (if available) about the key in the configuration whose value raised the failure
 
 - Breaking changes
   - `loadConfigFromFiles` works on `Path` instead of `File` for consistency
+  - `ConfigValueLocation` now uses `URL` instead of `Path` to encode locations of `ConfigValue`s
 
 - Bug fixes
   - `pureconfig.load*` methods don't throw exceptions on malformed configuration anymore


### PR DESCRIPTION
This PR updates the `CHANGELOG` to include the changes introduced by PRs #156, #180 and #181. I've also updated the current version in the file to `0.7.0`.

I noticed some style issues with the file that would like to fix, but I think we can leave them to a later PR:

* The style of sentences is not consistent throughout the document. We use both imperative sentences and "X now does Y" sentences. It would be nice to have an uniform style.
* The use of punctuation marks is not consistent. We either not use them at all, or use `.`, or use `;` to end full sentences, where `.` would probably be more correct.