### PR TITLE
I hope this fixes test failures with arbitrary Durations.

### DIFF
--- a/core/src/test/scala/pureconfig/DurationConvertSuite.scala
+++ b/core/src/test/scala/pureconfig/DurationConvertSuite.scala
@@ -7,10 +7,10 @@ import org.scalatest.{ EitherValues, FlatSpec, Matchers }
 import org.scalatest.Inspectors._
 import pureconfig.error.CannotConvert
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
+import DurationConvertSuite._
 
 class DurationConvertSuite extends FlatSpec with Matchers with EitherValues {
-  import DurationConvert.{ fromDuration => fromD }
   "Converting a Duration to a String" should "pick an appropriate unit when dealing with whole units less than the next step up" in {
     fromD(Duration(14, TimeUnit.DAYS)) shouldBe "14d"
     fromD(Duration(16, TimeUnit.HOURS)) shouldBe "16h"
@@ -40,7 +40,6 @@ class DurationConvertSuite extends FlatSpec with Matchers with EitherValues {
     fromS(fromD(expected)).right.value shouldBe expected
   }
 
-  val fromS = DurationConvert.fromString(_: String)(None)
   "Converting a String to a Duration" should "succeed for known units" in {
     fromS("1d") shouldBe Right(Duration(1, TimeUnit.DAYS))
     fromS("47h") shouldBe Right(Duration(47, TimeUnit.HOURS))
@@ -91,4 +90,36 @@ class DurationConvertSuite extends FlatSpec with Matchers with EitherValues {
   it should "correctly round trip when converting Duration.Inf" in {
     fromS(fromD(Duration.Inf)) shouldEqual Right(Duration.Inf)
   }
+  it should "convert a value larger than 2^52" in {
+    fromS("8092048641075763 ns").right.value shouldBe Duration(8092048641075763L, NANOSECONDS)
+  }
+  it should "round trip a value which is greater than 2^52" in {
+    val expected = Duration(781251341142500992L, NANOSECONDS)
+    fromS(fromD(expected)).right.value shouldBe expected
+  }
+  it should "round trip a value < 2^52 which is > 2^52 when converted to milliseconds" in {
+    val expected = Duration(781251341142501L, MICROSECONDS)
+    fromS(fromD(expected)).right.value shouldBe expected
+  }
+  it should "freak when given a value larger than 2^64" in {
+    val result = dcc.from(scc.to("12345678901234567890 ns"))
+    result shouldBe a[Left[_, _]]
+    val ex = result.left.value.head.asInstanceOf[error.ThrowableFailure].throwable
+    ex.getMessage should include regex "trying to construct too large duration"
+  }
+  it should "parse a fractional value" in {
+    val expected = 1.5.minutes
+    fromS(fromD(expected)).right.value shouldBe expected
+  }
+  it should "change the units on a fractional value, failing to round trip in the config representation" in {
+    val duration = dcc.from(scc.to("1.5 minutes")).right.value
+    val rep = scc.from(dcc.to(duration)).right.value shouldBe "90s" // Not "1.5 minutes" as we might hope
+  }
+}
+
+object DurationConvertSuite {
+  val scc = implicitly[ConfigConvert[String]]
+  val dcc = implicitly[ConfigConvert[Duration]]
+  val fromD = DurationConvert.fromDuration(_: Duration)
+  val fromS = DurationConvert.fromString(_: String)(None)
 }


### PR DESCRIPTION
The key was to parse the value as a `Long` first and then as a `Double` if that failed.

Sadly there are some automatic formatting changes included in this diff.

(Note I created this PR against @melrief's branch. I'm not sure if that was the best thing to do, but...)