### PR TITLE
Use -Xfatal-warnings just on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: scala
 scala:
-    - 2.10.6
-    - 2.11.11
-    - 2.12.2
+  - 2.10.6
+  - 2.11.11
+  - 2.12.2
 jdk:
-    - oraclejdk8
+  - oraclejdk8
 script:
-  - sbt coverage "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION tut" "+++$TRAVIS_SCALA_VERSION doc"
-  - (cd example ; sbt ++$TRAVIS_SCALA_VERSION test)
+  - sbt -S-Xfatal-warnings
+      coverage
+      "+++$TRAVIS_SCALA_VERSION test"
+      "+++$TRAVIS_SCALA_VERSION tut"
+      "+++$TRAVIS_SCALA_VERSION doc"
+
+  - cd example && sbt -S-Xfatal-warnings ++$TRAVIS_SCALA_VERSION test
 
   # check if there are no changes after `tut` runs
   - if [[ $TRAVIS_SCALA_VERSION =~ ^2\.12.* ]]; then

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,6 @@ lazy val allVersionLintFlags = Seq(
   "-encoding", "UTF-8", // yes, this is 2 args
   "-feature",
   "-unchecked",
-  "-Xfatal-warnings",
   "-Yno-adapted-args",
   "-Ywarn-dead-code")
 


### PR DESCRIPTION
This PR removes the `-Xfatal-warnings` flag from the SBT build and adds it only on the Travis build. It's very cumbersome for me to have this flag active during development - when I'm testing stuff I sometimes comment things or move code around and I always end up having to comment or remove the imports too. I should be able to easily compile the code with warnings, as long as I submit it without them.

Let me know what you think of this :)
