### PR TITLE
Wrap exceptions in ConfigReaderFailure when using map and xmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Bug fixes
   - A breaking change introduced in v0.7.1 where `loadConfigFromFiles` stopped allowing missing files was reverted;
   - `loadConfig` methods no longer throw an exception when passed a namespace where one of the keys is not a config
-    object.
+    object;
+  - The `xmap` of `ConfigConvert` and the `map` method of `ConfigReader` now wrap exceptions that the functions used to map might throw in a `ConfigReaderFailure`.
 
 ### 0.7.2 (May 29, 2017)
 

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -10,6 +10,8 @@ import scala.reflect.ClassTag
 import scala.util.Try
 
 import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
+
+import pureconfig.ConvertHelpers._
 import pureconfig.error.{ ConfigReaderFailure, ConfigReaderFailures, ConfigValueLocation }
 
 /**
@@ -27,7 +29,7 @@ trait ConfigConvert[A] extends ConfigReader[A] with ConfigWriter[A] { outer =>
    *         respectively.
    */
   def xmap[B](f: A => B, g: B => A): ConfigConvert[B] = new ConfigConvert[B] {
-    def from(config: ConfigValue) = outer.from(config).right.map(f)
+    def from(config: ConfigValue) = outer.from(config).right.flatMap(toResult(f)(_)(ConfigValueLocation(config)))
     def to(a: B) = outer.to(g(a))
   }
 }

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -31,7 +31,7 @@ trait ConfigReader[A] {
    * @return a `ConfigReader` returning the results of this reader mapped by `f`.
    */
   def map[B](f: A => B): ConfigReader[B] =
-    fromFunction[B](from(_).right.map(f))
+    fromFunction[B](v => from(v).right.flatMap(toResult(f)(_)(ConfigValueLocation(v))))
 
   /**
    * Maps a function that can possibly fail over the results of this reader.

--- a/core/src/main/scala/pureconfig/ConvertHelpers.scala
+++ b/core/src/main/scala/pureconfig/ConvertHelpers.scala
@@ -32,6 +32,9 @@ trait ConvertHelpers {
         ConfigReaderFailures(headImproved, tailImproved)
     }
 
+  private[pureconfig] def toResult[A, B](f: A => B): A => Option[ConfigValueLocation] => Either[ConfigReaderFailures, B] =
+    v => l => eitherToResult(tryToEither(Try(f(v)))(l))
+
   private[pureconfig] def eitherToResult[T](either: Either[ConfigReaderFailure, T]): Either[ConfigReaderFailures, T] =
     either match {
       case r: Right[_, _] => r.asInstanceOf[Either[ConfigReaderFailures, T]]


### PR DESCRIPTION
This PR modifies the `xmap` method of `ConfigConvert` and the `map` method of `ConfigReader` to wrap exceptions that the functions used to map might throw in a `ConfigReaderFailure`.