### PR TITLE
Make Travis check if generated docs didn't change after running tut

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,10 @@ jdk:
 script:
   - sbt ++$TRAVIS_SCALA_VERSION coverage test tut
   - (cd example ; sbt ++$TRAVIS_SCALA_VERSION test)
+
+  # check if there are no changes after `tut` runs
+  - if [[ $TRAVIS_SCALA_VERSION =~ '^2\.12.*' ]]; then
+      git diff --exit-code;
+      fi
 after_success:
   - sbt ++$TRAVIS_SCALA_VERSION coverageReport coverageAggregate coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ script:
       fi
 after_success:
   - sbt ++$TRAVIS_SCALA_VERSION coverageReport coverageAggregate coveralls
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot


### PR DESCRIPTION
I don't remember why we didn't this before, but the output of `sbt tut` seems deterministic and consistent with the current README in my laptop. We can make Travis check if this still holds after each PR so that people don't forget to update documentation and write the updates in tut sources.

EDIT: I took the opportunity to make Travis cache library dependencies and SBT boot files, since our builds are taking 15-20 minutes to run :/