### PR TITLE
support for Java Enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     The readers and writers of the inner type are used instead of the ones for products.
   - `ConfigReader` and `ConfigWriter` instances for `Pattern` and `Regex`.
   - `ConfigReader` and `ConfigWriter` for `java.io.File`
+  - `ConfigReader` and `ConfigWriter` for arbitrary Java Enums
 - Bug fixes
   - `Duration.Undefined` is correctly handled when reading and writing configurations. [[#184](https://github.com/melrief/pureconfig/issues/184)]
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Currently supported types for fields are:
 - `String`, `Boolean`, `Double` (standard
   and percentage format ending with `%`), `Float` (also supporting percentage),
     `Int`, `Long`, `Short`, `URL`, `URI`, `Duration`, `FiniteDuration`;
+- [`java.lang.Enum`](https://docs.oracle.com/javase/8/docs/api/java/lang/Enum.html)
 - all collections implementing the `TraversableOnce` trait where the type of
   the elements is in this list;
 - `Option` for optional values, i.e. values that can or cannot be in the configuration;

--- a/core/src/main/scala/pureconfig/BasicWriters.scala
+++ b/core/src/main/scala/pureconfig/BasicWriters.scala
@@ -28,6 +28,14 @@ trait PrimitiveWriters {
 }
 
 /**
+ * Trait containing instance for `ConfigWriter` for Java Enum.
+ */
+trait JavaEnumWriter {
+
+  implicit def javaEnumWriter[T <: Enum[T]]: ConfigWriter[T] = ConfigWriter.toDefaultString[T]
+}
+
+/**
  * Trait containing `ConfigWriter` instances for classes related to file system paths and URIs.
  */
 trait UriAndPathWriters {
@@ -104,6 +112,7 @@ trait TypesafeConfigWriters {
  */
 trait BasicWriters
   extends PrimitiveWriters
+  with JavaEnumWriter
   with UriAndPathWriters
   with RegexWriters
   with JavaTimeWriters

--- a/core/src/main/tut/README.md
+++ b/core/src/main/tut/README.md
@@ -109,6 +109,7 @@ Currently supported types for fields are:
 - `String`, `Boolean`, `Double` (standard
   and percentage format ending with `%`), `Float` (also supporting percentage),
     `Int`, `Long`, `Short`, `URL`, `URI`, `Duration`, `FiniteDuration`;
+- [`java.lang.Enum`](https://docs.oracle.com/javase/8/docs/api/java/lang/Enum.html)
 - all collections implementing the `TraversableOnce` trait where the type of
   the elements is in this list;
 - `Option` for optional values, i.e. values that can or cannot be in the configuration;

--- a/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -73,6 +73,12 @@ class BasicConvertersSuite extends BaseSuite {
 
   checkArbitrary[File]
 
+  checkRead[DayOfWeek]((DayOfWeek.MONDAY, ConfigValueFactory.fromAnyRef("MONDAY")))
+  checkRead[Month]((Month.JULY, ConfigValueFactory.fromAnyRef("JULY")))
+  checkFailure[DayOfWeek, CannotConvert](
+    ConfigValueFactory.fromAnyRef("thursday"), // lowercase string vs upper case enum
+    ConfigValueFactory.fromAnyRef("this is not a day")) // no such value
+
   checkArbitrary[immutable.HashSet[String]]
 
   checkArbitrary[immutable.List[Float]]


### PR DESCRIPTION
This PR adds support for loading arbitrary Java Enums. For example, we could load `java.time.DayOfWeek` or `java.lang.Character.UnicodeScript`, etc. It would close #230.