### PR TITLE
Distinguish parsing failures from conversion failures in ConfigReaderException

### DIFF
--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -106,7 +106,7 @@ trait DurationReaders {
     val fromString: String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, FiniteDuration] = { string => location =>
       DurationConvert.fromString(string)(location).right.flatMap {
         case d: FiniteDuration => Right(d)
-        case _ => Left(CannotConvert(string, "FiniteDuration", s"Couldn't parse '$string' into a FiniteDuration because it's infinite.", location, None))
+        case _ => Left(CannotConvert(string, "FiniteDuration", s"Couldn't parse '$string' into a FiniteDuration because it's infinite.", location, ""))
       }
     }
     ConfigReader.fromNonEmptyString[FiniteDuration](fromString)
@@ -121,14 +121,14 @@ trait TypesafeConfigReaders {
   implicit val configConfigReader: ConfigReader[Config] = new ConfigReader[Config] {
     override def from(config: ConfigValue): Either[ConfigReaderFailures, Config] = config match {
       case co: ConfigObject => Right(co.toConfig)
-      case other => fail(WrongType(other.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(config), None))
+      case other => fail(WrongType(other.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(config), ""))
     }
   }
 
   implicit val configObjectConfigReader: ConfigReader[ConfigObject] = new ConfigReader[ConfigObject] {
     override def from(config: ConfigValue): Either[ConfigReaderFailures, ConfigObject] = config match {
       case c: ConfigObject => Right(c)
-      case other => fail(WrongType(other.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(config), None))
+      case other => fail(WrongType(other.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(config), ""))
     }
   }
 
@@ -139,7 +139,7 @@ trait TypesafeConfigReaders {
   implicit val configListConfigReader: ConfigReader[ConfigList] = new ConfigReader[ConfigList] {
     override def from(config: ConfigValue): Either[ConfigReaderFailures, ConfigList] = config match {
       case c: ConfigList => Right(c)
-      case other => fail(WrongType(other.valueType, Set(ConfigValueType.LIST), ConfigValueLocation(config), None))
+      case other => fail(WrongType(other.valueType, Set(ConfigValueType.LIST), ConfigValueLocation(config), ""))
     }
   }
 }

--- a/core/src/main/scala/pureconfig/ConvertHelpers.scala
+++ b/core/src/main/scala/pureconfig/ConvertHelpers.scala
@@ -22,7 +22,7 @@ trait ConvertHelpers {
 
   def fail[A](failure: ConfigReaderFailure): Either[ConfigReaderFailures, A] = Left(ConfigReaderFailures(failure))
 
-  def failWithThrowable[A](throwable: Throwable): Option[ConfigValueLocation] => Either[ConfigReaderFailures, A] = location => fail[A](ThrowableFailure(throwable, location, None))
+  def failWithThrowable[A](throwable: Throwable): Option[ConfigValueLocation] => Either[ConfigReaderFailures, A] = location => fail[A](ThrowableFailure(throwable, location, ""))
 
   private[pureconfig] def improveFailures[Z](result: Either[ConfigReaderFailures, Z], keyStr: String, location: Option[ConfigValueLocation]): Either[ConfigReaderFailures, Z] =
     result.left.map {
@@ -40,7 +40,7 @@ trait ConvertHelpers {
 
   private[pureconfig] def tryToEither[T](t: Try[T]): Option[ConfigValueLocation] => Either[ConfigReaderFailure, T] = t match {
     case Success(v) => _ => Right(v)
-    case Failure(e) => location => Left(ThrowableFailure(e, location, None))
+    case Failure(e) => location => Left(ThrowableFailure(e, location, ""))
   }
 
   private[pureconfig] def stringToTryConvert[T](fromF: String => Try[T]): ConfigValue => Either[ConfigReaderFailures, T] =
@@ -62,14 +62,14 @@ trait ConvertHelpers {
     }
 
   private[pureconfig] def ensureNonEmpty[T](implicit ct: ClassTag[T]): String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, String] = {
-    case "" => location => Left(EmptyStringFound(ct.toString(), location, None))
+    case "" => location => Left(EmptyStringFound(ct.toString(), location, ""))
     case x => _ => Right(x)
   }
 
   def catchReadError[T](f: String => T)(implicit ct: ClassTag[T]): String => Option[ConfigValueLocation] => Either[CannotConvert, T] =
     string => location =>
       try Right(f(string)) catch {
-        case NonFatal(ex) => Left(CannotConvert(string, ct.toString(), ex.toString, location, None))
+        case NonFatal(ex) => Left(CannotConvert(string, ct.toString(), ex.toString, location, ""))
       }
 
   /**
@@ -81,7 +81,7 @@ trait ConvertHelpers {
     string => location =>
       f(string) match {
         case Success(t) => Right(t)
-        case Failure(e) => Left(CannotConvert(string, ct.runtimeClass.getName, e.getLocalizedMessage, location, None))
+        case Failure(e) => Left(CannotConvert(string, ct.runtimeClass.getName, e.getLocalizedMessage, location, ""))
       }
 
   /**
@@ -93,7 +93,7 @@ trait ConvertHelpers {
     string => location =>
       f(string) match {
         case Some(t) => Right(t)
-        case None => Left(CannotConvert(string, ct.runtimeClass.getName, "", location, None))
+        case None => Left(CannotConvert(string, ct.runtimeClass.getName, "", location, ""))
       }
 }
 

--- a/core/src/main/scala/pureconfig/CoproductHint.scala
+++ b/core/src/main/scala/pureconfig/CoproductHint.scala
@@ -1,6 +1,6 @@
 package pureconfig
 
-import com.typesafe.config.{ ConfigObject, ConfigRenderOptions, ConfigValue, ConfigValueType }
+import com.typesafe.config.{ ConfigObject, ConfigValue, ConfigValueType }
 import pureconfig.error._
 import pureconfig.syntax._
 
@@ -81,7 +81,7 @@ class FieldCoproductHint[T](key: String) extends CoproductHint[T] {
 
   def to(cv: ConfigValue, name: String): Either[ConfigReaderFailures, ConfigValue] = cv match {
     case co: ConfigObject =>
-      if (co.containsKey(key)) Left(ConfigReaderFailures(CollidingKeys(key, co.get(key).render(ConfigRenderOptions.concise()), ConfigValueLocation(co))))
+      if (co.containsKey(key)) Left(ConfigReaderFailures(CollidingKeys(key, co.get(key), ConfigValueLocation(co))))
       else Right(Map(key -> fieldValue(name)).toConfig.withFallback(co.toConfig))
 
     case _ =>

--- a/core/src/main/scala/pureconfig/CoproductHint.scala
+++ b/core/src/main/scala/pureconfig/CoproductHint.scala
@@ -72,11 +72,11 @@ class FieldCoproductHint[T](key: String) extends CoproductHint[T] {
         case Some(fv) => fv.unwrapped match {
           case v: String if v == fieldValue(name) => Right(Some(cv))
           case _: String => Right(None)
-          case _ => Left(ConfigReaderFailures(WrongType(fv.valueType, Set(ConfigValueType.STRING), ConfigValueLocation(fv), Some(key))))
+          case _ => Left(ConfigReaderFailures(WrongType(fv.valueType, Set(ConfigValueType.STRING), ConfigValueLocation(fv), key)))
         }
         case None => Left(ConfigReaderFailures(KeyNotFound(key, ConfigValueLocation(co))))
       }
-    case _ => Left(ConfigReaderFailures(WrongType(cv.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(cv), None)))
+    case _ => Left(ConfigReaderFailures(WrongType(cv.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(cv), "")))
   }
 
   def to(cv: ConfigValue, name: String): Either[ConfigReaderFailures, ConfigValue] = cv match {
@@ -85,7 +85,7 @@ class FieldCoproductHint[T](key: String) extends CoproductHint[T] {
       else Right(Map(key -> fieldValue(name)).toConfig.withFallback(co.toConfig))
 
     case _ =>
-      Left(ConfigReaderFailures(WrongType(cv.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(cv), None)))
+      Left(ConfigReaderFailures(WrongType(cv.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(cv), "")))
   }
 
   def tryNextOnFail(name: String) = false
@@ -110,13 +110,13 @@ class EnumCoproductHint[T] extends CoproductHint[T] {
   def from(cv: ConfigValue, name: String) = cv.valueType match {
     case ConfigValueType.STRING if cv.unwrapped.toString == fieldValue(name) => Right(Some(Map.empty[String, String].toConfig))
     case ConfigValueType.STRING => Right(None)
-    case typ => Left(ConfigReaderFailures(WrongType(typ, Set(ConfigValueType.STRING), ConfigValueLocation(cv), None)))
+    case typ => Left(ConfigReaderFailures(WrongType(typ, Set(ConfigValueType.STRING), ConfigValueLocation(cv), "")))
   }
 
   def to(cv: ConfigValue, name: String) = cv match {
     case co: ConfigObject if co.isEmpty => Right(fieldValue(name).toConfig)
-    case _: ConfigObject => Left(ConfigReaderFailures(NonEmptyObjectFound(name, ConfigValueLocation(cv), None)))
-    case _ => Left(ConfigReaderFailures(WrongType(cv.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(cv), None)))
+    case _: ConfigObject => Left(ConfigReaderFailures(NonEmptyObjectFound(name, ConfigValueLocation(cv), "")))
+    case _ => Left(ConfigReaderFailures(WrongType(cv.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(cv), "")))
   }
 
   def tryNextOnFail(name: String) = false

--- a/core/src/main/scala/pureconfig/CoproductHint.scala
+++ b/core/src/main/scala/pureconfig/CoproductHint.scala
@@ -1,6 +1,6 @@
 package pureconfig
 
-import com.typesafe.config.{ ConfigObject, ConfigValue, ConfigValueType }
+import com.typesafe.config.{ ConfigObject, ConfigRenderOptions, ConfigValue, ConfigValueType }
 import pureconfig.error._
 import pureconfig.syntax._
 
@@ -81,7 +81,7 @@ class FieldCoproductHint[T](key: String) extends CoproductHint[T] {
 
   def to(cv: ConfigValue, name: String): Either[ConfigReaderFailures, ConfigValue] = cv match {
     case co: ConfigObject =>
-      if (co.containsKey(key)) Left(ConfigReaderFailures(CollidingKeys(key, co.get(key).toString, ConfigValueLocation(co))))
+      if (co.containsKey(key)) Left(ConfigReaderFailures(CollidingKeys(key, co.get(key).render(ConfigRenderOptions.concise()), ConfigValueLocation(co))))
       else Right(Map(key -> fieldValue(name)).toConfig.withFallback(co.toConfig))
 
     case _ =>

--- a/core/src/main/scala/pureconfig/DerivedReaders.scala
+++ b/core/src/main/scala/pureconfig/DerivedReaders.scala
@@ -46,7 +46,7 @@ trait DerivedReaders1 {
   private[pureconfig] trait WrappedDefaultValue[Wrapped, SubRepr <: HList, DefaultRepr <: HList] {
     def fromWithDefault(config: ConfigValue, default: DefaultRepr): Either[ConfigReaderFailures, SubRepr] = config match {
       case co: ConfigObject => fromConfigObject(co, default)
-      case other => fail(WrongType(other.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(other), None))
+      case other => fail(WrongType(other.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(other), ""))
     }
     def fromConfigObject(co: ConfigObject, default: DefaultRepr): Either[ConfigReaderFailures, SubRepr]
   }
@@ -97,7 +97,7 @@ trait DerivedReaders1 {
 
   implicit final def cNilConfigReader[Wrapped]: WrappedConfigReader[Wrapped, CNil] = new WrappedConfigReader[Wrapped, CNil] {
     override def from(config: ConfigValue): Either[ConfigReaderFailures, CNil] =
-      fail(NoValidCoproductChoiceFound(config, ConfigValueLocation(config), None))
+      fail(NoValidCoproductChoiceFound(config, ConfigValueLocation(config), ""))
   }
 
   implicit final def coproductConfigReader[Wrapped, Name <: Symbol, V, T <: Coproduct](
@@ -154,7 +154,7 @@ trait DerivedReaders1 {
           def keyValueReader(key: String, value: ConfigValue): Either[ConfigReaderFailures, (Int, T)] = {
             val keyResult = catchReadError(_.toInt)(implicitly)(key)(ConfigValueLocation(value)).left.flatMap(t => fail(CannotConvert(key, "Int",
               s"To convert an object to a collection, its keys must be read as Int but key $key has value" +
-                s"$value which cannot converted. Error: ${t.because}", ConfigValueLocation(value), Some(key))))
+                s"$value which cannot converted. Error: ${t.because}", ConfigValueLocation(value), key)))
             val valueResult = configConvert.value.from(value)
             combineResults(keyResult, valueResult)(_ -> _)
           }
@@ -169,7 +169,7 @@ trait DerivedReaders1 {
               r.result()
           }
         case other =>
-          fail(WrongType(other.valueType, Set(ConfigValueType.LIST, ConfigValueType.OBJECT), ConfigValueLocation(other), None))
+          fail(WrongType(other.valueType, Set(ConfigValueType.LIST, ConfigValueType.OBJECT), ConfigValueLocation(other), ""))
       }
     }
   }
@@ -191,7 +191,7 @@ trait DerivedReaders1 {
           }
 
         case other =>
-          fail(WrongType(other.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(other), None))
+          fail(WrongType(other.valueType, Set(ConfigValueType.OBJECT), ConfigValueLocation(other), ""))
       }
     }
   }

--- a/core/src/main/scala/pureconfig/DurationConvert.scala
+++ b/core/src/main/scala/pureconfig/DurationConvert.scala
@@ -23,7 +23,7 @@ private[pureconfig] object DurationConvert {
     } catch {
       case ex: NumberFormatException =>
         val err = s"${ex.getMessage}. (try a number followed by any of ns, us, ms, s, m, h, d)"
-        Left(CannotConvert(string, "Duration", err, location, None))
+        Left(CannotConvert(string, "Duration", err, location, ""))
     }
   }
 

--- a/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
+++ b/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
@@ -34,9 +34,9 @@ object ConfigFactoryWrapper {
       case e: ConfigException.Parse =>
         Left(ConfigReaderFailures(CannotParse(e.getLocalizedMessage, ConfigValueLocation(e.origin()))))
       case e: ConfigException =>
-        Left(ConfigReaderFailures(ThrowableFailure(e, ConfigValueLocation(e.origin()), None)))
+        Left(ConfigReaderFailures(ThrowableFailure(e, ConfigValueLocation(e.origin()), "")))
       case NonFatal(e) =>
-        Left(ConfigReaderFailures(ThrowableFailure(e, None, None)))
+        Left(ConfigReaderFailures(ThrowableFailure(e, None, "")))
     }
   }
 }

--- a/core/src/main/scala/pureconfig/error/CollidingKeysException.scala
+++ b/core/src/main/scala/pureconfig/error/CollidingKeysException.scala
@@ -1,4 +1,0 @@
-package pureconfig.error
-
-case class CollidingKeysException(key: String, existingValue: String)
-  extends IllegalArgumentException(s"The coproduct hint key '$key' collides with existing field '$existingValue'")

--- a/core/src/main/scala/pureconfig/error/ConfigReaderException.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderException.scala
@@ -12,24 +12,23 @@ final case class ConfigReaderException[T](failures: ConfigReaderFailures)(implic
     val linesBuffer = mutable.Buffer.empty[String]
     linesBuffer += s"Cannot convert configuration to a ${ct.runtimeClass.getName}. Failures are:"
 
-    val failuresByPath = failures.toList.groupBy(_.path)
-    val failuresWithPath = (failuresByPath - None).map({ case (k, v) => k.get -> v }).toList.sortBy(_._1)
-    val failuresWithoutPath = failuresByPath.getOrElse(None, Nil)
+    val failuresList = failures.toList
+    val parseFailures = failuresList.collect { case f: CannotParse => f }
+    val convertFailures = failuresList.collect { case f: ConvertFailure => f }
 
-    if (failuresWithoutPath.nonEmpty)
-      linesBuffer += "  in the configuration:"
+    val failuresByPath = convertFailures.toList.groupBy(_.path).toList.sortBy(_._1)
 
-    failuresWithoutPath.foreach { failure =>
-      linesBuffer += s"    - ${ConfigReaderException.descriptionWithLocation(failure)}"
+    parseFailures.foreach { failure =>
+      linesBuffer += s"  - ${ConfigReaderException.descriptionWithLocation(failure)}"
     }
 
-    if (failuresWithPath.nonEmpty && failuresWithoutPath.nonEmpty) {
+    if (parseFailures.nonEmpty && convertFailures.nonEmpty) {
       linesBuffer += ""
     }
 
-    failuresWithPath.foreach {
+    failuresByPath.foreach {
       case (p, failures) =>
-        linesBuffer += s"  at '$p':"
+        linesBuffer += (if (p.isEmpty) s"  at the root:" else s"  at '$p':")
         failures.foreach { failure =>
           linesBuffer += s"    - ${ConfigReaderException.descriptionWithLocation(failure)}"
         }

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -58,24 +58,19 @@ object ConfigValueLocation {
 
 /**
  * A representation of a failure that might be raised from reading a
- * ConfigValue. The failure contains an optional location of the ConfigValue
- * that raised the error.
+ * ConfigValue. The failure contains an optional physical location of the
+ * configuration that raised the failure.
  */
 abstract class ConfigReaderFailure {
-  /**
-   * The optional location of the ConfigReaderFailure.
-   */
-  def location: Option[ConfigValueLocation]
-
-  /**
-   * The optional path to the `ConfigValue` that raised the failure.
-   */
-  def path: Option[String]
-
   /**
    * A human-readable description of the failure.
    */
   def description: String
+
+  /**
+   * The optional location of the ConfigReaderFailure.
+   */
+  def location: Option[ConfigValueLocation]
 
   /**
    * Improves the context of this failure with the key to the parent node and
@@ -85,12 +80,24 @@ abstract class ConfigReaderFailure {
 }
 
 /**
+ * A representation of a failure that might be raised from converting from a
+ * `ConfigValue` to a given type. The failure contains a path to the
+ * `ConfigValue` that raised the error.
+ */
+abstract class ConvertFailure extends ConfigReaderFailure {
+  /**
+   * The path to the `ConfigValue` that raised the failure.
+   */
+  def path: String
+}
+
+/**
  * A failure representing the inability to convert a null value. Since a null
  * represents a missing value, the location of this failure is always None.
  */
-final case object CannotConvertNull extends ConfigReaderFailure {
+final case object CannotConvertNull extends ConvertFailure {
   val location = None
-  val path = None
+  val path = ""
 
   def description = "Cannot convert a null value."
 
@@ -106,14 +113,14 @@ final case object CannotConvertNull extends ConfigReaderFailure {
  * @param because the reason why the conversion was not possible
  * @param location an optional location of the ConfigValue that raised the
  *                 failure
- * @param path an optional path to the value that couldn't be converted
+ * @param path thet path to the value that couldn't be converted
  */
-final case class CannotConvert(value: String, toType: String, because: String, location: Option[ConfigValueLocation], path: Option[String]) extends ConfigReaderFailure {
+final case class CannotConvert(value: String, toType: String, because: String, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
 
   def description = s"Cannot convert '$value' to $toType: $because."
 
   def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = path.map(parentKey + "." + _) orElse Some(parentKey))
+    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
 }
 
 /**
@@ -126,8 +133,8 @@ final case class CannotConvert(value: String, toType: String, because: String, l
  * @param location an optional location of the ConfigValue that raised the
  *                 failure
  */
-final case class CollidingKeys(key: String, existingValue: String, location: Option[ConfigValueLocation]) extends ConfigReaderFailure {
-  def path = Some(key)
+final case class CollidingKeys(key: String, existingValue: String, location: Option[ConfigValueLocation]) extends ConvertFailure {
+  def path = key
 
   def description = s"Key with value '$existingValue' collides with a key necessary to disambiguate a coproduct."
 
@@ -142,8 +149,8 @@ final case class CollidingKeys(key: String, existingValue: String, location: Opt
  * @param location an optional location of the ConfigValue that raised the
  *                 failure
  */
-final case class KeyNotFound(key: String, location: Option[ConfigValueLocation]) extends ConfigReaderFailure {
-  def path = Some(key)
+final case class KeyNotFound(key: String, location: Option[ConfigValueLocation]) extends ConvertFailure {
+  def path = key
 
   def description = s"Key not found."
 
@@ -161,8 +168,8 @@ final case class KeyNotFound(key: String, location: Option[ConfigValueLocation])
  * @param location an optional location of the ConfigValue that raised the
  *                 failure
  */
-final case class UnknownKey(key: String, location: Option[ConfigValueLocation]) extends ConfigReaderFailure {
-  def path = Some(key)
+final case class UnknownKey(key: String, location: Option[ConfigValueLocation]) extends ConvertFailure {
+  def path = key
 
   def description = s"Unknown key."
 
@@ -177,13 +184,13 @@ final case class UnknownKey(key: String, location: Option[ConfigValueLocation]) 
  * @param expectedTypes the ConfigValueTypes that were expected
  * @param location an optional location of the ConfigValue that raised the
  *                 failure
- * @param path an optional path to the value that had a wrong type
+ * @param path the path to the value that had a wrong type
  */
-final case class WrongType(foundType: ConfigValueType, expectedTypes: Set[ConfigValueType], location: Option[ConfigValueLocation], path: Option[String]) extends ConfigReaderFailure {
+final case class WrongType(foundType: ConfigValueType, expectedTypes: Set[ConfigValueType], location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
   def description = s"""Expected type ${expectedTypes.mkString(" or ")}. Found $foundType instead."""
 
   def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = path.map(parentKey + "." + _) orElse Some(parentKey))
+    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
 }
 
 /**
@@ -192,13 +199,13 @@ final case class WrongType(foundType: ConfigValueType, expectedTypes: Set[Config
  * @param throwable the Throwable that was raised
  * @param location an optional location of the ConfigValue that raised the
  *                 failure
- * @param path an optional path to the value that raised the Throwable
+ * @param path the path to the value that raised the Throwable
  */
-final case class ThrowableFailure(throwable: Throwable, location: Option[ConfigValueLocation], path: Option[String]) extends ConfigReaderFailure {
+final case class ThrowableFailure(throwable: Throwable, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
   def description = s"${throwable.getMessage}."
 
   def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = path.map(parentKey + "." + _) orElse Some(parentKey))
+    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
 }
 
 /**
@@ -207,13 +214,13 @@ final case class ThrowableFailure(throwable: Throwable, location: Option[ConfigV
  * @param typ the type that was attempted to be converted to from an empty string
  * @param location an optional location of the ConfigValue that raised the
  *                 failure
- * @param path an optional path to the value which was an unexpected empty string
+ * @param path the path to the value which was an unexpected empty string
  */
-final case class EmptyStringFound(typ: String, location: Option[ConfigValueLocation], path: Option[String]) extends ConfigReaderFailure {
+final case class EmptyStringFound(typ: String, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
   def description = s"Empty string found when trying to convert to $typ."
 
   def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = path.map(parentKey + "." + _) orElse Some(parentKey))
+    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
 }
 
 /**
@@ -221,13 +228,13 @@ final case class EmptyStringFound(typ: String, location: Option[ConfigValueLocat
  *
  * @param typ the type for which a non-empty object was attempted to be written
  * @param location an optional location of the ConfigValue that raised the failure
- * @param path an optional path to the value which was an unexpected empty string
+ * @param path the path to the value which was an unexpected empty string
  */
-final case class NonEmptyObjectFound(typ: String, location: Option[ConfigValueLocation], path: Option[String]) extends ConfigReaderFailure {
+final case class NonEmptyObjectFound(typ: String, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
   def description = s"Non-empty object found when using EnumCoproductHint to write a $typ."
 
   def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = path.map(parentKey + "." + _) orElse Some(parentKey))
+    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
 }
 
 /**
@@ -236,14 +243,14 @@ final case class NonEmptyObjectFound(typ: String, location: Option[ConfigValueLo
  * @param value the ConfigValue that was unable to be mapped to a coproduct choice
  * @param location an optional location of the ConfigValue that raised the
  *                 failure
- * @param path an optional path to the value who doesn't have a valid choice for
- *             a coproduct
+ * @param path the path to the value who doesn't have a valid choice for a
+ *             coproduct
  */
-final case class NoValidCoproductChoiceFound(value: ConfigValue, location: Option[ConfigValueLocation], path: Option[String]) extends ConfigReaderFailure {
+final case class NoValidCoproductChoiceFound(value: ConfigValue, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
   def description = s"No valid coproduct choice found for '${value.render(ConfigRenderOptions.concise())}'."
 
   def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = path.map(parentKey + "." + _) orElse Some(parentKey))
+    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
 }
 
 /**
@@ -254,9 +261,6 @@ final case class NoValidCoproductChoiceFound(value: ConfigValue, location: Optio
  *                 failure
  */
 final case class CannotParse(msg: String, location: Option[ConfigValueLocation]) extends ConfigReaderFailure {
-  // Since this failure is raised when trying to parse a configuration, it isn't tied to a specific path
-  val path = None
-
   def description = "Unable to parse the configuration."
 
   def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -141,7 +141,7 @@ object CannotConvertNull {
  * @param because the reason why the conversion was not possible
  * @param location an optional location of the ConfigValue that raised the
  *                 failure
- * @param path thet path to the value that couldn't be converted
+ * @param path the path to the value that couldn't be converted
  */
 final case class CannotConvert(value: String, toType: String, because: String, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
 

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -8,7 +8,7 @@ import java.net.URL
 import com.typesafe.config.{ ConfigOrigin, ConfigRenderOptions, ConfigValue, ConfigValueType }
 
 /**
- * The physical location of a ConfigValue, represented by a url and a line
+ * The file system location of a ConfigValue, represented by a url and a line
  * number
  *
  * @param url the URL describing the origin of the ConfigValue
@@ -58,7 +58,7 @@ object ConfigValueLocation {
 
 /**
  * A representation of a failure that might be raised from reading a
- * ConfigValue. The failure contains an optional physical location of the
+ * ConfigValue. The failure contains an optional file system location of the
  * configuration that raised the failure.
  */
 abstract class ConfigReaderFailure {

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -134,10 +134,10 @@ final case class CannotConvert(value: String, toType: String, because: String, l
  * @param location an optional location of the ConfigValue that raised the
  *                 failure
  */
-final case class CollidingKeys(key: String, existingValue: String, location: Option[ConfigValueLocation]) extends ConvertFailure {
+final case class CollidingKeys(key: String, existingValue: ConfigValue, location: Option[ConfigValueLocation]) extends ConvertFailure {
   def path = key
 
-  def description = s"Key with value '$existingValue' collides with a key necessary to disambiguate a coproduct."
+  def description = s"Key with value '{$existingValue.render(ConfigRenderOptions.concise)}' collides with a key necessary to disambiguate a coproduct."
 
   def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
     this.copy(key = parentKey + "." + key, location = location orElse parentLocation)

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -93,7 +93,8 @@ abstract class ConvertFailure extends ConfigReaderFailure {
 
 /**
  * A failure representing the inability to convert a null value. Since a null
- * represents a missing value, the location of this failure is always None.
+ * represents a missing value, the location of this failure is always at the
+ * root (i.e. an empty string).
  */
 final case object CannotConvertNull extends ConvertFailure {
   val location = None

--- a/core/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
@@ -52,7 +52,7 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
 
     exception1.getMessage shouldBe
       s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$Conf. Failures are:
-          |  in the configuration:
+          |  at the root:
           |    - Expected type OBJECT. Found NUMBER instead.
           |""".stripMargin
 
@@ -164,8 +164,7 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
 
     exception.getMessage shouldBe
       s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$Conf. Failures are:
-          |  in the configuration:
-          |    - (file:${workingDir}${file}:2) Unable to parse the configuration.
+          |  - (file:${workingDir}${file}:2) Unable to parse the configuration.
           |""".stripMargin
   }
 }

--- a/core/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
@@ -136,7 +136,7 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
           |""".stripMargin
   }
 
-  it should "have a message displaying the proper physical location of the values that raised errors, if available" in {
+  it should "have a message displaying the proper file system location of the values that raised errors, if available" in {
     val workingDir = getClass.getResource("/").getFile
     val file = "conf/configFailureLocation/single/a.conf"
     val conf = ConfigFactory.load(file).root()

--- a/core/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
@@ -39,7 +39,7 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
 
   case class ParentConf(conf: Conf)
 
-  it should "have a message displaying errors not associated with a given path" in {
+  it should "have a message displaying errors that occur at the root of the configuration" in {
     val conf = ConfigFactory.parseString("""
       {
         conf = 2

--- a/core/src/test/scala/pureconfig/ConfigReaderFailureLocationSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderFailureLocationSuite.scala
@@ -30,7 +30,7 @@ class ConfigReaderFailureLocationSuite extends FlatSpec with Matchers with Eithe
       "Int",
       """java.lang.NumberFormatException: For input string: "hello"""",
       Some(ConfigValueLocation(new URL("file", "", workingDir + file), 3)),
-      Some("c")))
+      "c"))
 
     val failures2 = conf.get("other-conf").to[Conf].left.value.toList
     failures2 should have size 3
@@ -41,7 +41,7 @@ class ConfigReaderFailureLocationSuite extends FlatSpec with Matchers with Eithe
       "Int",
       """java.lang.NumberFormatException: For input string: "hello"""",
       Some(ConfigValueLocation(new URL("file", "", workingDir + file), 9)),
-      Some("c")))
+      "c"))
   }
 
   it should "show proper error location when loading from multiple files" in {
@@ -60,6 +60,6 @@ class ConfigReaderFailureLocationSuite extends FlatSpec with Matchers with Eithe
       "Int",
       """java.lang.NumberFormatException: For input string: "string"""",
       Some(ConfigValueLocation(new URL("file", "", workingDir + file2), 2)),
-      Some("a")))
+      "a"))
   }
 }

--- a/core/src/test/scala/pureconfig/CoproductConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/CoproductConvertersSuite.scala
@@ -40,14 +40,4 @@ class CoproductConvertersSuite extends BaseSuite {
     failures should have size 1
     failures.head shouldBe a[KeyNotFound]
   }
-
-  it should "return a proper ConfigReaderFailure if the hint field clashes with a field of a coproduct option" in {
-    sealed trait Foo
-    case class Bar(`type`: String) extends Foo
-    val exception = intercept[ConfigReaderException[_]] {
-      ConfigWriter[Foo].to(Bar("bar"))
-    }
-    exception.failures.toList should have size 1
-    exception.failures.head shouldEqual CollidingKeys("type", """"bar"""", None)
-  }
 }

--- a/core/src/test/scala/pureconfig/CoproductHintSuite.scala
+++ b/core/src/test/scala/pureconfig/CoproductHintSuite.scala
@@ -26,7 +26,7 @@ class CoproductHintSuite extends BaseSuite {
     it should "fail to read values that are not objects when using a FieldCoproductHint" in {
       val conf = ConfigValueFactory.fromAnyRef("Dog")
       ConfigConvert[AnimalConfig].from(conf) shouldEqual Left(ConfigReaderFailures(
-        WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT), None, None)))
+        WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT), None, "")))
     }
 
     it should "throw an exception when the hint field conflicts with a field of an option when using a FieldCoproductHint" in {
@@ -66,12 +66,12 @@ class CoproductHintSuite extends BaseSuite {
     it should "fail to read values that are not case objects when using an EnumCoproductHint" in {
       val conf = ConfigFactory.parseString("{ which-animal = Dog, age = 2 }")
       ConfigConvert[AnimalConfig].from(conf.root()) shouldEqual Left(ConfigReaderFailures(
-        WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.STRING), None, None)))
+        WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.STRING), None, "")))
     }
 
     it should "fail to write values that are not case objects when using an EnumCoproductHint" in {
       val ex = the[ConfigReaderException[_]] thrownBy ConfigConvert[AnimalConfig].to(DogConfig(2))
-      ex.failures.toList shouldEqual List(NonEmptyObjectFound("DogConfig", None, None))
+      ex.failures.toList shouldEqual List(NonEmptyObjectFound("DogConfig", None, ""))
     }
   }
 

