### PR TITLE
scala-xml module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,10 @@ lazy val joda = (project in file("modules/joda")).
   dependsOn(core).
   dependsOn(core % "test->test") // In order to reuse the date/time related scalacheck generators.
 
+lazy val scalaxml = (project in file("modules/scala-xml")).
+  settings(settings).
+  dependsOn(core)
+
 lazy val squants = (project in file("modules/squants")).
   settings(settings).
   dependsOn(core)

--- a/modules/scala-xml/README.md
+++ b/modules/scala-xml/README.md
@@ -1,0 +1,49 @@
+# Scala-XML module for PureConfig
+
+Adds support for XML via [Scala XML](https://github.com/scala/scala-xml) to PureConfig.
+
+## Add pureconfig-scala-xml to your project
+
+In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
+
+```scala
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-scala-xml" % "0.7.1"
+```
+
+## Example
+
+To load an `Elem` into a configuration, we'll create a class to hold our configuration:
+
+```scala
+import scala.xml.Elem
+import com.typesafe.config.ConfigFactory.parseString
+import pureconfig._
+import pureconfig.module.scalaxml._
+
+case class Config(people: Elem)
+```
+
+We can read a `Config` like:
+```scala
+val conf = parseString(
+  s"""{ people = 
+    |   \"\"\"<people>
+    |      <person firstName="A" lastName="Person" />
+    |      <person firstName="Another" lastName="Person" />
+    |    </people>\"\"\"
+    |}""".stripMargin)
+// conf: com.typesafe.config.Config = Config(SimpleConfigObject({"people":"<people>\n      <person firstName=\"A\" lastName=\"Person\" />\n      <person firstName=\"Another\" lastName=\"Person\" />\n    </people>"}))
+
+loadConfig[Config](conf)
+// res1: Either[pureconfig.error.ConfigReaderFailures,Config] =
+// Right(Config(<people>
+//       <person lastName="Person" firstName="A"/>
+//       <person lastName="Person" firstName="Another"/>
+//     </people>))
+```
+
+## Notes
+
+All XML values are deserialized into `Elem`. 
+
+In HOCON files, if the XML contains quotes, you will need to wrap the XML in triple-quotes, as in the example above.

--- a/modules/scala-xml/build.sbt
+++ b/modules/scala-xml/build.sbt
@@ -1,0 +1,61 @@
+name := "pureconfig-scala-xml"
+
+organization := "com.github.pureconfig"
+
+homepage := Some(url("https://github.com/pureconfig/pureconfig"))
+
+licenses := Seq("Mozilla Public License, version 2.0" -> url("https://www.mozilla.org/MPL/2.0/"))
+
+resolvers ++= Seq(
+  Resolver.sonatypeRepo("releases"),
+  Resolver.sonatypeRepo("snapshots")
+)
+
+libraryDependencies ++= Seq(
+  Dependencies.scalaMacrosParadise,
+  Dependencies.scalaTest,
+  Dependencies.scalaCheck
+)
+
+// on scala 2.11+, pull in newer scala-xml library
+libraryDependencies ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+      Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.6")
+    case _ =>
+      Nil
+  }
+}
+
+publishMavenStyle := true
+
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+}
+
+publishArtifact in Test := false
+
+pomExtra := (
+  <scm>
+    <url>git@github.com:pureconfig/pureconfig.git</url>
+    <connection>scm:git:git@github.com:pureconfig/pureconfig.git</connection>
+  </scm>
+    <developers>
+      <developer>
+        <id>derekmorr</id>
+        <name>Derek Morr</name>
+        <url>https://github.com/derekmorr</url>
+      </developer>
+    </developers>)
+
+osgiSettings
+
+OsgiKeys.exportPackage := Seq("pureconfig.module.scalaxml.*")
+
+OsgiKeys.privatePackage := Seq()
+
+OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")

--- a/modules/scala-xml/src/main/scala/pureconfig/module/package.scala
+++ b/modules/scala-xml/src/main/scala/pureconfig/module/package.scala
@@ -1,0 +1,19 @@
+package pureconfig.module
+
+import scala.xml.{ Elem, XML }
+
+import pureconfig.{ ConfigReader, ConfigWriter }
+import pureconfig.ConvertHelpers.catchReadError
+
+/**
+ * [[ConfigReader]] and [[ConfigWriter]] instances for Scala-XML's data structures.
+ */
+package object scalaxml {
+
+  implicit def elemReader: ConfigReader[Elem] =
+    ConfigReader.fromString[Elem](catchReadError(XML.loadString))
+
+  implicit def elemWriter: ConfigWriter[Elem] =
+    ConfigWriter.toDefaultString[Elem]
+
+}

--- a/modules/scala-xml/src/main/tut/README.md
+++ b/modules/scala-xml/src/main/tut/README.md
@@ -1,0 +1,43 @@
+# Scala-XML module for PureConfig
+
+Adds support for XML via [Scala XML](https://github.com/scala/scala-xml) to PureConfig.
+
+## Add pureconfig-scala-xml to your project
+
+In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
+
+```scala
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-scala-xml" % "0.7.1"
+```
+
+## Example
+
+To load an `Elem` into a configuration, we'll create a class to hold our configuration:
+
+```tut:silent
+import scala.xml.Elem
+import com.typesafe.config.ConfigFactory.parseString
+import pureconfig._
+import pureconfig.module.scalaxml._
+
+case class Config(people: Elem)
+```
+
+We can read a `Config` like:
+```tut:book
+val conf = parseString(
+  s"""{ people = 
+    |   \"\"\"<people>
+    |      <person firstName="A" lastName="Person" />
+    |      <person firstName="Another" lastName="Person" />
+    |    </people>\"\"\"
+    |}""".stripMargin)
+loadConfig[Config](conf)
+```
+
+## Notes
+
+All XML values are deserialized into `Elem`. 
+
+In HOCON files, if the XML contains quotes, you will need to either wrap the XML in triple-quotes or escape the 
+embedded quotes.

--- a/modules/scala-xml/src/test/scala/pureconfig/module/scalaxml/ScalaXMLSuite.scala
+++ b/modules/scala-xml/src/test/scala/pureconfig/module/scalaxml/ScalaXMLSuite.scala
@@ -1,0 +1,31 @@
+package pureconfig.module.scalaxml
+
+import scala.xml.Elem
+
+import com.typesafe.config.ConfigFactory.parseString
+import org.scalatest._
+import pureconfig.syntax._
+
+class ScalaXMLSuite extends FlatSpec with Matchers with EitherValues {
+
+  case class Config(people: Elem)
+
+  val sampleXML: Elem =
+    <people>
+      <person firstName="foo" lastName="bar"/>
+      <person firstName="blah" lastName="stuff"/>
+    </people>
+
+  it should "be able to read a config with XML" in {
+    val config = parseString(
+      s"""{ people =
+         |    \"\"\"$sampleXML\"\"\"
+         | }""".stripMargin)
+    config.to[Config] shouldEqual Right(Config(sampleXML))
+  }
+
+  it should "return an error when reading invalid XML " in {
+    val config = parseString("{ people: <people> }")
+    config.to[Config] shouldBe 'left
+  }
+}


### PR DESCRIPTION
This adds a module for loading XML. Admittedly, loading XML from HOCON is an unusual use-case. This was more inspired by refined's XML support.

I'm not sure it's worth merging, but I offer it for what it's worth.