### PR TITLE
Value classes config reader writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - New features
   - `ConfigReader`, `ConfigWriter` and `ConfigConvert` now have combinators such as `map`, `flatMap` and `contramap`,
     making them easier to compose.
+  - New mechanism to read and write [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html).
+    The readers and writers of the inner type are used instead of the ones for products.
 - Bug fixes
   - `Duration.Undefined` is correctly handled when reading and writing configurations. [[#184](https://github.com/melrief/pureconfig/issues/184)]
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Currently supported types for fields are:
 - [`java.util.UUID`](https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html);
 - [`java.nio.file.Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html);
 - Typesafe `ConfigValue`, `ConfigObject` and `ConfigList`;
+- value classes for which readers and writers of the inner type are used;
 - case classes;
 - sealed families of case classes (ADTs).
 
@@ -131,14 +132,22 @@ import pureconfig.loadConfig
 sealed trait MyAdt
 case class AdtA(a: String) extends MyAdt
 case class AdtB(b: Int) extends MyAdt
-case class MyClass(int: Int, adt: MyAdt, list: List[Double], map: Map[String, String], option: Option[String])
+final case class Port(value: Int) extends AnyVal
+case class MyClass(
+  boolean: Boolean,
+  port: Port,
+  adt: MyAdt,
+  list: List[Double],
+  map: Map[String, String],
+  option: Option[String])
 ```
 
 Then, load the configuration (in this case from a hard-coded string):
 
 ```scala
 val conf = parseString("""{ 
-  "int": 1, 
+  "boolean": true,
+  "port": 8080, 
   "adt": { 
     "type": "adtb", 
     "b": 1 
@@ -146,10 +155,10 @@ val conf = parseString("""{
   "list": ["1", "20%"], 
   "map": { "key": "value" } 
 }""")
-// conf: com.typesafe.config.Config = Config(SimpleConfigObject({"adt":{"b":1,"type":"adtb"},"int":1,"list":["1","20%"],"map":{"key":"value"}}))
+// conf: com.typesafe.config.Config = Config(SimpleConfigObject({"adt":{"b":1,"type":"adtb"},"boolean":true,"list":["1","20%"],"map":{"key":"value"},"port":8080}))
 
 loadConfig[MyClass](conf)
-// res3: Either[pureconfig.error.ConfigReaderFailures,MyClass] = Right(MyClass(1,AdtB(1),List(1.0, 0.2),Map(key -> value),None))
+// res3: Either[pureconfig.error.ConfigReaderFailures,MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
 ```
 
 

--- a/core/src/main/scala/pureconfig/DerivedWriters.scala
+++ b/core/src/main/scala/pureconfig/DerivedWriters.scala
@@ -9,10 +9,21 @@ import pureconfig.error._
 import shapeless._
 import shapeless.labelled._
 
+trait DerivedWriters extends DerivedWriters1 {
+  implicit def deriveAnyVal[T, U](
+    implicit
+    ev: T <:< AnyVal,
+    unwrapped: Unwrapped.Aux[T, U],
+    writer: ConfigWriter[U]): ConfigWriter[T] =
+    new ConfigWriter[T] {
+      override def to(t: T): ConfigValue = writer.to(unwrapped.unwrap(t))
+    }
+}
+
 /**
  * Trait containing `ConfigWriter` instances for collection, product and coproduct types.
  */
-trait DerivedWriters {
+trait DerivedWriters1 {
 
   private[pureconfig] trait WrappedConfigWriter[Wrapped, SubRepr] extends ConfigWriter[SubRepr]
 

--- a/core/src/main/tut/README.md
+++ b/core/src/main/tut/README.md
@@ -117,6 +117,7 @@ Currently supported types for fields are:
 - [`java.util.UUID`](https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html);
 - [`java.nio.file.Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html);
 - Typesafe `ConfigValue`, `ConfigObject` and `ConfigList`;
+- value classes for which readers and writers of the inner type are used;
 - case classes;
 - sealed families of case classes (ADTs).
 
@@ -131,14 +132,22 @@ import pureconfig.loadConfig
 sealed trait MyAdt
 case class AdtA(a: String) extends MyAdt
 case class AdtB(b: Int) extends MyAdt
-case class MyClass(int: Int, adt: MyAdt, list: List[Double], map: Map[String, String], option: Option[String])
+final case class Port(value: Int) extends AnyVal
+case class MyClass(
+  boolean: Boolean,
+  port: Port,
+  adt: MyAdt,
+  list: List[Double],
+  map: Map[String, String],
+  option: Option[String])
 ```
 
 Then, load the configuration (in this case from a hard-coded string):
 
 ```tut:book
 val conf = parseString("""{ 
-  "int": 1, 
+  "boolean": true,
+  "port": 8080, 
   "adt": { 
     "type": "adtb", 
     "b": 1 

--- a/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -64,7 +64,7 @@ class BasicConvertersSuite extends BaseSuite {
   checkArbitrary[immutable.HashSet[String]]
 
   checkArbitrary[immutable.List[Float]]
-  check[immutable.List[Int]](
+  checkRead[immutable.List[Int]](
     // order of keys maintained
     (List(2, 3, 1), ConfigValueFactory.fromMap(Map("2" -> 1, "0" -> 2, "1" -> 3).asJava)),
     (List(4, 2), ConfigValueFactory.fromMap(Map("3" -> 2, "1" -> 4).asJava)))
@@ -81,7 +81,7 @@ class BasicConvertersSuite extends BaseSuite {
   checkArbitrary[immutable.Queue[Boolean]]
 
   checkArbitrary[immutable.Set[Double]]
-  check[immutable.Set[Int]](
+  checkRead[immutable.Set[Int]](
     (Set(4, 5, 6), ConfigValueFactory.fromMap(Map("1" -> 4, "2" -> 5, "3" -> 6).asJava)))
 
   checkArbitrary[immutable.Stream[String]]
@@ -92,17 +92,17 @@ class BasicConvertersSuite extends BaseSuite {
 
   checkArbitrary[Option[Int]]
 
-  check[URL](
+  checkRead[URL](
     new URL("http://host/path?with=query&param") -> ConfigValueFactory.fromAnyRef("http://host/path?with=query&param"))
 
-  check[URI](
+  checkRead[URI](
     new URI("http://host/path?with=query&param") -> ConfigValueFactory.fromAnyRef("http://host/path?with=query&param"))
 
-  check[ConfigList](
+  checkRead[ConfigList](
     ConfigValueFactory.fromIterable(List().asJava) -> ConfigValueFactory.fromIterable(List().asJava),
     ConfigValueFactory.fromIterable(List(1, 2, 3).asJava) -> ConfigValueFactory.fromAnyRef(List(1, 2, 3).asJava))
 
-  check[ConfigValue](
+  checkRead[ConfigValue](
     ConfigValueFactory.fromAnyRef(4) -> ConfigValueFactory.fromAnyRef(4),
     ConfigValueFactory.fromAnyRef("str") -> ConfigValueFactory.fromAnyRef("str"),
     ConfigValueFactory.fromAnyRef(List(1, 2, 3).asJava) -> ConfigValueFactory.fromAnyRef(List(1, 2, 3).asJava))
@@ -110,10 +110,10 @@ class BasicConvertersSuite extends BaseSuite {
   {
     val conf = ConfigFactory.parseString("""{ v1 = 3, v2 = 4 }""".stripMargin)
 
-    check[ConfigObject](
+    checkRead[ConfigObject](
       ConfigValueFactory.fromMap(Map("v1" -> 3, "v2" -> 4).asJava) -> conf.root().asInstanceOf[ConfigValue])
 
-    check[Config](
+    checkRead[Config](
       conf -> conf.root().asInstanceOf[ConfigValue])
   }
 }

--- a/core/src/test/scala/pureconfig/ValueClassSuite.scala
+++ b/core/src/test/scala/pureconfig/ValueClassSuite.scala
@@ -1,0 +1,13 @@
+package pureconfig
+
+final class IntWrapper(val inner: Int) extends AnyVal {
+  override def toString: String = s"IntWrapper($inner)"
+}
+
+class ValueClassSuite extends BaseSuite {
+
+  behavior of "ConfigConvert for Value Classes"
+
+  checkRead[IntWrapper](new IntWrapper(1) -> ConfigWriter.forPrimitive[Int].to(1))
+  checkWrite[IntWrapper](new IntWrapper(1) -> ConfigWriter.forPrimitive[Int].to(1))
+}


### PR DESCRIPTION
Closes #206 

I've added readers and writers for value classes that "skip" the wrappers when they read or write. In this way, if you have a `final case class Port(value: Int) extends AnyVal`, you can read and write it as `Int` instead of product with one field of type `Int`.

This change has some consequences on the architecture of the traits `DerivedReaders` and `DerivedWriters` because just putting the decoders derivation for value classes inside the previous traits was causing conflicts between them and the product decoders. The solution that I've adopted is to split the traits in two and make the trait containing the new decoders extend the old decoders trait. In this way, the new decoders have higher priority during the implicit resolution.

A side-change that I've done is to rename `check` and `checkString` utility functions for testing into `checkRead` and `checkReadString` and change their implicit parameter to `ConfigReader`, because those two methods just test the reading of a type `T`. I also added `checkWrite` for the inverse test.

I haven't added a section for value classes but I mention them in the README and in the CHANGELOG. I'm not sure that what I've written is good enough, please have a look at that too and tell me what you think.