### PR TITLE
first version of cats module; supports NonEmptyList and NonEmptyVector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,10 @@ lazy val docs = (project in file("docs")).
   settings(settings, publishArtifact := false).
   dependsOn(core)
 
+lazy val cats = (project in file("modules/cats")).
+  settings(settings, publishArtifact := false).
+  dependsOn(core)
+
 lazy val enumeratum = (project in file("modules/enumeratum")).
   settings(settings).
   dependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val docs = (project in file("docs")).
   dependsOn(core)
 
 lazy val cats = (project in file("modules/cats")).
-  settings(settings, publishArtifact := false).
+  settings(settings).
   dependsOn(core)
 
 lazy val enumeratum = (project in file("modules/enumeratum")).

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -217,6 +217,21 @@ final case class EmptyStringFound(typ: String, location: Option[ConfigValueLocat
 }
 
 /**
+ * A failure representing an unexpected empty traversable
+ *
+ * @param typ the type that was attempted to be converted to from an empty string
+ * @param location an optional location of the ConfigValue that raised the
+ *                 failure
+ * @param path an optional path to the value which was an unexpected empty string
+ */
+final case class EmptyTraversableFound(typ: String, location: Option[ConfigValueLocation], path: Option[String]) extends ConfigReaderFailure {
+  def description = s"Empty collection found when trying to convert to $typ."
+
+  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
+    this.copy(location = location orElse parentLocation, path = path.map(parentKey + "." + _) orElse Some(parentKey))
+}
+
+/**
  * A failure representing an unexpected non-empty object when using `EnumCoproductHint` to write a config.
  *
  * @param typ the type for which a non-empty object was attempted to be written

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -61,7 +61,7 @@ object ConfigValueLocation {
  * ConfigValue. The failure contains an optional location of the ConfigValue
  * that raised the error.
  */
-sealed abstract class ConfigReaderFailure {
+abstract class ConfigReaderFailure {
   /**
    * The optional location of the ConfigReaderFailure.
    */
@@ -211,21 +211,6 @@ final case class ThrowableFailure(throwable: Throwable, location: Option[ConfigV
  */
 final case class EmptyStringFound(typ: String, location: Option[ConfigValueLocation], path: Option[String]) extends ConfigReaderFailure {
   def description = s"Empty string found when trying to convert to $typ."
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = path.map(parentKey + "." + _) orElse Some(parentKey))
-}
-
-/**
- * A failure representing an unexpected empty traversable
- *
- * @param typ the type that was attempted to be converted to from an empty string
- * @param location an optional location of the ConfigValue that raised the
- *                 failure
- * @param path an optional path to the value which was an unexpected empty string
- */
-final case class EmptyTraversableFound(typ: String, location: Option[ConfigValueLocation], path: Option[String]) extends ConfigReaderFailure {
-  def description = s"Empty collection found when trying to convert to $typ."
 
   def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
     this.copy(location = location orElse parentLocation, path = path.map(parentKey + "." + _) orElse Some(parentKey))

--- a/modules/cats/README.md
+++ b/modules/cats/README.md
@@ -1,0 +1,45 @@
+# Cats module for PureConfig
+
+Adds support for selected cats classes to PureConfig.
+
+## Add pureconfig-cats to your project
+
+In addition to [core pureconfig](https://github.com/melrief/pureconfig), you'll need:
+
+```scala
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats" % "0.7.1"
+```
+
+## Example
+
+To load a `NonEmptyList[Int]` into a configuration, we need a class to hold our configuration:
+
+```scala
+import cats.data.{NonEmptyList, NonEmptyVector}
+import com.typesafe.config.ConfigFactory.parseString
+import pureconfig._
+import pureconfig.module.cats._
+
+case class MyConfig(numbers: NonEmptyList[Int])
+```
+
+We can read a `MyConfig` like:
+```scala
+val conf = parseString("""{ numbers: [1,2,3] }""")
+// conf: com.typesafe.config.Config = Config(SimpleConfigObject({"numbers":[1,2,3]}))
+
+loadConfig[MyConfig](conf)
+// res1: Either[pureconfig.error.ConfigReaderFailures,MyConfig] = Right(MyConfig(NonEmptyList(1, 2, 3)))
+```
+
+You can also load `NonEmptyVector`. First, define a case class for the config:
+
+```scala
+case class MyVecConfig(numbers: NonEmptyVector[Int])
+```
+
+then load the config:
+```scala
+loadConfig[MyVecConfig](conf)
+// res2: Either[pureconfig.error.ConfigReaderFailures,MyVecConfig] = Right(MyVecConfig(NonEmptyVector(1, 2, 3)))
+```

--- a/modules/cats/README.md
+++ b/modules/cats/README.md
@@ -1,10 +1,10 @@
 # Cats module for PureConfig
 
-Adds support for selected cats classes to PureConfig.
+Adds support for selected [cats](http://typelevel.org/cats/) classes to PureConfig.
 
 ## Add pureconfig-cats to your project
 
-In addition to [core pureconfig](https://github.com/melrief/pureconfig), you'll need:
+In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
 libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats" % "0.7.1"

--- a/modules/cats/build.sbt
+++ b/modules/cats/build.sbt
@@ -1,0 +1,52 @@
+name := "pureconfig-cats"
+
+organization := "com.github.pureconfig"
+
+homepage := Some(url("https://github.com/pureconfig/pureconfig"))
+
+licenses := Seq("Mozilla Public License, version 2.0" -> url("https://www.mozilla.org/MPL/2.0/"))
+
+resolvers ++= Seq(
+  Resolver.sonatypeRepo("releases"),
+  Resolver.sonatypeRepo("snapshots")
+)
+
+libraryDependencies ++= Seq(
+  "org.typelevel" %% "cats-core" % "0.9.0",
+  Dependencies.scalaMacrosParadise,
+  Dependencies.scalaTest,
+  Dependencies.scalaCheck
+)
+
+publishMavenStyle := true
+
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+}
+
+publishArtifact in Test := false
+
+pomExtra := (
+  <scm>
+    <url>git@github.com:pureconfig/pureconfig.git</url>
+    <connection>scm:git:git@github.com:pureconfig/pureconfig.git</connection>
+  </scm>
+    <developers>
+      <developer>
+        <id>derekmorr</id>
+        <name>Derek Morr</name>
+        <url>https://github.com/derekmorr</url>
+      </developer>
+    </developers>)
+
+osgiSettings
+
+OsgiKeys.exportPackage := Seq("pureconfig.module.cats.*")
+
+OsgiKeys.privatePackage := Seq()
+
+OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")

--- a/modules/cats/src/main/scala/pureconfig/module/Cats.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/Cats.scala
@@ -1,0 +1,22 @@
+package pureconfig.module
+
+import pureconfig.error.{ ConfigReaderFailure, ConfigValueLocation }
+
+object Cats {
+
+  /**
+   * A failure representing an unexpected empty traversable
+   *
+   * @param typ the type that was attempted to be converted to from an empty string
+   * @param location an optional location of the ConfigValue that raised the
+   *                 failure
+   * @param path an optional path to the value which was an unexpected empty string
+   */
+  final case class EmptyTraversableFound(typ: String, location: Option[ConfigValueLocation], path: Option[String]) extends ConfigReaderFailure {
+    def description = s"Empty collection found when trying to convert to $typ."
+
+    def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
+      this.copy(location = location orElse parentLocation, path = path.map(parentKey + "." + _) orElse Some(parentKey))
+  }
+
+}

--- a/modules/cats/src/main/scala/pureconfig/module/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/package.scala
@@ -8,7 +8,8 @@ import com.typesafe.config.ConfigValue
 import pureconfig.{ ConfigReader, ConfigWriter }
 import pureconfig.ConfigReader.{ fromFunction => fromFunctionReader }
 import pureconfig.ConfigWriter.{ fromFunction => fromFunctionWriter }
-import pureconfig.error.{ ConfigReaderFailures, ConfigValueLocation, EmptyTraversableFound }
+import pureconfig.error.{ ConfigReaderFailures, ConfigValueLocation }
+import pureconfig.module.Cats.EmptyTraversableFound
 
 /**
  * [[ConfigReader]] and [[ConfigWriter]] instances for cats data structures.

--- a/modules/cats/src/main/scala/pureconfig/module/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/package.scala
@@ -1,0 +1,37 @@
+package pureconfig.module
+
+import scala.language.higherKinds
+import scala.reflect.ClassTag
+
+import _root_.cats.data.{ NonEmptyList, NonEmptyVector }
+import com.typesafe.config.ConfigValue
+import pureconfig.{ ConfigReader, ConfigWriter }
+import pureconfig.ConfigReader.{ fromFunction => fromFunctionReader }
+import pureconfig.ConfigWriter.{ fromFunction => fromFunctionWriter }
+import pureconfig.error.{ ConfigReaderFailures, ConfigValueLocation, EmptyTraversableFound }
+
+/**
+ * [[ConfigReader]] and [[ConfigWriter]] instances for cats data structures.
+ */
+package object cats {
+
+  private[pureconfig] def fromNonEmpty[F[_], G[_], T](fromFT: F[T] => Option[G[T]])(configValue: ConfigValue)(implicit ct: ClassTag[F[T]], fReader: ConfigReader[F[T]]): Either[ConfigReaderFailures, G[T]] =
+    fReader.from(configValue).right.flatMap { ft =>
+      fromFT(ft) match {
+        case None => Left(ConfigReaderFailures(EmptyTraversableFound(ct.toString, ConfigValueLocation(configValue), None)))
+        case Some(nonEmpty) => Right(nonEmpty)
+      }
+    }
+
+  implicit def nonEmptyListReader[T](implicit listReader: ConfigReader[List[T]]): ConfigReader[NonEmptyList[T]] =
+    fromFunctionReader(fromNonEmpty[List, NonEmptyList, T](NonEmptyList.fromList))
+
+  implicit def nonEmptyListWriter[T](implicit listWriter: ConfigWriter[List[T]]): ConfigWriter[NonEmptyList[T]] =
+    fromFunctionWriter(nel => listWriter.to(nel.toList))
+
+  implicit def nonEmptyVectorReader[T](implicit vectorReader: ConfigReader[Vector[T]]): ConfigReader[NonEmptyVector[T]] =
+    fromFunctionReader(fromNonEmpty[Vector, NonEmptyVector, T](NonEmptyVector.fromVector))
+
+  implicit def nonEmptyVectorWriter[T](implicit vectorWriter: ConfigWriter[Vector[T]]): ConfigWriter[NonEmptyVector[T]] =
+    fromFunctionWriter(nonEmptyVector => vectorWriter.to(nonEmptyVector.toVector))
+}

--- a/modules/cats/src/main/tut/README.md
+++ b/modules/cats/src/main/tut/README.md
@@ -4,7 +4,7 @@ Adds support for selected [cats](http://typelevel.org/cats/) classes to PureConf
 
 ## Add pureconfig-cats to your project
 
-In addition to [core pureconfig](https://github.com/melrief/pureconfig), you'll need:
+In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
 libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats" % "0.7.1"

--- a/modules/cats/src/main/tut/README.md
+++ b/modules/cats/src/main/tut/README.md
@@ -1,0 +1,41 @@
+# Cats module for PureConfig
+
+Adds support for selected [cats](http://typelevel.org/cats/) classes to PureConfig.
+
+## Add pureconfig-cats to your project
+
+In addition to [core pureconfig](https://github.com/melrief/pureconfig), you'll need:
+
+```scala
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats" % "0.7.1"
+```
+
+## Example
+
+To load a `NonEmptyList[Int]` into a configuration, we need a class to hold our configuration:
+
+```tut:silent
+import cats.data.{NonEmptyList, NonEmptyVector}
+import com.typesafe.config.ConfigFactory.parseString
+import pureconfig._
+import pureconfig.module.cats._
+
+case class MyConfig(numbers: NonEmptyList[Int])
+```
+
+We can read a `MyConfig` like:
+```tut:book
+val conf = parseString("""{ numbers: [1,2,3] }""")
+loadConfig[MyConfig](conf)
+```
+
+You can also load `NonEmptyVector`. First, define a case class for the config:
+
+```tut:silent
+case class MyVecConfig(numbers: NonEmptyVector[Int])
+```
+
+then load the config:
+```tut:book
+loadConfig[MyVecConfig](conf)
+```

--- a/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
@@ -1,0 +1,23 @@
+package pureconfig.module.cats
+
+import cats.data.{ NonEmptyList, NonEmptyVector }
+import com.typesafe.config.ConfigFactory
+import org.scalatest._
+import pureconfig.syntax._
+
+class CatsSuite extends FlatSpec with Matchers with EitherValues {
+
+  case class Numbers(numbers: NonEmptyList[Int])
+
+  it should "be able to read a config with a NonEmptyList" in {
+    val config = ConfigFactory.parseString(s"""{ numbers: [1,2,3] }""")
+    config.to[Numbers].right.value shouldEqual Numbers(NonEmptyList(1, List(2, 3)))
+  }
+
+  case class NumVec(numbers: NonEmptyVector[Int])
+
+  it should "be able to read a config with an NonEmptyVector" in {
+    val config = ConfigFactory.parseString(s"""{ numbers: [1,2,3] }""")
+    config.to[NumVec].right.value shouldEqual NumVec(NonEmptyVector(1, Vector(2, 3)))
+  }
+}

--- a/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
@@ -1,8 +1,10 @@
 package pureconfig.module.cats
 
 import cats.data.{ NonEmptyList, NonEmptyVector }
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigFactory.parseString
 import org.scalatest._
+import pureconfig.error.ConfigReaderFailures
+import pureconfig.module.Cats.EmptyTraversableFound
 import pureconfig.syntax._
 
 class CatsSuite extends FlatSpec with Matchers with EitherValues {
@@ -10,14 +12,26 @@ class CatsSuite extends FlatSpec with Matchers with EitherValues {
   case class Numbers(numbers: NonEmptyList[Int])
 
   it should "be able to read a config with a NonEmptyList" in {
-    val config = ConfigFactory.parseString(s"""{ numbers: [1,2,3] }""")
-    config.to[Numbers].right.value shouldEqual Numbers(NonEmptyList(1, List(2, 3)))
+    val config = parseString(s"""{ numbers: [1,2,3] }""")
+    config.to[Numbers] shouldEqual Right(Numbers(NonEmptyList(1, List(2, 3))))
+  }
+
+  it should "return an EmptyTraversableFound when reading empty lists into NonEmptyList" in {
+    val config = parseString("{ numbers: [] }")
+    config.to[Numbers] shouldEqual
+      Left(ConfigReaderFailures(EmptyTraversableFound("scala.collection.immutable.List", None, Some("numbers")), Nil))
   }
 
   case class NumVec(numbers: NonEmptyVector[Int])
 
   it should "be able to read a config with an NonEmptyVector" in {
-    val config = ConfigFactory.parseString(s"""{ numbers: [1,2,3] }""")
-    config.to[NumVec].right.value shouldEqual NumVec(NonEmptyVector(1, Vector(2, 3)))
+    val config = parseString(s"""{ numbers: [1,2,3] }""")
+    config.to[NumVec] shouldEqual Right(NumVec(NonEmptyVector(1, Vector(2, 3))))
+  }
+
+  it should "return an EmptyTraversableFound when reading empty lists into NonEmptyVector" in {
+    val config = parseString("{ numbers: [] }")
+    config.to[NumVec] shouldEqual
+      Left(ConfigReaderFailures(EmptyTraversableFound("scala.collection.immutable.Vector", None, Some("numbers")), Nil))
   }
 }


### PR DESCRIPTION
This would fix #101.

I wonder if the `fromNonEmpty` and `nonEmptyTo` functions should be moved into `core` as other modules might want to reuse them.