### PR TITLE
upgrade ammonite-repl to 0.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val settings = Seq(
     case Some((2, scalaMajor)) if scalaMajor >= 11 => scala211Flags
   }.toList.flatten,
   // use sbt <module_name>/test:console to run an ammonite console
-  libraryDependencies += "com.lihaoyi" % "ammonite" % "0.8.5" % "test" cross CrossVersion.patch,
+  libraryDependencies += "com.lihaoyi" % "ammonite" % "0.9.0" % "test" cross CrossVersion.patch,
   initialCommands in (Test, console) := """ammonite.Main().run()""",
   initialize := {
     val required = "1.8"


### PR DESCRIPTION
Ammonite updated their REPL to 0.9.0. Since we just updated dependencies (in #229), we should pull in this version.