### PR TITLE
fix deriveAnyVal to derive only Generic

### DIFF
--- a/core/src/main/scala/pureconfig/DerivedReaders.scala
+++ b/core/src/main/scala/pureconfig/DerivedReaders.scala
@@ -28,6 +28,7 @@ trait DerivedReaders extends DerivedReaders1 {
   implicit def deriveAnyVal[T, U](
     implicit
     ev: T <:< AnyVal,
+    generic: Generic[T],
     unwrapped: Unwrapped.Aux[T, U],
     reader: ConfigReader[U]): ConfigReader[T] =
     new ConfigReader[T] {

--- a/core/src/main/scala/pureconfig/DerivedWriters.scala
+++ b/core/src/main/scala/pureconfig/DerivedWriters.scala
@@ -12,6 +12,7 @@ trait DerivedWriters extends DerivedWriters1 {
   implicit def deriveAnyVal[T, U](
     implicit
     ev: T <:< AnyVal,
+    generic: Generic[T],
     unwrapped: Unwrapped.Aux[T, U],
     writer: ConfigWriter[U]): ConfigWriter[T] =
     new ConfigWriter[T] {

--- a/core/src/test/scala/pureconfig/ValueClassSuite.scala
+++ b/core/src/test/scala/pureconfig/ValueClassSuite.scala
@@ -1,8 +1,12 @@
 package pureconfig
 
+import shapeless.test.illTyped
+
 final class IntWrapper(val inner: Int) extends AnyVal {
   override def toString: String = s"IntWrapper($inner)"
 }
+
+final class PrivateFloatValue private (val value: Float) extends AnyVal
 
 class ValueClassSuite extends BaseSuite {
 
@@ -10,4 +14,8 @@ class ValueClassSuite extends BaseSuite {
 
   checkRead[IntWrapper](new IntWrapper(1) -> ConfigWriter.forPrimitive[Int].to(1))
   checkWrite[IntWrapper](new IntWrapper(1) -> ConfigWriter.forPrimitive[Int].to(1))
+
+  "ConfigReader[PrivateFloatValue]" should "not be derivable because the constructor is private" in {
+    illTyped("pureconfig.ConfigReader[PrivateFloatValue]")
+  }
 }

--- a/core/src/test/scala/pureconfig/ValueClassSuite.scala
+++ b/core/src/test/scala/pureconfig/ValueClassSuite.scala
@@ -8,6 +8,26 @@ final class IntWrapper(val inner: Int) extends AnyVal {
 
 final class PrivateFloatValue private (val value: Float) extends AnyVal
 
+final class GenericValue[T] private (val t: T) extends AnyVal {
+  override def toString: String = "GenericValue(" + t.toString + ")"
+}
+
+object GenericValue {
+  def from[T](t: T): GenericValue[T] = new GenericValue[T](t)
+}
+
+trait Read[T] {
+  def read(str: String): T
+}
+
+object Read {
+  def apply[T](implicit readT: Read[T]): Read[T] = readT
+
+  implicit val badReadString = new Read[String] {
+    override def read(str: String): String = ""
+  }
+}
+
 class ValueClassSuite extends BaseSuite {
 
   behavior of "ConfigConvert for Value Classes"
@@ -17,5 +37,17 @@ class ValueClassSuite extends BaseSuite {
 
   "ConfigReader[PrivateFloatValue]" should "not be derivable because the constructor is private" in {
     illTyped("pureconfig.ConfigReader[PrivateFloatValue]")
+  }
+
+  {
+    implicit def genericValueReader[T](implicit readT: Read[T]): ConfigReader[GenericValue[T]] =
+      ConfigReader.fromString(s => _ => Right(GenericValue.from(readT.read(s))))
+
+    "ConfigReader" should " should be able to override value classes ConfigReader" in {
+      val reader = ConfigReader[GenericValue[String]]
+      val expected = Right(GenericValue.from(""))
+      val configValue = ConfigWriter.forPrimitive[String].to("foobar")
+      reader.from(configValue) shouldEqual expected
+    }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.2-SNAPSHOT"
+version in ThisBuild := "0.7.2"


### PR DESCRIPTION
Sneaky bug, it took sometime to understand what is going on. Basically without the `Generic` constraint, `deriveAnyVal` was deriving an instance of `ConfigReader`/`ConfigWriter` for any `T` extending `AnyVal` and having a `ConfigReader`/`ConfigWriter`. The issue is this [shapeless code](https://github.com/milessabin/shapeless/blob/39f73305e3cd2746948c6ef2dd1e065fe08cb1e1/core/src/main/scala/shapeless/unwrapped.scala#L70) which creates and instance of `Unwrapped` for any `T`. Given the fact that literally anything has an `Unwrapped` instance, anything else creating a real `ConfigReader` for `AnyVal`, like Refined, was conflicting and scalac gave up the implicit resolution with a diverging implicit expansion issue.

I've tried it with refined master and it works.

One thing that is still not nice is that if there in implicit resolution conflict, Scalac doesn't tell you at `loadConfig` level and you need to specifically ask for that type `ConfigReader` instance. Silent errors are the worst and I wonder if there is a flag to force printing this issue.

Note that I've set the version to `0.7.1.1` because I think it's not worth it increasing the point version. Let me know if it's fine for you.