### PR TITLE
Add combinators to ConfigReader, ConfigWriter and ConfigConvert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-### 0.7.0 (undefined)
+### 0.7.1 (unreleased)
+
+- New features
+  - `ConfigReader`, `ConfigWriter` and `ConfigConvert` now have combinators such as `map`, `flatMap` and `contramap`,
+    making them easier to compose.
+
+### 0.7.0 (Apr 2, 2017)
 
 - New features
   - `ConfigConvert` is now a union of two new traits - `ConfigReader` for reading configs and `ConfigWriter` for writing

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -15,7 +15,22 @@ import pureconfig.error.{ ConfigReaderFailure, ConfigReaderFailures, ConfigValue
 /**
  * Trait for objects capable of reading and writing objects of a given type from and to `ConfigValues`.
  */
-trait ConfigConvert[A] extends ConfigReader[A] with ConfigWriter[A]
+trait ConfigConvert[A] extends ConfigReader[A] with ConfigWriter[A] { outer =>
+
+  /**
+   * Transforms the values read and written by this `ConfigConvert` using two functions.
+   *
+   * @param f the function applied to values after they are read
+   * @param g the function applied to values before they are written
+   * @tparam B the type of the returned `ConfigConvert`
+   * @return a `ConfigConvert` that reads and writes values of type `B` by applying `f` and `g` on read and write,
+   *         respectively.
+   */
+  def xmap[B](f: A => B, g: B => A): ConfigConvert[B] = new ConfigConvert[B] {
+    def from(config: ConfigValue) = outer.from(config).right.map(f)
+    def to(a: B) = outer.to(g(a))
+  }
+}
 
 /**
  * Provides methods to create [[ConfigConvert]] instances.

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -15,7 +15,7 @@ import pureconfig.error.{ ConfigReaderFailure, ConfigReaderFailures, ConfigValue
 /**
  * Trait for objects capable of reading and writing objects of a given type from and to `ConfigValues`.
  */
-trait ConfigConvert[T] extends ConfigReader[T] with ConfigWriter[T]
+trait ConfigConvert[A] extends ConfigReader[A] with ConfigWriter[A]
 
 /**
  * Provides methods to create [[ConfigConvert]] instances.

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -34,6 +34,17 @@ trait ConfigReader[A] {
     fromFunction[B](from(_).right.map(f))
 
   /**
+   * Maps a function that can possibly fail over the results of this reader.
+   *
+   * @param f the function to map over this reader
+   * @tparam B the value read by the function in case of success
+   * @return a `ConfigReader` returning the results of this reader mapped by `f`, with the resulting `Either` flattened
+   *         as a success or failure.
+   */
+  def emap[B](f: A => Either[ConfigReaderFailures, B]): ConfigReader[B] =
+    fromFunction[B] { cv: ConfigValue => from(cv).right.flatMap(f) }
+
+  /**
    * Monadically bind a function over the results of this reader.
    *
    * @param f the function to bind over this reader

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -4,6 +4,7 @@ import scala.reflect.ClassTag
 import scala.util.Try
 
 import com.typesafe.config.ConfigValue
+import pureconfig.ConfigReader._
 import pureconfig.ConvertHelpers._
 import pureconfig.error.{ ConfigReaderFailure, ConfigReaderFailures, ConfigValueLocation }
 
@@ -21,6 +22,61 @@ trait ConfigReader[A] {
    * @return either a list of failures or an object of type `A`
    */
   def from(config: ConfigValue): Either[ConfigReaderFailures, A]
+
+  /**
+   * Maps a function over the results of this reader.
+   *
+   * @param f the function to map over this reader
+   * @tparam B the output type of the function
+   * @return a `ConfigReader` returning the results of this reader mapped by `f`.
+   */
+  def map[B](f: A => B): ConfigReader[B] =
+    fromFunction[B](from(_).right.map(f))
+
+  /**
+   * Monadically bind a function over the results of this reader.
+   *
+   * @param f the function to bind over this reader
+   * @tparam B the type of the objects readable by the resulting `ConfigReader`
+   * @return a `ConfigReader` returning the results of this reader bound by `f`.
+   */
+  def flatMap[B](f: A => ConfigReader[B]): ConfigReader[B] =
+    fromFunction[B] { cv: ConfigValue => from(cv).right.flatMap(f(_).from(cv)) }
+
+  /**
+   * Combines this reader with another, returning both results as a pair.
+   *
+   * @param reader the reader to combine with this one
+   * @tparam B the type of the objects readable by the provided reader
+   * @return a `ConfigReader` returning the results of both readers as a pair.
+   */
+  def zip[B](reader: ConfigReader[B]): ConfigReader[(A, B)] =
+    for (a <- this; b <- reader) yield (a, b)
+
+  /**
+   * Combines this reader with another, returning the result of the first one that succeeds.
+   *
+   * @param reader the reader to combine with this one
+   * @tparam AA the type of the objects readable by both readers
+   * @return a `ConfigReader` returning the results of this reader if it succeeds and the results of `reader`
+   *         otherwise.
+   */
+  def orElse[AA >: A, B <: AA](reader: => ConfigReader[B]): ConfigReader[AA] =
+    fromFunction[AA] { cv: ConfigValue =>
+      from(cv) match {
+        case Right(a) => Right(a)
+        case Left(failures) => reader.from(cv).left.map(failures ++ _)
+      }
+    }
+
+  /**
+   * Applies a function to configs before passing them to this reader.
+   *
+   * @param f the function to apply to input configs
+   * @return a `ConfigReader` returning the results of this reader when the input configs are mapped using `f`.
+   */
+  def contramapConfig(f: ConfigValue => ConfigValue): ConfigReader[A] =
+    fromFunction[A] { a => from(f(a)) }
 }
 
 /**
@@ -29,6 +85,17 @@ trait ConfigReader[A] {
 object ConfigReader extends BasicReaders with DerivedReaders {
 
   def apply[A](implicit reader: ConfigReader[A]): ConfigReader[A] = reader
+
+  /**
+   * Creates a `ConfigReader` from a function.
+   *
+   * @param fromF the function used to read configs to values
+   * @tparam A the type of the objects readable by the returned reader
+   * @return a `ConfigReader` for reading objects of type `A` using `fromF`.
+   */
+  def fromFunction[A](fromF: ConfigValue => Either[ConfigReaderFailures, A]) = new ConfigReader[A] {
+    def from(config: ConfigValue) = fromF(config)
+  }
 
   def fromString[A](fromF: String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, A]): ConfigReader[A] = new ConfigReader[A] {
     override def from(config: ConfigValue): Either[ConfigReaderFailures, A] = stringToEitherConvert(fromF)(config)

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -10,17 +10,17 @@ import pureconfig.error.{ ConfigReaderFailure, ConfigReaderFailures, ConfigValue
 /**
  * Trait for objects capable of reading objects of a given type from `ConfigValues`.
  *
- * @tparam T the type of objects readable by this `ConfigReader`
+ * @tparam A the type of objects readable by this `ConfigReader`
  */
-trait ConfigReader[T] {
+trait ConfigReader[A] {
 
   /**
-   * Convert the given configuration into an instance of `T` if possible.
+   * Convert the given configuration into an instance of `A` if possible.
    *
    * @param config The configuration from which load the config
-   * @return either a list of failures or an object of type `T`
+   * @return either a list of failures or an object of type `A`
    */
-  def from(config: ConfigValue): Either[ConfigReaderFailures, T]
+  def from(config: ConfigValue): Either[ConfigReaderFailures, A]
 }
 
 /**
@@ -28,29 +28,29 @@ trait ConfigReader[T] {
  */
 object ConfigReader extends BasicReaders with DerivedReaders {
 
-  def apply[T](implicit reader: ConfigReader[T]): ConfigReader[T] = reader
+  def apply[A](implicit reader: ConfigReader[A]): ConfigReader[A] = reader
 
-  def fromString[T](fromF: String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, T]): ConfigReader[T] = new ConfigReader[T] {
-    override def from(config: ConfigValue): Either[ConfigReaderFailures, T] = stringToEitherConvert(fromF)(config)
+  def fromString[A](fromF: String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, A]): ConfigReader[A] = new ConfigReader[A] {
+    override def from(config: ConfigValue): Either[ConfigReaderFailures, A] = stringToEitherConvert(fromF)(config)
   }
 
-  def fromStringTry[T](fromF: String => Try[T])(implicit ct: ClassTag[T]): ConfigReader[T] = {
-    fromString[T](tryF(fromF))
+  def fromStringTry[A](fromF: String => Try[A])(implicit ct: ClassTag[A]): ConfigReader[A] = {
+    fromString[A](tryF(fromF))
   }
 
-  def fromStringOpt[T](fromF: String => Option[T])(implicit ct: ClassTag[T]): ConfigReader[T] = {
-    fromString[T](optF(fromF))
+  def fromStringOpt[A](fromF: String => Option[A])(implicit ct: ClassTag[A]): ConfigReader[A] = {
+    fromString[A](optF(fromF))
   }
 
-  def fromNonEmptyString[T](fromF: String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, T])(implicit ct: ClassTag[T]): ConfigReader[T] = {
+  def fromNonEmptyString[A](fromF: String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, A])(implicit ct: ClassTag[A]): ConfigReader[A] = {
     fromString(string => location => ensureNonEmpty(ct)(string)(location).right.flatMap(s => fromF(s)(location)))
   }
 
-  def fromNonEmptyStringTry[T](fromF: String => Try[T])(implicit ct: ClassTag[T]): ConfigReader[T] = {
-    fromNonEmptyString[T](tryF(fromF))
+  def fromNonEmptyStringTry[A](fromF: String => Try[A])(implicit ct: ClassTag[A]): ConfigReader[A] = {
+    fromNonEmptyString[A](tryF(fromF))
   }
 
-  def fromNonEmptyStringOpt[T](fromF: String => Option[T])(implicit ct: ClassTag[T]): ConfigReader[T] = {
-    fromNonEmptyString[T](optF(fromF))
+  def fromNonEmptyStringOpt[A](fromF: String => Option[A])(implicit ct: ClassTag[A]): ConfigReader[A] = {
+    fromNonEmptyString[A](optF(fromF))
   }
 }

--- a/core/src/main/scala/pureconfig/ConfigWriter.scala
+++ b/core/src/main/scala/pureconfig/ConfigWriter.scala
@@ -5,17 +5,17 @@ import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
 /**
  * Trait for objects capable of writing objects of a given type to `ConfigValues`.
  *
- * @tparam T the type of objects writable by this `ConfigWriter`
+ * @tparam A the type of objects writable by this `ConfigWriter`
  */
-trait ConfigWriter[T] {
+trait ConfigWriter[A] {
 
   /**
-   * Converts a type `T` to a `ConfigValue`.
+   * Converts a type `A` to a `ConfigValue`.
    *
-   * @param t The instance of `T` to convert
-   * @return The `ConfigValue` obtained from the `T` instance
+   * @param a The instance of `A` to convert
+   * @return The `ConfigValue` obtained from the `A` instance
    */
-  def to(t: T): ConfigValue
+  def to(a: A): ConfigValue
 }
 
 /**
@@ -23,37 +23,37 @@ trait ConfigWriter[T] {
  */
 object ConfigWriter extends BasicWriters with DerivedWriters {
 
-  def apply[T](implicit writer: ConfigWriter[T]): ConfigWriter[T] = writer
+  def apply[A](implicit writer: ConfigWriter[A]): ConfigWriter[A] = writer
 
   /**
    * Returns a `ConfigWriter` for types supported by `ConfigValueFactory.fromAnyRef`. This method should be used
    * carefully, as a runtime exception is thrown if the type passed as argument is not supported.
    *
-   * @tparam T the primitive type for which a `ConfigWriter` is to be created
-   * @return a `ConfigWriter` for the type `T`.
+   * @tparam A the primitive type for which a `ConfigWriter` is to be created
+   * @return a `ConfigWriter` for the type `A`.
    */
-  def forPrimitive[T]: ConfigWriter[T] = new ConfigWriter[T] {
-    def to(t: T) = ConfigValueFactory.fromAnyRef(t)
+  def forPrimitive[A]: ConfigWriter[A] = new ConfigWriter[A] {
+    def to(t: A) = ConfigValueFactory.fromAnyRef(t)
   }
 
   /**
    * Returns a `ConfigWriter` that writes objects of a given type as strings created by `.toString`.
    *
-   * @tparam T the type for which a `ConfigWriter` is to be created
-   * @return a `ConfigWriter` for the type `T`.
+   * @tparam A the type for which a `ConfigWriter` is to be created
+   * @return a `ConfigWriter` for the type `A`.
    */
-  def toDefaultString[T]: ConfigWriter[T] = new ConfigWriter[T] {
-    def to(t: T) = ConfigValueFactory.fromAnyRef(t.toString)
+  def toDefaultString[A]: ConfigWriter[A] = new ConfigWriter[A] {
+    def to(t: A) = ConfigValueFactory.fromAnyRef(t.toString)
   }
 
   /**
    * Returns a `ConfigWriter` that writes objects of a given type as strings created by a function.
    *
-   * @param toF the function converting an object of type `T` to a string
-   * @tparam T the type for which a `ConfigWriter` is to be created
-   * @return a `ConfigWriter` for the type `T`.
+   * @param toF the function converting an object of type `A` to a string
+   * @tparam A the type for which a `ConfigWriter` is to be created
+   * @return a `ConfigWriter` for the type `A`.
    */
-  def toString[T](toF: T => String): ConfigWriter[T] = new ConfigWriter[T] {
-    def to(t: T) = ConfigValueFactory.fromAnyRef(toF(t))
+  def toString[A](toF: A => String): ConfigWriter[A] = new ConfigWriter[A] {
+    def to(t: A) = ConfigValueFactory.fromAnyRef(toF(t))
   }
 }

--- a/core/src/test/scala/pureconfig/ConfigConvertSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigConvertSuite.scala
@@ -4,11 +4,13 @@ import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
 import org.scalacheck.{ Arbitrary, Gen }
 
 class ConfigConvertSuite extends BaseSuite {
+  implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
+
   val intConvert = ConfigConvert[Int]
 
   // generate configs that always read correctly as strings, but not always as integers
   val genConfig: Gen[ConfigValue] =
-    Gen.frequency(95 -> Gen.chooseNum(Int.MinValue, Int.MaxValue), 5 -> Gen.alphaStr)
+    Gen.frequency(80 -> Gen.chooseNum(Int.MinValue, Int.MaxValue), 20 -> Gen.alphaStr)
       .map(ConfigValueFactory.fromAnyRef)
 
   implicit val arbConfig = Arbitrary(genConfig)
@@ -16,7 +18,7 @@ class ConfigConvertSuite extends BaseSuite {
   behavior of "ConfigConvert"
 
   it should "have a correct xmap method" in forAll { (f: Int => String, g: String => Int) =>
-    forAll { str: String => intConvert.xmap(f, g).to(str) === intConvert.to(g(str)) }
-    forAll { conf: ConfigValue => intConvert.xmap(f, g).from(conf) === intConvert.from(conf).right.map(f) }
+    forAll { str: String => intConvert.xmap(f, g).to(str) shouldEqual intConvert.to(g(str)) }
+    forAll { conf: ConfigValue => intConvert.xmap(f, g).from(conf) shouldEqual intConvert.from(conf).right.map(f) }
   }
 }

--- a/core/src/test/scala/pureconfig/ConfigConvertSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigConvertSuite.scala
@@ -1,0 +1,22 @@
+package pureconfig
+
+import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
+import org.scalacheck.{ Arbitrary, Gen }
+
+class ConfigConvertSuite extends BaseSuite {
+  val intConvert = ConfigConvert[Int]
+
+  // generate configs that always read correctly as strings, but not always as integers
+  val genConfig: Gen[ConfigValue] =
+    Gen.frequency(95 -> Gen.chooseNum(Int.MinValue, Int.MaxValue), 5 -> Gen.alphaStr)
+      .map(ConfigValueFactory.fromAnyRef)
+
+  implicit val arbConfig = Arbitrary(genConfig)
+
+  behavior of "ConfigConvert"
+
+  it should "have a correct xmap method" in forAll { (f: Int => String, g: String => Int) =>
+    forAll { str: String => intConvert.xmap(f, g).to(str) === intConvert.to(g(str)) }
+    forAll { conf: ConfigValue => intConvert.xmap(f, g).from(conf) === intConvert.from(conf).right.map(f) }
+  }
+}

--- a/core/src/test/scala/pureconfig/ConfigReaderSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderSuite.scala
@@ -42,8 +42,9 @@ class ConfigReaderSuite extends BaseSuite {
     def zip[A, B](r1: ConfigReader[A], r2: ConfigReader[B]): Either[ConfigReaderFailures, (A, B)] = {
       (r1.from(conf), r2.from(conf)) match {
         case (Right(a), Right(b)) => Right((a, b))
-        case (Left(fa), _) => Left(fa)
-        case (_, Left(fb)) => Left(fb)
+        case (Left(fa), Right(_)) => Left(fa)
+        case (Right(_), Left(fb)) => Left(fb)
+        case (Left(fa), Left(fb)) => Left(fa ++ fb)
       }
     }
 

--- a/core/src/test/scala/pureconfig/ConfigReaderSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderSuite.scala
@@ -1,0 +1,70 @@
+package pureconfig
+
+import com.typesafe.config.{ ConfigFactory, ConfigValue, ConfigValueFactory }
+import org.scalacheck.{ Arbitrary, Gen }
+import pureconfig.error.ConfigReaderFailures
+
+class ConfigReaderSuite extends BaseSuite {
+  val intReader = ConfigReader[Int]
+  val strReader = ConfigReader[String]
+
+  def intSummedReader(n: Int) = new ConfigReader[Int] {
+    def from(config: ConfigValue) = intReader.from(config).right.map(_ + n)
+  }
+
+  // generate configs that always read correctly as strings, but not always as integers
+  val genConfig: Gen[ConfigValue] =
+    Gen.frequency(95 -> Gen.chooseNum(Int.MinValue, Int.MaxValue), 5 -> Gen.alphaStr)
+      .map(ConfigValueFactory.fromAnyRef)
+
+  implicit val arbConfig = Arbitrary(genConfig)
+
+  behavior of "ConfigReader"
+
+  it should "have a correct map method" in forAll { (conf: ConfigValue, f: Int => String) =>
+    intReader.map(f).from(conf) === intReader.from(conf).right.map(f)
+  }
+
+  it should "have a correct flatMap method" in forAll { conf: ConfigValue =>
+    val g = { n: Int => intSummedReader(n) }
+    intReader.flatMap(g).from(conf) === intReader.from(conf).right.flatMap(g(_).from(conf))
+  }
+
+  it should "have a correct zip method" in forAll { conf: ConfigValue =>
+    def zip[A, B](r1: ConfigReader[A], r2: ConfigReader[B]): Either[ConfigReaderFailures, (A, B)] = {
+      (r1.from(conf), r2.from(conf)) match {
+        case (Right(a), Right(b)) => Right((a, b))
+        case (Left(fa), _) => Left(fa)
+        case (_, Left(fb)) => Left(fb)
+      }
+    }
+
+    intReader.zip(strReader).from(conf) === zip(intReader, strReader)
+    strReader.zip(intReader).from(conf) === zip(strReader, intReader)
+    intReader.zip(intReader).from(conf) === zip(intReader, intReader)
+    strReader.zip(strReader).from(conf) === zip(strReader, strReader)
+  }
+
+  it should "have a correct orElse method" in forAll { conf: ConfigValue =>
+    def orElse[AA, A <: AA, B <: AA](r1: ConfigReader[A], r2: ConfigReader[B]): Either[ConfigReaderFailures, AA] = {
+      (r1.from(conf), r2.from(conf)) match {
+        case (Right(a), _) => Right(a)
+        case (Left(_), Right(b)) => Right(b)
+        case (Left(fa), Left(fb)) => Left(fa ++ fb)
+      }
+    }
+
+    // results are explicitly typed so that we also test the resulting type of `orElse`
+    intReader.orElse(strReader).from(conf) === orElse[Any, Int, String](intReader, strReader)
+    strReader.orElse(intReader).from(conf) === orElse[Any, String, Int](strReader, intReader)
+    intReader.orElse(intReader).from(conf) === orElse[Int, Int, Int](intReader, intReader)
+    strReader.orElse(strReader).from(conf) === orElse[String, String, String](strReader, strReader)
+  }
+
+  it should "have a correct contramapConfig method" in forAll { conf: ConfigValue =>
+    val wrappedConf = ConfigFactory.parseString(s"{ value: ${conf.render} }").root()
+    val unwrap = { cv: ConfigValue => cv.atKey("value").root() }
+
+    intReader.contramapConfig(unwrap).from(wrappedConf) === intReader.from(conf)
+  }
+}

--- a/core/src/test/scala/pureconfig/ConfigWriterSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigWriterSuite.scala
@@ -1,0 +1,18 @@
+package pureconfig
+
+import com.typesafe.config.{ ConfigFactory, ConfigValue }
+
+class ConfigWriterSuite extends BaseSuite {
+  val intWriter = ConfigWriter[Int]
+
+  behavior of "ConfigWriter"
+
+  it should "have a correct contramap method" in forAll { (str: String, f: String => Int) =>
+    intWriter.contramap(f).to(str) === intWriter.to(f(str))
+  }
+
+  it should "have a correct mapConfig method" in forAll { x: Int =>
+    val wrap = { cv: ConfigValue => ConfigFactory.parseString(s"{ value: ${cv.render} }").root() }
+    intWriter.mapConfig(wrap).to(x) === wrap(intWriter.to(x))
+  }
+}

--- a/core/src/test/scala/pureconfig/ConfigWriterSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigWriterSuite.scala
@@ -3,16 +3,18 @@ package pureconfig
 import com.typesafe.config.{ ConfigFactory, ConfigValue }
 
 class ConfigWriterSuite extends BaseSuite {
+  implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
+
   val intWriter = ConfigWriter[Int]
 
   behavior of "ConfigWriter"
 
   it should "have a correct contramap method" in forAll { (str: String, f: String => Int) =>
-    intWriter.contramap(f).to(str) === intWriter.to(f(str))
+    intWriter.contramap(f).to(str) shouldEqual intWriter.to(f(str))
   }
 
   it should "have a correct mapConfig method" in forAll { x: Int =>
     val wrap = { cv: ConfigValue => ConfigFactory.parseString(s"{ value: ${cv.render} }").root() }
-    intWriter.mapConfig(wrap).to(x) === wrap(intWriter.to(x))
+    intWriter.mapConfig(wrap).to(x) shouldEqual wrap(intWriter.to(x))
   }
 }


### PR DESCRIPTION
Adds some combinators to config reading/writing classes so they are easier to compose.

I ended up not needing anything from cats; my previous concerns with F-bounded polymorphism didn't apply to this specific situation. Now that we have these methods defined we should probably create a `pureconfig-cats` module (and a `pureconfig-scalaz`, if anybody asks for it) with type classes for our three classes.

Closes #93.
