### PR TITLE
Support reading booleans from "yes" and "no" strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
     by config objects;
   - `ConfigFieldMapping` now has a `withOverrides` method that allows users to easily define exceptional cases to an
     existing mapping;
-  - `ConfigReader` and `ConfigWriter` for `java.math.BigDecimal` and `java.math.BigInteger`.
+  - `ConfigReader` and `ConfigWriter` for `java.math.BigDecimal` and `java.math.BigInteger`;
+  - `ConfigReader` for `Boolean`s allows reading them from "yes"/"no" strings.
 - Bug fixes
   - A breaking change introduced in v0.7.1 where `loadConfigFromFiles` stopped allowing missing files was reverted;
   - `loadConfig` methods no longer throw an exception when passed a namespace where one of the keys is not a config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   - `ConfigFieldMapping` now has a `withOverrides` method that allows users to easily define exceptional cases to an
     existing mapping;
   - `ConfigReader` and `ConfigWriter` for `java.math.BigDecimal` and `java.math.BigInteger`;
-  - `ConfigReader` for `Boolean`s allows reading them from "yes"/"no" strings.
+  - `ConfigReader` for `Boolean`s allows reading them from "yes", "no", "on" and "off" strings.
 - Bug fixes
   - A breaking change introduced in v0.7.1 where `loadConfigFromFiles` stopped allowing missing files was reverted;
   - `loadConfig` methods no longer throw an exception when passed a namespace where one of the keys is not a config

--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -25,8 +25,8 @@ trait PrimitiveReaders {
 
   implicit val stringConfigReader = ConfigReader.fromString[String](s => _ => Right(s))
   implicit val booleanConfigReader = ConfigReader.fromNonEmptyString[Boolean](catchReadError({
-    case "yes" => true
-    case "no" => false
+    case "yes" | "on" => true
+    case "no" | "off" => false
     case other => other.toBoolean
   }))
   implicit val doubleConfigReader = ConfigReader.fromNonEmptyString[Double](catchReadError({

--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -24,7 +24,11 @@ import pureconfig.error._
 trait PrimitiveReaders {
 
   implicit val stringConfigReader = ConfigReader.fromString[String](s => _ => Right(s))
-  implicit val booleanConfigReader = ConfigReader.fromNonEmptyString[Boolean](catchReadError(_.toBoolean))
+  implicit val booleanConfigReader = ConfigReader.fromNonEmptyString[Boolean](catchReadError({
+    case "yes" => true
+    case "no" => false
+    case other => other.toBoolean
+  }))
   implicit val doubleConfigReader = ConfigReader.fromNonEmptyString[Double](catchReadError({
     case v if v.last == '%' => v.dropRight(1).toDouble / 100d
     case v => v.toDouble

--- a/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -53,6 +53,9 @@ class BasicConvertersSuite extends BaseSuite {
   checkArbitrary[String]
 
   checkArbitrary[Boolean]
+  checkRead[Boolean](
+    true -> ConfigValueFactory.fromAnyRef("yes"),
+    false -> ConfigValueFactory.fromAnyRef("no"))
 
   checkArbitrary[Double]
   checkArbitrary2[Double, Percentage](_.toDoubleFraction)

--- a/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -55,7 +55,9 @@ class BasicConvertersSuite extends BaseSuite {
   checkArbitrary[Boolean]
   checkRead[Boolean](
     true -> ConfigValueFactory.fromAnyRef("yes"),
-    false -> ConfigValueFactory.fromAnyRef("no"))
+    true -> ConfigValueFactory.fromAnyRef("on"),
+    false -> ConfigValueFactory.fromAnyRef("no"),
+    false -> ConfigValueFactory.fromAnyRef("off"))
 
   checkArbitrary[Double]
   checkArbitrary2[Double, Percentage](_.toDoubleFraction)


### PR DESCRIPTION
This PR modifies the `ConfigReader` for `Boolean`s to allow reading them from `"yes"` and `"no"` strings, in line with what is supported in the `getBoolean` method of Typesafe config.

This PR fixes #293.