### PR TITLE
Documentation Clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Click on the demo gif below to see how PureConfig effortlessly translates your c
 - [Add PureConfig to your project](#add-pureconfig-to-your-project)
 - [Use PureConfig](#use-pureconfig)
 - [Supported types](#supported-types)
+- [Integrating with other libraries](#integrating-with-other-libraries)
+- [Contribute](#contribute)
+- [License](#license)
+- [Special thanks](#special-thanks)
+
+## Deeper Documention
 - [Configurable converters](docs/configurable-converters.md)
 - [Support new types](docs/support-new-types.md)
   - [Add support for simple types](docs/add-support-for-simple-types.md)
@@ -36,14 +42,9 @@ Click on the demo gif below to see how PureConfig effortlessly translates your c
 - [Error handling](docs/error-handling.md)
 - [Handling missing keys](docs/handling-missing-keys.md)
 - [Example](docs/example.md)
-- [Whence the config files](docs/whence-the-config-files.md)
+- [Config files](docs/config-files.md)
 - [Support for Duration](docs/support-for-duration.md)
-- [Integrating with other libraries](#integrating-with-other-libraries)
-- [Contribute](#contribute)
 - [FAQ](docs/faq.md)
-- [License](#license)
-- [Special thanks](#special-thanks)
-
 
 ## Why
 
@@ -101,15 +102,46 @@ As a result we recommend only using 2.11.11 or 2.12.1 or newer within the minor 
 
 ## Use PureConfig
 
-Import the library package and use one of the `loadConfig` methods:
+First, import the library, define data types, and a case class to hold the configuration:
 
 ```scala
-import pureconfig._
-import pureconfig.error.ConfigReaderFailures
+import pureconfig.loadConfig
 
-case class YourConfClass(name: String, quantity: Int)
+sealed trait MyAdt
+case class AdtA(a: String) extends MyAdt
+case class AdtB(b: Int) extends MyAdt
+final case class Port(value: Int) extends AnyVal
+case class MyClass(
+  boolean: Boolean,
+  port: Port,
+  adt: MyAdt,
+  list: List[Double],
+  map: Map[String, String],
+  option: Option[String])
+```
 
-val config: Either[pureconfig.error.ConfigReaderFailures,YourConfClass] = loadConfig[YourConfClass]
+Second, define a configuration. Options for defining this are described in
+the (config files documentation)[docs/config-files.md]:
+
+`application.json`
+```json
+{ 
+  "boolean": true,
+  "port": 8080, 
+  "adt": { 
+    "type": "adtb", 
+    "b": 1 
+  }, 
+  "list": ["1", "20%"], 
+  "map": { "key": "value" } 
+}
+```
+
+Then, load the configuration ((in this case from the classpath)[docs/config-files.md]):
+
+```scala
+loadConfig[MyClass](conf)
+// res3: Either[pureconfig.error.ConfigReaderFailures,MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
 ```
 
 
@@ -137,47 +169,6 @@ Currently supported types for fields are:
 - case classes;
 - sealed families of case classes (ADTs);
 - `shapeless.HList`s of elements whose type is in this list.
-
-# Example
-
-First, import the library, define data types, and a case class to hold the configuration:
-
-```scala
-import com.typesafe.config.ConfigFactory.parseString
-import pureconfig.loadConfig
-
-sealed trait MyAdt
-case class AdtA(a: String) extends MyAdt
-case class AdtB(b: Int) extends MyAdt
-final case class Port(value: Int) extends AnyVal
-case class MyClass(
-  boolean: Boolean,
-  port: Port,
-  adt: MyAdt,
-  list: List[Double],
-  map: Map[String, String],
-  option: Option[String])
-```
-
-Then, load the configuration (in this case from a hard-coded string):
-
-```scala
-val conf = parseString("""{ 
-  "boolean": true,
-  "port": 8080, 
-  "adt": { 
-    "type": "adtb", 
-    "b": 1 
-  }, 
-  "list": ["1", "20%"], 
-  "map": { "key": "value" } 
-}""")
-// conf: com.typesafe.config.Config = Config(SimpleConfigObject({"adt":{"b":1,"type":"adtb"},"boolean":true,"list":["1","20%"],"map":{"key":"value"},"port":8080}))
-
-loadConfig[MyClass](conf)
-// res3: Either[pureconfig.error.ConfigReaderFailures,MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
-```
-
 
 ## Integrating with other libraries
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@ Click on the demo gif below to see how PureConfig effortlessly translates your c
 - [Add PureConfig to your project](#add-pureconfig-to-your-project)
 - [Use PureConfig](#use-pureconfig)
 - [Supported types](#supported-types)
-- [Integrating with other libraries](#integrating-with-other-libraries)
-- [Contribute](#contribute)
-- [License](#license)
-- [Special thanks](#special-thanks)
-
-## Deeper Documention
 - [Configurable converters](docs/configurable-converters.md)
 - [Support new types](docs/support-new-types.md)
   - [Add support for simple types](docs/add-support-for-simple-types.md)
@@ -44,7 +38,12 @@ Click on the demo gif below to see how PureConfig effortlessly translates your c
 - [Example](docs/example.md)
 - [Config files](docs/config-files.md)
 - [Support for Duration](docs/support-for-duration.md)
+- [Integrating with other libraries](#integrating-with-other-libraries)
+- [Contribute](#contribute)
 - [FAQ](docs/faq.md)
+- [License](#license)
+- [Special thanks](#special-thanks)
+
 
 ## Why
 
@@ -169,6 +168,7 @@ Currently supported types for fields are:
 - case classes;
 - sealed families of case classes (ADTs);
 - `shapeless.HList`s of elements whose type is in this list.
+
 
 ## Integrating with other libraries
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Click on the demo gif below to see how PureConfig effortlessly translates your c
 - [Add PureConfig to your project](#add-pureconfig-to-your-project)
 - [Use PureConfig](#use-pureconfig)
 - [Supported types](#supported-types)
+- [Integrating with other libraries](#integrating-with-other-libraries)
+- [Contribute](#contribute)
+- [License](#license)
+- [Special thanks](#special-thanks)
+
+## Deeper Documention
 - [Configurable converters](docs/configurable-converters.md)
 - [Support new types](docs/support-new-types.md)
   - [Add support for simple types](docs/add-support-for-simple-types.md)
@@ -36,14 +42,9 @@ Click on the demo gif below to see how PureConfig effortlessly translates your c
 - [Error handling](docs/error-handling.md)
 - [Handling missing keys](docs/handling-missing-keys.md)
 - [Example](docs/example.md)
-- [Whence the config files](docs/whence-the-config-files.md)
+- [Config files](docs/config-files.md)
 - [Support for Duration](docs/support-for-duration.md)
-- [Integrating with other libraries](#integrating-with-other-libraries)
-- [Contribute](#contribute)
 - [FAQ](docs/faq.md)
-- [License](#license)
-- [Special thanks](#special-thanks)
-
 
 ## Why
 
@@ -101,15 +102,46 @@ As a result we recommend only using 2.11.11 or 2.12.1 or newer within the minor 
 
 ## Use PureConfig
 
-Import the library package and use one of the `loadConfig` methods:
+First, import the library, define data types, and a case class to hold the configuration:
 
 ```scala
-import pureconfig._
-import pureconfig.error.ConfigReaderFailures
+import pureconfig.loadConfig
 
-case class YourConfClass(name: String, quantity: Int)
+sealed trait MyAdt
+case class AdtA(a: String) extends MyAdt
+case class AdtB(b: Int) extends MyAdt
+final case class Port(value: Int) extends AnyVal
+case class MyClass(
+  boolean: Boolean,
+  port: Port,
+  adt: MyAdt,
+  list: List[Double],
+  map: Map[String, String],
+  option: Option[String])
+```
 
-val config: Either[pureconfig.error.ConfigReaderFailures,YourConfClass] = loadConfig[YourConfClass]
+Second, define a configuration. Options for defining this are described in
+the [config files documentation](docs/config-files.md):
+
+`application.json`
+```json
+{ 
+  "boolean": true,
+  "port": 8080, 
+  "adt": { 
+    "type": "adtb", 
+    "b": 1 
+  }, 
+  "list": ["1", "20%"], 
+  "map": { "key": "value" } 
+}
+```
+
+Then, load the configuration ([in this case from the classpath](docs/config-files.md)):
+
+```scala
+loadConfig[MyClass](conf)
+// res3: Either[pureconfig.error.ConfigReaderFailures,MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
 ```
 
 
@@ -137,47 +169,6 @@ Currently supported types for fields are:
 - case classes;
 - sealed families of case classes (ADTs);
 - `shapeless.HList`s of elements whose type is in this list.
-
-# Example
-
-First, import the library, define data types, and a case class to hold the configuration:
-
-```scala
-import com.typesafe.config.ConfigFactory.parseString
-import pureconfig.loadConfig
-
-sealed trait MyAdt
-case class AdtA(a: String) extends MyAdt
-case class AdtB(b: Int) extends MyAdt
-final case class Port(value: Int) extends AnyVal
-case class MyClass(
-  boolean: Boolean,
-  port: Port,
-  adt: MyAdt,
-  list: List[Double],
-  map: Map[String, String],
-  option: Option[String])
-```
-
-Then, load the configuration (in this case from a hard-coded string):
-
-```scala
-val conf = parseString("""{ 
-  "boolean": true,
-  "port": 8080, 
-  "adt": { 
-    "type": "adtb", 
-    "b": 1 
-  }, 
-  "list": ["1", "20%"], 
-  "map": { "key": "value" } 
-}""")
-// conf: com.typesafe.config.Config = Config(SimpleConfigObject({"adt":{"b":1,"type":"adtb"},"boolean":true,"list":["1","20%"],"map":{"key":"value"},"port":8080}))
-
-loadConfig[MyClass](conf)
-// res3: Either[pureconfig.error.ConfigReaderFailures,MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
-```
-
 
 ## Integrating with other libraries
 

--- a/core/src/main/tut/README.md
+++ b/core/src/main/tut/README.md
@@ -36,7 +36,7 @@ Click on the demo gif below to see how PureConfig effortlessly translates your c
 - [Error handling](docs/error-handling.md)
 - [Handling missing keys](docs/handling-missing-keys.md)
 - [Example](docs/example.md)
-- [Whence the config files](docs/whence-the-config-files.md)
+- [Config files](docs/config-files.md)
 - [Support for Duration](docs/support-for-duration.md)
 - [Integrating with other libraries](#integrating-with-other-libraries)
 - [Contribute](#contribute)
@@ -101,15 +101,46 @@ As a result we recommend only using 2.11.11 or 2.12.1 or newer within the minor 
 
 ## Use PureConfig
 
-Import the library package and use one of the `loadConfig` methods:
+First, import the library, define data types, and a case class to hold the configuration:
 
-```tut:silent
-import pureconfig._
-import pureconfig.error.ConfigReaderFailures
+```scala
+import pureconfig.loadConfig
 
-case class YourConfClass(name: String, quantity: Int)
+sealed trait MyAdt
+case class AdtA(a: String) extends MyAdt
+case class AdtB(b: Int) extends MyAdt
+final case class Port(value: Int) extends AnyVal
+case class MyClass(
+  boolean: Boolean,
+  port: Port,
+  adt: MyAdt,
+  list: List[Double],
+  map: Map[String, String],
+  option: Option[String])
+```
 
-val config: Either[pureconfig.error.ConfigReaderFailures,YourConfClass] = loadConfig[YourConfClass]
+Second, define a configuration. Options for defining this are described in
+the [config files documentation](docs/config-files.md):
+
+`application.json`
+```json
+{ 
+  "boolean": true,
+  "port": 8080, 
+  "adt": { 
+    "type": "adtb", 
+    "b": 1 
+  }, 
+  "list": ["1", "20%"], 
+  "map": { "key": "value" } 
+}
+```
+
+Then, load the configuration ([in this case from the classpath](docs/config-files.md)):
+
+```scala
+loadConfig[MyClass](conf)
+// res3: Either[pureconfig.error.ConfigReaderFailures,MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
 ```
 
 
@@ -137,44 +168,6 @@ Currently supported types for fields are:
 - case classes;
 - sealed families of case classes (ADTs);
 - `shapeless.HList`s of elements whose type is in this list.
-
-# Example
-
-First, import the library, define data types, and a case class to hold the configuration:
-
-```tut:silent
-import com.typesafe.config.ConfigFactory.parseString
-import pureconfig.loadConfig
-
-sealed trait MyAdt
-case class AdtA(a: String) extends MyAdt
-case class AdtB(b: Int) extends MyAdt
-final case class Port(value: Int) extends AnyVal
-case class MyClass(
-  boolean: Boolean,
-  port: Port,
-  adt: MyAdt,
-  list: List[Double],
-  map: Map[String, String],
-  option: Option[String])
-```
-
-Then, load the configuration (in this case from a hard-coded string):
-
-```tut:book
-val conf = parseString("""{ 
-  "boolean": true,
-  "port": 8080, 
-  "adt": { 
-    "type": "adtb", 
-    "b": 1 
-  }, 
-  "list": ["1", "20%"], 
-  "map": { "key": "value" } 
-}""")
-
-loadConfig[MyClass](conf)
-```
 
 
 ## Integrating with other libraries

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -1,4 +1,4 @@
-## Whence the config files?
+## Where are the config files?
 
 By default, PureConfig `loadConfig` methods load all resources in the classpath named:
 
@@ -7,7 +7,7 @@ By default, PureConfig `loadConfig` methods load all resources in the classpath 
 - `application.properties`, and
 - `reference.conf`.
 
-The various `loadConfig` methods defer to [Typesafe Config][typesafe-config]'s
+The various `loadConfig` methods defer to Typesafe Config's
 [`ConfigFactory`](https://typesafehub.github.io/config/latest/api/com/typesafe/config/ConfigFactory.html) to
 select where to load the config files from. Typesafe Config has [well-documented rules for configuration
 loading](https://github.com/typesafehub/config#standard-behavior) which we'll not repeat. Please see Typesafe
@@ -18,6 +18,6 @@ Alternatively, PureConfig also provides a `loadConfigFromFiles` method, which bu
 an explicit list of files. Files earlier in the list have greater precedence than later ones. Each file can
 include a partial configuration as long as the whole list produces a complete configuration. For an example,
 see the test of `loadConfigFromFiles` in
-[`PureconfSuite.scala`](https://github.com/melrief/pureconfig/blob/master/core/src/test/scala/pureconfig/PureconfSuite.scala).
+[`ApiSuite.scala`](https://github.com/pureconfig/pureconfig/blob/master/core/src/test/scala/pureconfig/ApiSuite.scala).
 
 Because PureConfig uses Typesafe Config to load configuration, it supports reading files in [HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md#hocon-human-optimized-config-object-notation), JSON, and Java `.properties` formats. HOCON is a delightful superset of both JSON and `.properties` that is highly recommended. As an added bonus it supports [advanced features](https://github.com/typesafehub/config/blob/master/README.md#features-of-hocon) like variable substitution and file sourcing.

--- a/docs/src/main/tut/config-files.md
+++ b/docs/src/main/tut/config-files.md
@@ -1,4 +1,4 @@
-## Whence the config files?
+## Where are the config files?
 
 By default, PureConfig `loadConfig` methods load all resources in the classpath named:
 
@@ -7,7 +7,7 @@ By default, PureConfig `loadConfig` methods load all resources in the classpath 
 - `application.properties`, and
 - `reference.conf`.
 
-The various `loadConfig` methods defer to [Typesafe Config][typesafe-config]'s
+The various `loadConfig` methods defer to Typesafe Config's
 [`ConfigFactory`](https://typesafehub.github.io/config/latest/api/com/typesafe/config/ConfigFactory.html) to
 select where to load the config files from. Typesafe Config has [well-documented rules for configuration
 loading](https://github.com/typesafehub/config#standard-behavior) which we'll not repeat. Please see Typesafe
@@ -18,6 +18,6 @@ Alternatively, PureConfig also provides a `loadConfigFromFiles` method, which bu
 an explicit list of files. Files earlier in the list have greater precedence than later ones. Each file can
 include a partial configuration as long as the whole list produces a complete configuration. For an example,
 see the test of `loadConfigFromFiles` in
-[`PureconfSuite.scala`](https://github.com/melrief/pureconfig/blob/master/core/src/test/scala/pureconfig/PureconfSuite.scala).
+[`ApiSuite.scala`](https://github.com/pureconfig/pureconfig/blob/master/core/src/test/scala/pureconfig/ApiSuite.scala).
 
 Because PureConfig uses Typesafe Config to load configuration, it supports reading files in [HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md#hocon-human-optimized-config-object-notation), JSON, and Java `.properties` formats. HOCON is a delightful superset of both JSON and `.properties` that is highly recommended. As an added bonus it supports [advanced features](https://github.com/typesafehub/config/blob/master/README.md#features-of-hocon) like variable substitution and file sourcing.


### PR DESCRIPTION
I've had a few people at work get confused by the structure of the pureconfig documentation. Issues addressed here:

* Assumption that "Table of Contents" applied only to the README after clicking the first few links.
* Confused by "Whence the config files?"
* The `use` section showed a lot of magic without links to explanation. 
* The `example` section was an example of `parseString`, which is not the recommended way of using the library. The README usage/example should be the preferred way, so someone could could conceivably get to using it immediately.
* Fixed a broken link in the doc discussing how to use `loadConfigFromFiles`.