### PR TITLE
Add failing test for #205

### DIFF
--- a/core/src/test/scala/pureconfig/CoproductConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/CoproductConvertersSuite.scala
@@ -21,6 +21,12 @@ class CoproductConvertersSuite extends BaseSuite {
     ConfigConvert[AnimalConfig].from(conf.root()) shouldEqual Right(DogConfig(2))
   }
 
+  it should "read disambiguation information on sealed families with the cases nested in the companion" in {
+    import CarMaker._
+    val conf = ConfigFactory.parseString("{ type = bmw }")
+    ConfigConvert[CarMaker].from(conf.root()) shouldEqual Right(BMW)
+  }
+
   it should "write disambiguation information on sealed families by default" in {
     val conf = ConfigConvert[AnimalConfig].to(DogConfig(2))
     conf shouldBe a[ConfigObject]
@@ -40,4 +46,12 @@ class CoproductConvertersSuite extends BaseSuite {
     failures should have size 1
     failures.head shouldBe a[KeyNotFound]
   }
+}
+
+sealed trait CarMaker
+
+object CarMaker {
+  case object Mercedes extends CarMaker
+  case object BMW extends CarMaker
+  case object Tesla extends CarMaker
 }


### PR DESCRIPTION
Adds a test illustrating #205.

If the three case objects are moved out of the `CarMaker` companion everything works as expected.

If they are in the companion compilation fails with these errors:

```
[error] knownDirectSubclasses of CarMaker observed before subclass BMW registered
[error] .../pureconfig/core/src/test/scala/pureconfig/CoproductConvertersSuite.scala:27: could not find implicit value for parameter conv: pureconfig.ConfigConvert[pureconfig.CarMaker]
[error]     ConfigConvert[CarMaker].from(conf.root()) shouldEqual Right(BMW)
[error]                  ^
[error] knownDirectSubclasses of CarMaker observed before subclass Mercedes registered
[error] knownDirectSubclasses of CarMaker observed before subclass Tesla registered
```