### PR TITLE
Add a reason to CannotReadFile and catch all read errors

### DIFF
--- a/core/src/main/scala/pureconfig/error/ConfigReaderException.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderException.scala
@@ -13,16 +13,15 @@ final case class ConfigReaderException[T](failures: ConfigReaderFailures)(implic
     linesBuffer += s"Cannot convert configuration to a ${ct.runtimeClass.getName}. Failures are:"
 
     val failuresList = failures.toList
-    val parseFailures = failuresList.collect { case f: CannotParse => f }
-    val convertFailures = failuresList.collect { case f: ConvertFailure => f }
+    val (convertFailures, otherFailures) = failuresList.partition(_.isInstanceOf[ConvertFailure])
 
-    val failuresByPath = convertFailures.toList.groupBy(_.path).toList.sortBy(_._1)
+    val failuresByPath = convertFailures.asInstanceOf[List[ConvertFailure]].groupBy(_.path).toList.sortBy(_._1)
 
-    parseFailures.foreach { failure =>
+    otherFailures.foreach { failure =>
       linesBuffer += s"${ConfigReaderException.descriptionWithLocation(failure, "  ")}"
     }
 
-    if (parseFailures.nonEmpty && convertFailures.nonEmpty) {
+    if (otherFailures.nonEmpty && convertFailures.nonEmpty) {
       linesBuffer += ""
     }
 

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package pureconfig.error
 
+import java.io.FileNotFoundException
 import java.net.URL
 import java.nio.file.Path
 
@@ -301,10 +302,15 @@ final case class NoValidCoproductChoiceFound(value: ConfigValue, location: Optio
 /**
  * A failure representing the inability to read a requested file.
  */
-final case class CannotReadFile(path: Path) extends ConfigReaderFailure {
+final case class CannotReadFile(path: Path, reason: Option[Throwable]) extends ConfigReaderFailure {
   val location = None
 
-  def description = s"Unable to read file: ${path.toString}"
+  def description = reason match {
+    case Some(ex: FileNotFoundException) => s"Unable to read file ${ex.getMessage}." // a FileNotFoundException already includes the path
+    case Some(ex) => s"Unable to read file $path (${ex.getMessage})."
+    case None => s"Unable to read file $path."
+  }
+
   def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) = this
 }
 

--- a/core/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
@@ -212,4 +212,18 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
           |  - (file:${workingDir}${file}:2) Unable to parse the configuration.
           |""".stripMargin
   }
+
+  it should "have a message indicating that a given file does not exist" in {
+    val workingDir = getClass.getResource("/").getFile
+    val file = "conf/nonexisting"
+
+    val exception = intercept[ConfigReaderException[_]] {
+      loadConfigOrThrow[Conf](Paths.get(workingDir, file))
+    }
+
+    exception.getMessage shouldBe
+      s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$Conf. Failures are:
+          |  - Unable to read file ${workingDir}${file} (No such file or directory).
+          |""".stripMargin
+  }
 }

--- a/core/src/test/scala/pureconfig/ConfigReaderMatchers.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderMatchers.scala
@@ -3,7 +3,7 @@ package pureconfig
 import scala.reflect.ClassTag
 
 import org.scalatest._
-import org.scalatest.matchers.Matcher
+import org.scalatest.matchers.{ MatchResult, Matcher }
 import pureconfig.error.{ ConfigReaderFailure, ConfigReaderFailures }
 
 trait ConfigReaderMatchers { this: FlatSpec with Matchers =>
@@ -13,4 +13,12 @@ trait ConfigReaderMatchers { this: FlatSpec with Matchers =>
 
   def failWithType[Failure <: ConfigReaderFailure: ClassTag]: Matcher[Either[ConfigReaderFailures, Any]] =
     matchPattern { case Left(ConfigReaderFailures(_: Failure, Nil)) => }
+
+  def failLike(pf: PartialFunction[ConfigReaderFailure, MatchResult]) =
+    new Matcher[Either[ConfigReaderFailures, Any]] with Inside with PartialFunctionValues {
+
+      def apply(left: Either[ConfigReaderFailures, Any]): MatchResult = {
+        inside(left) { case Left(ConfigReaderFailures(failure, Nil)) => pf.valueAt(failure) }
+      }
+    }
 }

--- a/core/src/test/scala/pureconfig/backend/ConfigFactoryWrapperSpec.scala
+++ b/core/src/test/scala/pureconfig/backend/ConfigFactoryWrapperSpec.scala
@@ -1,5 +1,7 @@
 package pureconfig.backend
 
+import java.io.FileNotFoundException
+
 import com.typesafe.config.{ ConfigException, ConfigFactory }
 import pureconfig.BaseSuite
 import pureconfig.PathUtils._
@@ -11,7 +13,9 @@ class ConfigFactoryWrapperSpec extends BaseSuite {
 
   it should "return a Left when a file does not exist" in {
     ConfigFactory.parseFile(nonExistingPath.toFile) shouldEqual ConfigFactory.empty
-    ConfigFactoryWrapper.parseFile(nonExistingPath) should failWith(CannotReadFile(nonExistingPath))
+    ConfigFactoryWrapper.parseFile(nonExistingPath) should failLike {
+      case CannotReadFile(`nonExistingPath`, Some(reason)) => be(a[FileNotFoundException])(reason)
+    }
   }
 
   it should "return a Left when a file exists but cannot be parsed" in {
@@ -24,7 +28,9 @@ class ConfigFactoryWrapperSpec extends BaseSuite {
 
   it should "return a Left when a file does not exist" in {
     ConfigFactory.load(ConfigFactory.parseFile(nonExistingPath.toFile)) shouldEqual ConfigFactory.load
-    ConfigFactoryWrapper.loadFile(nonExistingPath) should failWith(CannotReadFile(nonExistingPath))
+    ConfigFactoryWrapper.loadFile(nonExistingPath) should failLike {
+      case CannotReadFile(`nonExistingPath`, Some(reason)) => be(a[FileNotFoundException])(reason)
+    }
   }
 
   it should "return a Left when a file exists but cannot be parsed" in {


### PR DESCRIPTION
This PR improves the handling of file reading errors by preventing `ConfigFactory` from silently ignoring missing files in `parseFile` and dealing with the resulting `ConfigException.IO` exceptions in a special way.

Incidentally, this also makes pureconfig turn all reading IO exceptions into `CannotReadFile` failures, instead of wrapping them into generic `ThrowableFailure` failures as before.

Closes #248.