--- a/core/src/test/scala/pureconfig/CoproductHintSuite.scala
+++ b/core/src/test/scala/pureconfig/CoproductHintSuite.scala
@@ -34,7 +34,7 @@ class CoproductHintSuite extends BaseSuite {
       val cc = implicitly[ConfigConvert[AnimalConfig]]
 
       val ex = the[ConfigReaderException[_]] thrownBy cc.to(DogConfig(2))
-      ex.failures.toList shouldEqual List(CollidingKeys("age", "ConfigInt(2)", None))
+      ex.failures.toList shouldEqual List(CollidingKeys("age", ConfigValueFactory.fromAnyRef(2), None))
     }
   }
 

--- a/core/src/test/scala/pureconfig/ProductHintSuite.scala
+++ b/core/src/test/scala/pureconfig/ProductHintSuite.scala
@@ -146,7 +146,7 @@ class ProductHintSuite extends BaseSuite {
     conf.getConfig("conf").to[Conf1] shouldBe Right(Conf1(1))
     val failures = conf.getConfig("conf").to[Conf2].left.value.toList
     failures should have size 1
-    failures.head shouldBe a[UnknownKey]
+    failures.head shouldEqual UnknownKey("b", None)
   }
 
   it should "not use default arguments if specified through a product hint" in {

--- a/core/src/test/scala/pureconfig/data/Percentage.scala
+++ b/core/src/test/scala/pureconfig/data/Percentage.scala
@@ -11,7 +11,7 @@ final case class Percentage(value: Int) {
 object Percentage {
   private val failConfigReadPercentage =
     (s: String) => (l: Option[ConfigValueLocation]) =>
-      Left(CannotConvert(s, "Percentage", "Percentage is a dummy type, you should not read it", l, None))
+      Left(CannotConvert(s, "Percentage", "Percentage is a dummy type, you should not read it", l, ""))
 
   implicit val percentageConfigWriter =
     ConfigConvert.viaNonEmptyString[Percentage](failConfigReadPercentage, percentage => s"${percentage.value} %")

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -5,10 +5,10 @@ describe failures reading from a `ConfigValue`. When implementing your own
 `ConfigConvert`s, you're recommended to use the provided case classes.
 
 The `ConfigReaderFailure` class has an optional location field that can be used
-to point to the physical location of a `ConfigValue` that raised an error. When
-using the `ConfigReaderFailure` sealed family of case classes, you can use the
-`ConfigValueLocation.apply(cv: ConfigValue)` method to automatically create an
-optional location from a `ConfigValue`.
+to point to the file system location of a `ConfigValue` that raised an error.
+When using the `ConfigReaderFailure` sealed family of case classes, you can use
+the `ConfigValueLocation.apply(cv: ConfigValue)` method to automatically create
+an optional location from a `ConfigValue`.
 
 If we load a config and try to load a missing key:
 

--- a/docs/src/main/tut/error-handling.md
+++ b/docs/src/main/tut/error-handling.md
@@ -5,10 +5,10 @@ describe failures reading from a `ConfigValue`. When implementing your own
 `ConfigConvert`s, you're recommended to use the provided case classes.
 
 The `ConfigReaderFailure` class has an optional location field that can be used
-to point to the physical location of a `ConfigValue` that raised an error. When
-using the `ConfigReaderFailure` sealed family of case classes, you can use the
-`ConfigValueLocation.apply(cv: ConfigValue)` method to automatically create an
-optional location from a `ConfigValue`.
+to point to the file system location of a `ConfigValue` that raised an error.
+When using the `ConfigReaderFailure` sealed family of case classes, you can use
+the `ConfigValueLocation.apply(cv: ConfigValue)` method to automatically create
+an optional location from a `ConfigValue`.
 
 If we load a config and try to load a missing key:
 

--- a/modules/akka/README.md
+++ b/modules/akka/README.md
@@ -7,7 +7,7 @@ Adds support for selected [Akka](http://akka.io/) classes to PureConfig.
 In addition to [core pureconfig](https://github.com/melrief/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.melrief" %% "pureconfig-akka" % "0.6.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-akka" % "0.7.0"
 ```
 
 ## Example

--- a/modules/cats/src/main/scala/pureconfig/module/Cats.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/Cats.scala
@@ -1,6 +1,6 @@
 package pureconfig.module
 
-import pureconfig.error.{ ConfigReaderFailure, ConfigValueLocation }
+import pureconfig.error.{ ConvertFailure, ConfigValueLocation }
 
 object Cats {
 
@@ -10,13 +10,13 @@ object Cats {
    * @param typ the type that was attempted to be converted to from an empty string
    * @param location an optional location of the ConfigValue that raised the
    *                 failure
-   * @param path an optional path to the value which was an unexpected empty string
+   * @param path the path to the value which was an unexpected empty string
    */
-  final case class EmptyTraversableFound(typ: String, location: Option[ConfigValueLocation], path: Option[String]) extends ConfigReaderFailure {
+  final case class EmptyTraversableFound(typ: String, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
     def description = s"Empty collection found when trying to convert to $typ."
 
     def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-      this.copy(location = location orElse parentLocation, path = path.map(parentKey + "." + _) orElse Some(parentKey))
+      this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
   }
 
 }

--- a/modules/cats/src/main/scala/pureconfig/module/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/package.scala
@@ -19,7 +19,7 @@ package object cats {
   private[pureconfig] def fromNonEmpty[F[_], G[_], T](fromFT: F[T] => Option[G[T]])(configValue: ConfigValue)(implicit ct: ClassTag[F[T]], fReader: ConfigReader[F[T]]): Either[ConfigReaderFailures, G[T]] =
     fReader.from(configValue).right.flatMap { ft =>
       fromFT(ft) match {
-        case None => Left(ConfigReaderFailures(EmptyTraversableFound(ct.toString, ConfigValueLocation(configValue), None)))
+        case None => Left(ConfigReaderFailures(EmptyTraversableFound(ct.toString, ConfigValueLocation(configValue), "")))
         case Some(nonEmpty) => Right(nonEmpty)
       }
     }

--- a/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
@@ -19,7 +19,7 @@ class CatsSuite extends FlatSpec with Matchers with EitherValues {
   it should "return an EmptyTraversableFound when reading empty lists into NonEmptyList" in {
     val config = parseString("{ numbers: [] }")
     config.to[Numbers] shouldEqual
-      Left(ConfigReaderFailures(EmptyTraversableFound("scala.collection.immutable.List", None, Some("numbers")), Nil))
+      Left(ConfigReaderFailures(EmptyTraversableFound("scala.collection.immutable.List", None, "numbers"), Nil))
   }
 
   case class NumVec(numbers: NonEmptyVector[Int])
@@ -32,6 +32,6 @@ class CatsSuite extends FlatSpec with Matchers with EitherValues {
   it should "return an EmptyTraversableFound when reading empty lists into NonEmptyVector" in {
     val config = parseString("{ numbers: [] }")
     config.to[NumVec] shouldEqual
-      Left(ConfigReaderFailures(EmptyTraversableFound("scala.collection.immutable.Vector", None, Some("numbers")), Nil))
+      Left(ConfigReaderFailures(EmptyTraversableFound("scala.collection.immutable.Vector", None, "numbers"), Nil))
   }
 }

--- a/modules/enum/src/main/scala/pureconfig/module/enum.scala
+++ b/modules/enum/src/main/scala/pureconfig/module/enum.scala
@@ -11,7 +11,7 @@ package object enum {
   implicit def enumConfigConvert[T](implicit e: Enum[T], ct: ClassTag[T]): ConfigConvert[T] = {
     viaNonEmptyString(
       s => location =>
-        e.decode(s).left.map(failure => CannotConvert(s, ct.runtimeClass.getSimpleName, failure.toString, location, None)),
+        e.decode(s).left.map(failure => CannotConvert(s, ct.runtimeClass.getSimpleName, failure.toString, location, "")),
       e.encode)
   }
 }

--- a/modules/enumeratum/src/main/scala/pureconfig/module/enumeratum.scala
+++ b/modules/enumeratum/src/main/scala/pureconfig/module/enumeratum.scala
@@ -32,7 +32,7 @@ package object enumeratum {
     viaNonEmptyString[A](
       s => location => ensureOneChar(s) match {
         case Right(v) => Right(enum.withValue(v))
-        case Left(msg) => Left(CannotConvert(s, ct.runtimeClass.getSimpleName, msg, location, None))
+        case Left(msg) => Left(CannotConvert(s, ct.runtimeClass.getSimpleName, msg, location, ""))
       },
       _.value.toString)
 


### PR DESCRIPTION
This PR proposes a distinction between parsing failures and conversion failures, mainly to make it clearer in the `ConfigReaderException` message what errors happened at the root of the configuration and what errors were raised due to an inability to parse the configuration.

This fixes #190.