### PR TITLE
Allow periods in Map keys.

### DIFF
--- a/core/src/main/scala/pureconfig/DerivedReaders.scala
+++ b/core/src/main/scala/pureconfig/DerivedReaders.scala
@@ -183,12 +183,12 @@ trait DerivedReaders1 {
         case co: ConfigObject =>
           val z: Either[ConfigReaderFailures, Map[String, T]] = Right(Map.empty[String, T])
 
-          co.asScala.foldLeft(z) {
-            case (acc, (key, value)) =>
+          co.toConfig.entrySet.asScala.foldLeft(z) {
+            (acc, entry) =>
               combineResults(
                 acc,
-                improveFailures(configConvert.value.from(value), key, ConfigValueLocation(value))) {
-                  (map, valueConverted) => map + (key -> valueConverted)
+                improveFailures(configConvert.value.from(entry.getValue), entry.getKey, ConfigValueLocation(entry.getValue))) {
+                  (map, valueConverted) => map + (entry.getKey -> valueConverted)
                 }
           }
 


### PR DESCRIPTION
The current conversion just uses `ConfigObject` from the `ConfigValue`.

Given e.g. `{ foo.bar = 10 }`, you get `Map(foo -> Map(bar -> 10))`, whereas I think what would be wanted for a `Map[String, Int]` would be  `Map(foo.bar -> 10)`. Kafka takes its config as a `Map[String, Object]` (see https://kafka.apache.org/0100/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html) where the keys are things like `client.id` and `enable.auto.commit`. We have those stored in sections of reference.conf and application.conf, but the current PureConfig `Map` reader doesn't work for this. The `.entrySet` method on `Config` returns the contents flattened out with the keys being the full (period-delimited) path to each leaf node value.


This change seems to pass the tests, except for the case where you're turning a `Map` with an empty string into Config - this `.entrySet` method seems to turn that empty string into `""` (a string that's just a pair of quotes) on the way back. I'm not sure empty string makes sense as a config value - how could an empty string be written as a key in a .conf file? Could restrict those test cases to "non-empty string". Or modify the ConfigWriter behaviour to add the empty quotes in that case, to match the ConfigReader?

Also, PureConfig doesn't support converting to `Object`, but it seems easy enough to just an a `ConfigReader` that calls `.unwrapped` on any `ConfigValue`.