### PR TITLE
support for Pattern and Regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     making them easier to compose.
   - New mechanism to read and write [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html).
     The readers and writers of the inner type are used instead of the ones for products.
+  - `ConfigReader` and `ConfigWriter` instances for `Pattern` and `Regex`.
 - Bug fixes
   - `Duration.Undefined` is correctly handled when reading and writing configurations. [[#184](https://github.com/melrief/pureconfig/issues/184)]
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Currently supported types for fields are:
   configured first - see [Configurable converters](docs/configurable-converters.md));
 - [`java.util.UUID`](https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html);
 - [`java.nio.file.Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html);
+- [`java.util.regex.Pattern`](https://docs.oracle.com/javase/8/docs/api/index.html?java/util/regex/Pattern.html) and [`scala.util.matching.Regex`](https://www.scala-lang.org/files/archive/api/current/scala/util/matching/Regex.html);
 - Typesafe `ConfigValue`, `ConfigObject` and `ConfigList`;
 - value classes for which readers and writers of the inner type are used;
 - case classes;

--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -50,8 +50,8 @@ trait UriAndPathReaders {
  */
 trait RegexReaders {
 
-  implicit val patternReader = ConfigReader.fromNonEmptyString[Pattern](catchReadError(Pattern.compile))
-  implicit val regexReader = ConfigReader.fromNonEmptyString[Regex](catchReadError(new Regex(_)))
+  implicit val patternReader = ConfigReader.fromString[Pattern](catchReadError(Pattern.compile))
+  implicit val regexReader = ConfigReader.fromString[Regex](catchReadError(new Regex(_)))
 }
 
 /**

--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -5,8 +5,10 @@ import java.nio.file.{ Path, Paths }
 import java.time._
 import java.time.{ Duration => JavaDuration }
 import java.util.UUID
+import java.util.regex.Pattern
 
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.util.matching.Regex
 
 import com.typesafe.config._
 import pureconfig.ConvertHelpers._
@@ -41,6 +43,15 @@ trait UriAndPathReaders {
   implicit val uuidConfigReader = ConfigReader.fromNonEmptyString[UUID](catchReadError(UUID.fromString))
   implicit val pathConfigReader = ConfigReader.fromString[Path](catchReadError(Paths.get(_)))
   implicit val uriConfigReader = ConfigReader.fromString[URI](catchReadError(new URI(_)))
+}
+
+/**
+ * Trait containing `ConfigReader` instances for classes related to regular expressions.
+ */
+trait RegexReaders {
+
+  implicit val patternReader = ConfigReader.fromNonEmptyString[Pattern](catchReadError(Pattern.compile))
+  implicit val regexReader = ConfigReader.fromNonEmptyString[Regex](catchReadError(new Regex(_)))
 }
 
 /**
@@ -125,6 +136,7 @@ trait TypesafeConfigReaders {
 trait BasicReaders
   extends PrimitiveReaders
   with UriAndPathReaders
+  with RegexReaders
   with JavaTimeReaders
   with DurationReaders
   with TypesafeConfigReaders

--- a/core/src/main/scala/pureconfig/BasicWriters.scala
+++ b/core/src/main/scala/pureconfig/BasicWriters.scala
@@ -5,8 +5,10 @@ import java.nio.file.Path
 import java.time._
 import java.time.{ Duration => JavaDuration }
 import java.util.UUID
+import java.util.regex.Pattern
 
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.util.matching.Regex
 
 import com.typesafe.config._
 
@@ -33,6 +35,15 @@ trait UriAndPathWriters {
   implicit val uuidConfigWriter = ConfigWriter.toDefaultString[UUID]
   implicit val pathConfigWriter = ConfigWriter.toDefaultString[Path]
   implicit val uriConfigWriter = ConfigWriter.toDefaultString[URI]
+}
+
+/**
+ * Trait containing `ConfigWriter` instances for classes related to regular expressions.
+ */
+trait RegexWriters {
+
+  implicit val patternWriter = ConfigWriter.toString[Pattern](_.pattern)
+  implicit val regexWriter = ConfigWriter.toString[Regex](_.pattern.pattern) // Regex.regex isn't supported until 2.11
 }
 
 /**
@@ -92,6 +103,7 @@ trait TypesafeConfigWriters {
 trait BasicWriters
   extends PrimitiveWriters
   with UriAndPathWriters
+  with RegexWriters
   with JavaTimeWriters
   with DurationWriters
   with TypesafeConfigWriters

--- a/core/src/main/tut/README.md
+++ b/core/src/main/tut/README.md
@@ -117,6 +117,7 @@ Currently supported types for fields are:
   configured first - see [Configurable converters](docs/configurable-converters.md));
 - [`java.util.UUID`](https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html);
 - [`java.nio.file.Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html);
+- [`java.util.regex.Pattern`](https://docs.oracle.com/javase/8/docs/api/index.html?java/util/regex/Pattern.html) and [`scala.util.matching.Regex`](https://www.scala-lang.org/files/archive/api/current/scala/util/matching/Regex.html);
 - Typesafe `ConfigValue`, `ConfigObject` and `ConfigList`;
 - value classes for which readers and writers of the inner type are used;
 - case classes;

--- a/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -10,6 +10,7 @@ import java.util.regex.Pattern
 import com.typesafe.config._
 import pureconfig.arbitrary._
 import pureconfig.data.Percentage
+import pureconfig.equality._
 import pureconfig.error.{ CannotConvert, EmptyStringFound }
 import scala.collection.JavaConverters._
 import scala.collection.immutable
@@ -98,9 +99,9 @@ class BasicConvertersSuite extends BaseSuite {
 
   checkArbitrary[Option[Int]]
 
-  checkReadF[Pattern, String](Pattern.compile("(a|b)") -> ConfigValueFactory.fromAnyRef("(a|b)"))(_.pattern)
+  checkRead[Pattern](Pattern.compile("(a|b)") -> ConfigValueFactory.fromAnyRef("(a|b)"))
 
-  checkReadF[Regex, String](new Regex("(a|b)") -> ConfigValueFactory.fromAnyRef("(a|b)"))(_.pattern.pattern)
+  checkRead[Regex](new Regex("(a|b)") -> ConfigValueFactory.fromAnyRef("(a|b)"))
 
   checkFailure[Pattern, CannotConvert](ConfigValueFactory.fromAnyRef("(a|b")) // missing closing ')'
   checkFailure[Regex, CannotConvert](ConfigValueFactory.fromAnyRef("(a|b")) // missing closing ')'

--- a/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -5,15 +5,16 @@ import java.nio.file.Path
 import java.time._
 import java.time.{ Duration => JavaDuration }
 import java.util.UUID
+import java.util.regex.Pattern
 
 import com.typesafe.config._
 import pureconfig.arbitrary._
 import pureconfig.data.Percentage
 import pureconfig.error.{ CannotConvert, EmptyStringFound }
-
 import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.util.matching.Regex
 
 class BasicConvertersSuite extends BaseSuite {
 
@@ -96,6 +97,13 @@ class BasicConvertersSuite extends BaseSuite {
   checkArbitrary[immutable.Vector[Short]]
 
   checkArbitrary[Option[Int]]
+
+  checkReadF[Pattern, String](Pattern.compile("(a|b)") -> ConfigValueFactory.fromAnyRef("(a|b)"))(_.pattern)
+
+  checkReadF[Regex, String](new Regex("(a|b)") -> ConfigValueFactory.fromAnyRef("(a|b)"))(_.pattern.pattern)
+
+  checkFailure[Pattern, CannotConvert](ConfigValueFactory.fromAnyRef("(a|b")) // missing closing ')'
+  checkFailure[Regex, CannotConvert](ConfigValueFactory.fromAnyRef("(a|b")) // missing closing ')'
 
   checkRead[URL](
     new URL("http://host/path?with=query&param") -> ConfigValueFactory.fromAnyRef("http://host/path?with=query&param"))

--- a/core/src/test/scala/pureconfig/ConfigConvertChecks.scala
+++ b/core/src/test/scala/pureconfig/ConfigConvertChecks.scala
@@ -27,7 +27,6 @@ trait ConfigConvertChecks { this: FlatSpec with Matchers with GeneratorDrivenPro
     it should s"read an arbitrary ${tag.runtimeClass.getCanonicalName}" in forAll {
       (t: T) =>
         val result = cc.from(cc.to(t))
-        result shouldBe a[Right[_, _]]
         result.right.value shouldEqual t
     }
 
@@ -93,9 +92,8 @@ trait ConfigConvertChecks { this: FlatSpec with Matchers with GeneratorDrivenPro
       it should s"fail when it tries to read a value of type ${tag.runtimeClass.getCanonicalName} " +
         s"from ${value.render(ConfigRenderOptions.concise())}" in {
           val result = cr.from(value)
-          result shouldBe a[Left[_, _]]
-          result.left.get.toList should have size 1
-          result.left.get.head shouldBe a[E]
+          result.left.value.toList should have size 1
+          result.left.value.head shouldBe a[E]
         }
     }
 }

--- a/core/src/test/scala/pureconfig/equality/package.scala
+++ b/core/src/test/scala/pureconfig/equality/package.scala
@@ -1,0 +1,26 @@
+package pureconfig
+
+import java.util.regex.Pattern
+
+import scala.util.matching.Regex
+
+import org.scalactic.Equality
+import org.scalactic.TypeCheckedTripleEquals._
+
+package object equality {
+
+  implicit val patternEquality = new Equality[Pattern] {
+    def areEqual(a: Pattern, b: Any): Boolean = b match {
+      case bp: Pattern => a.pattern === bp.pattern
+      case _ => false
+    }
+  }
+
+  implicit val regexEquality = new Equality[Regex] {
+    override def areEqual(a: Regex, b: Any): Boolean = b match {
+      case r: Regex => patternEquality.areEqual(a.pattern, r.pattern)
+      case _ => false
+    }
+  }
+
+}

--- a/core/src/test/scala/pureconfig/equality/package.scala
+++ b/core/src/test/scala/pureconfig/equality/package.scala
@@ -9,16 +9,16 @@ import org.scalactic.TypeCheckedTripleEquals._
 
 package object equality {
 
-  implicit val patternEquality = new Equality[Pattern] {
+  implicit final val PatternEquality = new Equality[Pattern] {
     def areEqual(a: Pattern, b: Any): Boolean = b match {
       case bp: Pattern => a.pattern === bp.pattern
       case _ => false
     }
   }
 
-  implicit val regexEquality = new Equality[Regex] {
+  implicit final val RegexEquality = new Equality[Regex] {
     override def areEqual(a: Regex, b: Any): Boolean = b match {
-      case r: Regex => patternEquality.areEqual(a.pattern, r.pattern)
+      case r: Regex => PatternEquality.areEqual(a.pattern, r.pattern)
       case _ => false
     }
   }


### PR DESCRIPTION
Support for `java.util.regex.Pattern` and `scala.util.matching.Regex`.

I had to add a new function to core's test suite, `checkReadF` which applies a function to the `Right` value. This is because neither `Pattern` or `Regex` implement structural equality:

```scala
scala> import java.util.regex.Pattern
import java.util.regex.Pattern

scala> val p1 = Pattern.compile("a|b")
p1: java.util.regex.Pattern = a|b

scala> val p2 = Pattern.compile("a|b")
p2: java.util.regex.Pattern = a|b

scala> p1 == p2
res0: Boolean = false

scala> p1.pattern == p2.pattern
res1: Boolean = true
```

So I can't compare two `Pattern`s directly, but if I map them to Strings, via `.pattern()`, I can.

I'm open to suggestions on how to do this more elegantly.