### PR TITLE
add ActorPath to akka module; fix osgi exportPackage

### DIFF
--- a/modules/akka/README.md
+++ b/modules/akka/README.md
@@ -12,24 +12,28 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-akka" % "0.7.0"
 
 ## Example
 
-To load a `Timeout` into a configuration, we need a class to hold our configuration:
+To load a `Timeout` and an `ActorPath` into a configuration, we create a class to hold our configuration:
 
 ```scala
+import akka.actor.ActorPath
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory.parseString
 import pureconfig._
 import pureconfig.module.akka._
 
-case class MyConfig(timeout: Timeout)
+case class MyConfig(timeout: Timeout, actorPath: ActorPath)
 ```
 
 We can read a `MyConfig` like:
 ```scala
-val conf = parseString("""{ timeout: 5 seconds }""")
-// conf: com.typesafe.config.Config = Config(SimpleConfigObject({"timeout":"5 seconds"}))
+val conf = parseString("""{ 
+  timeout: 5 seconds, 
+  actor-path:  "akka://my-sys/user/service-a/worker1"
+}""")
+// conf: com.typesafe.config.Config = Config(SimpleConfigObject({"actor-path":"akka://my-sys/user/service-a/worker1","timeout":"5 seconds"}))
 
 loadConfig[MyConfig](conf)
-// res1: Either[pureconfig.error.ConfigReaderFailures,MyConfig] = Right(MyConfig(Timeout(5 seconds)))
+// res1: Either[pureconfig.error.ConfigReaderFailures,MyConfig] = Right(MyConfig(Timeout(5 seconds),akka://my-sys/user/service-a/worker1))
 ```
 
 

--- a/modules/akka/build.sbt
+++ b/modules/akka/build.sbt
@@ -49,7 +49,7 @@ pomExtra := (
 
 osgiSettings
 
-OsgiKeys.exportPackage := Seq("pureconfig.module.javax.*")
+OsgiKeys.exportPackage := Seq("pureconfig.module.akka.*")
 
 OsgiKeys.privatePackage := Seq()
 

--- a/modules/akka/src/main/scala/pureconfig/module/package.scala
+++ b/modules/akka/src/main/scala/pureconfig/module/package.scala
@@ -2,8 +2,11 @@ package pureconfig.module
 
 import scala.concurrent.duration.FiniteDuration
 
+import _root_.akka.actor.ActorPath
 import _root_.akka.util.Timeout
 import pureconfig.ConfigConvert
+import pureconfig.ConfigConvert.viaString
+import pureconfig.ConvertHelpers.catchReadError
 
 /**
  * ConfigConvert instances for Akka value classes.
@@ -11,4 +14,8 @@ import pureconfig.ConfigConvert
 package object akka {
   implicit val timeoutCC: ConfigConvert[Timeout] =
     ConfigConvert[FiniteDuration].xmap(new Timeout(_), _.duration)
+
+  implicit val actorPathCC: ConfigConvert[ActorPath] =
+    viaString[ActorPath](catchReadError(ActorPath.fromString), _.toSerializationFormat)
+
 }

--- a/modules/akka/src/main/tut/README.md
+++ b/modules/akka/src/main/tut/README.md
@@ -12,20 +12,24 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-akka" % "0.7.0"
 
 ## Example
 
-To load a `Timeout` into a configuration, we need a class to hold our configuration:
+To load a `Timeout` and an `ActorPath` into a configuration, we create a class to hold our configuration:
 
 ```tut:silent
+import akka.actor.ActorPath
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory.parseString
 import pureconfig._
 import pureconfig.module.akka._
 
-case class MyConfig(timeout: Timeout)
+case class MyConfig(timeout: Timeout, actorPath: ActorPath)
 ```
 
 We can read a `MyConfig` like:
 ```tut:book
-val conf = parseString("""{ timeout: 5 seconds }""")
+val conf = parseString("""{ 
+  timeout: 5 seconds, 
+  actor-path:  "akka://my-sys/user/service-a/worker1"
+}""")
 loadConfig[MyConfig](conf)
 ```
 

--- a/modules/akka/src/test/scala/pureconfig/module/akka/AkkaSuite.scala
+++ b/modules/akka/src/test/scala/pureconfig/module/akka/AkkaSuite.scala
@@ -1,6 +1,8 @@
 package pureconfig.module.akka
 
 import scala.concurrent.duration._
+
+import akka.actor.ActorPath
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.scalatest._
@@ -8,11 +10,24 @@ import pureconfig.syntax._
 
 class AkkaSuite extends FlatSpec with Matchers with EitherValues {
 
-  case class AkkaConf(timeout: Timeout)
+  case class TimeoutConf(timeout: Timeout)
+  case class PathConf(path: ActorPath)
 
   it should "be able to read a config with a Timeout" in {
     val expected = 5.seconds
     val config = ConfigFactory.parseString(s"""{ timeout: $expected }""")
-    config.to[AkkaConf].right.value shouldEqual AkkaConf(Timeout(expected))
+    config.to[TimeoutConf].right.value shouldEqual TimeoutConf(Timeout(expected))
+  }
+
+  it should "load a valid ActorPath" in {
+    val str = "akka://my-sys/user/service-a/worker1"
+    val expected = ActorPath.fromString(str)
+    val config = ConfigFactory.parseString(s"""{ path: "$str" }""")
+    config.to[PathConf].right.value shouldEqual PathConf(expected)
+  }
+
+  it should "not load invalid ActorPath" in {
+    val config = ConfigFactory.parseString("""{ path: "this is this the path you're looking for" }""")
+    config.to[PathConf] should be('left)
   }
 }


### PR DESCRIPTION
This adds `ActorPath` to the Akka module. It also fixes a wrong value for the OSGI exportPackage (it was set to "javax").