### PR TITLE
Support Java duration. Naming choices are up for discussion

### DIFF
--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -3,6 +3,7 @@ package pureconfig
 import java.net.{ URI, URL }
 import java.nio.file.{ Path, Paths }
 import java.time._
+import java.time.{ Duration => JavaDuration }
 import java.util.UUID
 
 import scala.concurrent.duration.{ Duration, FiniteDuration }
@@ -58,6 +59,9 @@ trait JavaTimeReaders {
 
   implicit val periodConfigReader: ConfigReader[Period] =
     ConfigReader.fromNonEmptyString[Period](catchReadError(Period.parse))
+
+  implicit val javaDurationConfigReader: ConfigReader[JavaDuration] =
+    ConfigReader.fromNonEmptyString[JavaDuration](catchReadError(JavaDuration.parse))
 
   implicit val yearConfigReader: ConfigReader[Year] =
     ConfigReader.fromNonEmptyString[Year](catchReadError(Year.parse))

--- a/core/src/main/scala/pureconfig/BasicWriters.scala
+++ b/core/src/main/scala/pureconfig/BasicWriters.scala
@@ -3,6 +3,7 @@ package pureconfig
 import java.net.{ URI, URL }
 import java.nio.file.Path
 import java.time._
+import java.time.{ Duration => JavaDuration }
 import java.util.UUID
 
 import scala.concurrent.duration.{ Duration, FiniteDuration }
@@ -49,6 +50,7 @@ trait JavaTimeWriters {
     if (year.getValue > 9999) "+" + year else year.toString
 
   implicit val yearConfigWriter = ConfigWriter.toString[Year](yearToString)
+  implicit val javaDurationConfigWriter = ConfigWriter.toDefaultString[JavaDuration]
 }
 
 /**

--- a/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -3,6 +3,7 @@ package pureconfig
 import java.net.{ URI, URL }
 import java.nio.file.Path
 import java.time._
+import java.time.{ Duration => JavaDuration }
 import java.util.UUID
 
 import com.typesafe.config._
@@ -21,6 +22,10 @@ class BasicConvertersSuite extends BaseSuite {
   checkArbitrary[Duration]
   checkFailure[Duration, EmptyStringFound](ConfigValueFactory.fromAnyRef(""))
   checkFailure[Duration, CannotConvert](ConfigValueFactory.fromIterable(List(1).asJava))
+
+  checkArbitrary[JavaDuration]
+  checkFailure[JavaDuration, EmptyStringFound](ConfigValueFactory.fromAnyRef(""))
+  checkFailure[JavaDuration, CannotConvert](ConfigValueFactory.fromIterable(List(1).asJava))
 
   checkArbitrary[FiniteDuration]
   checkFailure[FiniteDuration, EmptyStringFound](ConfigValueFactory.fromAnyRef(""))

--- a/core/src/test/scala/pureconfig/ConfigConvertChecks.scala
+++ b/core/src/test/scala/pureconfig/ConfigConvertChecks.scala
@@ -24,7 +24,7 @@ trait ConfigConvertChecks { this: FlatSpec with Matchers with GeneratorDrivenPro
    * representations.
    */
   def checkArbitrary[T](implicit cc: ConfigConvert[T], arb: Arbitrary[T], tag: ClassTag[T]): Unit =
-    it should s"read an arbitrary ${tag.runtimeClass.getSimpleName}" in forAll {
+    it should s"read an arbitrary ${tag.runtimeClass.getCanonicalName}" in forAll {
       (t: T) =>
         val result = cc.from(cc.to(t))
         result shouldBe a[Right[_, _]]
@@ -78,7 +78,7 @@ trait ConfigConvertChecks { this: FlatSpec with Matchers with GeneratorDrivenPro
    */
   def checkFailure[T, E <: ConfigReaderFailure](values: ConfigValue*)(implicit cr: ConfigConvert[T], tag: ClassTag[T], eTag: ClassTag[E]): Unit =
     for (value <- values) {
-      it should s"fail when it tries to read a value of type ${tag.runtimeClass.getSimpleName} " +
+      it should s"fail when it tries to read a value of type ${tag.runtimeClass.getCanonicalName} " +
         s"from ${value.render(ConfigRenderOptions.concise())}" in {
           val result = cr.from(value)
           result shouldBe a[Left[_, _]]

--- a/core/src/test/scala/pureconfig/arbitrary/package.scala
+++ b/core/src/test/scala/pureconfig/arbitrary/package.scala
@@ -6,6 +6,7 @@ import pureconfig.gen._
 package object arbitrary {
 
   implicit val arbDuration = Arbitrary(genDuration)
+  implicit val arbJavaDuration = Arbitrary(genJavaDuration)
   implicit val arbFiniteDuration = Arbitrary(genFiniteDuration)
   implicit val arbInstant = Arbitrary(genInstant)
   implicit val arbZoneId = Arbitrary(genZoneId)

--- a/core/src/test/scala/pureconfig/gen/package.scala
+++ b/core/src/test/scala/pureconfig/gen/package.scala
@@ -2,6 +2,7 @@ package pureconfig
 
 import java.nio.file.{ Path, Paths }
 import java.time._
+import java.time.{ Duration => JavaDuration }
 
 import org.scalacheck.{ Arbitrary, Gen }
 import pureconfig.configurable.ConfigurableSuite
@@ -16,6 +17,10 @@ package object gen {
     Gen.choose(Long.MinValue + 1, Long.MaxValue)
       .suchThat(_ != 8092048641075763L) // doesn't work, see #182
       .map(Duration.fromNanos)
+
+  val genJavaDuration: Gen[JavaDuration] =
+    Gen.choose(Long.MinValue + 1, Long.MaxValue)
+      .map(JavaDuration.ofNanos)
 
   val genDuration: Gen[Duration] =
     Gen.frequency(


### PR DESCRIPTION
I've seen in the Scala source that jDuration might be more standard, but seems to be “less classy”). Also, since both Durations have the same SimpleName had to change the namer in the test suite, not sure if this is the best choice. I removed the limitation on the generated duration, though, java.time.Duration seems to handle that specific number just fine