### PR TITLE
Improve ConfigReaderFailure for better scoping from ConfigCursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,17 @@
 - New features
   - A new `ConfigCursor` now provides idiomatic, safe methods to navigate through a config. It also holds context for
     building failures with a more accurate location and path in the config;
+  - `ConfigReaderFailure` was revamped to facilitate the propagation of context on failures. There is now a separation
+    between higher-level `ConfigReaderFailures` and concrete, location-agnostic `FailureReason`s.
 
 - Breaking changes
   - `ConfigReader`, as well as many related methods and classes, now reads configs from `ConfigCursor` instances instead
     of from direct `ConfigValue`s. Code can be migrated simply by accessing the `value` field of `ConfigCursor` whenever
     a `ConfigValue` is needed. However, rewriting the code to use the new `ConfigCursor` methods is heavily recommended
     as it provides safer config handling and much better error handling;
+  - Code for handling and raising failures may not work due to the revamp of the failure model. Inside `ConfigReader`
+    instances users should now use the `failed` method of the new `ConfigCursor` instead of manually creating instances
+    of `ConfigReaderFailures`;
   - The `CannotConvertNull` failure was removed, being superseeded by `KeyNotFound`;
   - Methods deprecated in previous versions were removed.
 

--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -23,7 +23,7 @@ import pureconfig.error._
  */
 trait PrimitiveReaders {
 
-  implicit val stringConfigReader = ConfigReader.fromString[String](s => _ => Right(s))
+  implicit val stringConfigReader = ConfigReader.fromString[String](s => Right(s))
   implicit val booleanConfigReader = ConfigReader.fromNonEmptyString[Boolean](catchReadError({
     case "yes" | "on" => true
     case "no" | "off" => false
@@ -109,10 +109,11 @@ trait DurationReaders {
     ConfigReader.fromNonEmptyString[Duration](DurationConvert.fromString)
 
   implicit val finiteDurationConfigReader: ConfigReader[FiniteDuration] = {
-    val fromString: String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, FiniteDuration] = { string => location =>
-      DurationConvert.fromString(string)(location).right.flatMap {
+    val fromString: String => Either[FailureReason, FiniteDuration] = { string =>
+      DurationConvert.fromString(string).right.flatMap {
         case d: FiniteDuration => Right(d)
-        case _ => Left(CannotConvert(string, "FiniteDuration", s"Couldn't parse '$string' into a FiniteDuration because it's infinite.", location, ""))
+        case _ => Left(CannotConvert(string, "FiniteDuration",
+          s"Couldn't parse '$string' into a FiniteDuration because it's infinite."))
       }
     }
     ConfigReader.fromNonEmptyString[FiniteDuration](fromString)

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -28,7 +28,7 @@ trait ConfigConvert[A] extends ConfigReader[A] with ConfigWriter[A] { outer =>
    *         respectively.
    */
   def xmap[B](f: A => B, g: B => A): ConfigConvert[B] = new ConfigConvert[B] {
-    def from(cur: ConfigCursor) = outer.from(cur).right.flatMap { v => cur.scopeFailures(toResult(f)(v)) }
+    def from(cur: ConfigCursor) = outer.from(cur).right.flatMap { v => cur.scopeFailure(toResult(f)(v)) }
     def to(a: B) = outer.to(g(a))
   }
 }

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -10,9 +10,8 @@ import scala.reflect.ClassTag
 import scala.util.Try
 
 import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
-
 import pureconfig.ConvertHelpers._
-import pureconfig.error.{ ConfigReaderFailure, ConfigReaderFailures, ConfigValueLocation }
+import pureconfig.error.{ ConfigReaderFailures, FailureReason }
 
 /**
  * Trait for objects capable of reading and writing objects of a given type from and to `ConfigValues`.
@@ -29,7 +28,7 @@ trait ConfigConvert[A] extends ConfigReader[A] with ConfigWriter[A] { outer =>
    *         respectively.
    */
   def xmap[B](f: A => B, g: B => A): ConfigConvert[B] = new ConfigConvert[B] {
-    def from(cur: ConfigCursor) = outer.from(cur).right.flatMap(toResult(f)(_)(ConfigValueLocation(cur.value)))
+    def from(cur: ConfigCursor) = outer.from(cur).right.flatMap { v => cur.scopeFailures(toResult(f)(v)) }
     def to(a: B) = outer.to(g(a))
   }
 }
@@ -50,7 +49,7 @@ object ConfigConvert extends ConvertHelpers {
     def to(t: T) = writer.value.to(t)
   }
 
-  def viaString[T](fromF: String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, T], toF: T => String): ConfigConvert[T] = new ConfigConvert[T] {
+  def viaString[T](fromF: String => Either[FailureReason, T], toF: T => String): ConfigConvert[T] = new ConfigConvert[T] {
     override def from(cur: ConfigCursor): Either[ConfigReaderFailures, T] = stringToEitherConvert(fromF)(cur)
     override def to(t: T): ConfigValue = ConfigValueFactory.fromAnyRef(toF(t))
   }
@@ -63,8 +62,8 @@ object ConfigConvert extends ConvertHelpers {
     viaString[T](optF(fromF), toF)
   }
 
-  def viaNonEmptyString[T](fromF: String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, T], toF: T => String)(implicit ct: ClassTag[T]): ConfigConvert[T] = {
-    viaString[T](string => location => ensureNonEmpty(ct)(string)(location).right.flatMap(s => fromF(s)(location)), toF)
+  def viaNonEmptyString[T](fromF: String => Either[FailureReason, T], toF: T => String)(implicit ct: ClassTag[T]): ConfigConvert[T] = {
+    viaString[T](string => ensureNonEmpty(ct)(string).right.flatMap(s => fromF(s)), toF)
   }
 
   def viaNonEmptyStringTry[T: ClassTag](fromF: String => Try[T], toF: T => String): ConfigConvert[T] = {

--- a/core/src/main/scala/pureconfig/ConfigCursor.scala
+++ b/core/src/main/scala/pureconfig/ConfigCursor.scala
@@ -4,7 +4,6 @@ import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success, Try }
 
 import com.typesafe.config._
-import pureconfig.ConvertHelpers._
 import pureconfig.backend.PathUtil
 import pureconfig.error._
 
@@ -103,27 +102,65 @@ sealed trait ConfigCursor {
    */
   def asCollectionCursor: Either[ConfigReaderFailures, Either[ConfigListCursor, ConfigObjectCursor]] = {
     if (isUndefined) {
-      fail(KeyNotFound(path, location, Set()))
+      failed(KeyNotFound.forKeys(path, Set()))
     } else {
       val listAtLeft = asListCursor.right.map(Left.apply)
       lazy val mapAtRight = asObjectCursor.right.map(Right.apply)
       listAtLeft
         .left.flatMap(_ => mapAtRight)
-        .left.flatMap(_ => fail(WrongType(value.valueType, Set(ConfigValueType.LIST, ConfigValueType.OBJECT), location, path)))
+        .left.flatMap(_ => failed(WrongType(value.valueType, Set(ConfigValueType.LIST, ConfigValueType.OBJECT))))
     }
   }
 
+  /**
+   * Returns a failed `ConfigReader` result resulting from scoping a `FailureReason` into the context of this cursor.
+   *
+   * This operation is the easiest way to return a failure from a `ConfigReader`.
+   *
+   * @param reason the reason of the failure
+   * @tparam A the returning type of the `ConfigReader`
+   * @return a failed `ConfigReader` result built by scoping `reason` into the context of this cursor.
+   */
+  def failed[A](reason: FailureReason): Either[ConfigReaderFailures, A] =
+    Left(ConfigReaderFailures(failureFor(reason)))
+
+  /**
+   * Returns a `ConfigReaderFailure` resulting from scoping a `FailureReason` into the context of this cursor.
+   *
+   * This operation is useful for constructing `ConfigReaderFailures` when there are multiple `FailureReason`s.
+   *
+   * @param reason the reason of the failure
+   * @return a `ConfigReaderFailure` built by scoping `reason` into the context of this cursor.
+   */
+  def failureFor(reason: FailureReason): ConfigReaderFailure =
+    ConvertFailure(reason, this)
+
+  /**
+   * Returns a failed `ConfigReader` result resulting from scoping a `Either[FailureReason, A]` into the context of
+   * this cursor.
+   *
+   * This operation is needed when control of the reading process is passed to a place without a `ConfigCursor`
+   * instance providing the nexessary context (for example, when `ConfigReader.fromString` is used. In those scenarios,
+   * the call should be wrapped in this method in order to turn `FailureReason` instances into `ConfigReaderFailures`.
+   *
+   * @param result the result of a config reading operation
+   * @tparam A the returning type of the `ConfigReader`
+   * @return a `ConfigReader` result built by scoping `reason` into the context of this cursor.
+   */
+  def scopeFailures[A](result: Either[FailureReason, A]): Either[ConfigReaderFailures, A] =
+    result.left.map { reason => ConfigReaderFailures(failureFor(reason), Nil) }
+
   private[this] def castOrFail[A](expectedType: ConfigValueType, cast: ConfigValue => A): Either[ConfigReaderFailures, A] = {
     if (isUndefined) {
-      fail(KeyNotFound(path, location, Set()))
+      failed(KeyNotFound.forKeys(path, Set()))
     } else if (value.valueType != expectedType) {
-      fail(WrongType(value.valueType, Set(expectedType), location, path))
+      failed(WrongType(value.valueType, Set(expectedType)))
     } else {
       Try(cast(value)) match {
         case Success(v) => Right(v)
         case Failure(ex) =>
           // this should never happen, this is just a safety net
-          fail(CannotConvert(value.toString, expectedType.toString, ex.toString, location, path))
+          failed(CannotConvert(value.toString, expectedType.toString, ex.toString))
       }
     }
   }
@@ -173,7 +210,7 @@ case class ConfigListCursor(value: ConfigList, pathElems: List[String], offset: 
    */
   def atIndex(idx: Int): Either[ConfigReaderFailures, ConfigCursor] = {
     atIndexOrUndefined(idx) match {
-      case idxCur if idxCur.isUndefined => fail(KeyNotFound(idxCur.path, location, indexKey(idx), Set()))
+      case idxCur if idxCur.isUndefined => failed(KeyNotFound.forKeys(indexKey(idx), Set()))
       case idxCur => Right(idxCur)
     }
   }
@@ -242,7 +279,7 @@ case class ConfigObjectCursor(value: ConfigObject, pathElems: List[String]) exte
    */
   def atKey(key: String): Either[ConfigReaderFailures, ConfigCursor] = {
     atKeyOrUndefined(key) match {
-      case keyCur if keyCur.isUndefined => fail(KeyNotFound(keyCur.path, location, key, keys))
+      case keyCur if keyCur.isUndefined => failed(KeyNotFound.forKeys(key, keys))
       case keyCur => Right(keyCur)
     }
   }

--- a/core/src/main/scala/pureconfig/ConfigCursor.scala
+++ b/core/src/main/scala/pureconfig/ConfigCursor.scala
@@ -147,7 +147,7 @@ sealed trait ConfigCursor {
    * @tparam A the returning type of the `ConfigReader`
    * @return a `ConfigReader` result built by scoping `reason` into the context of this cursor.
    */
-  def scopeFailures[A](result: Either[FailureReason, A]): Either[ConfigReaderFailures, A] =
+  def scopeFailure[A](result: Either[FailureReason, A]): Either[ConfigReaderFailures, A] =
     result.left.map { reason => ConfigReaderFailures(failureFor(reason), Nil) }
 
   private[this] def castOrFail[A](expectedType: ConfigValueType, cast: ConfigValue => A): Either[ConfigReaderFailures, A] = {

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -40,7 +40,7 @@ trait ConfigReader[A] {
    * @return a `ConfigReader` returning the results of this reader mapped by `f`.
    */
   def map[B](f: A => B): ConfigReader[B] =
-    fromCursor[B] { cur => from(cur).right.flatMap { v => cur.scopeFailures(toResult(f)(v)) } }
+    fromCursor[B] { cur => from(cur).right.flatMap { v => cur.scopeFailure(toResult(f)(v)) } }
 
   /**
    * Maps a function that can possibly fail over the results of this reader.

--- a/core/src/main/scala/pureconfig/ConvertHelpers.scala
+++ b/core/src/main/scala/pureconfig/ConvertHelpers.scala
@@ -22,71 +22,60 @@ trait ConvertHelpers {
 
   def fail[A](failure: ConfigReaderFailure): Either[ConfigReaderFailures, A] = Left(ConfigReaderFailures(failure))
 
-  def failWithThrowable[A](throwable: Throwable): Option[ConfigValueLocation] => Either[ConfigReaderFailures, A] = location => fail[A](ThrowableFailure(throwable, location, ""))
+  private[pureconfig] def toResult[A, B](f: A => B): A => Either[FailureReason, B] =
+    v => tryToEither(Try(f(v)))
 
-  private[pureconfig] def toResult[A, B](f: A => B): A => Option[ConfigValueLocation] => Either[ConfigReaderFailures, B] =
-    v => l => eitherToResult(tryToEither(Try(f(v)))(l))
-
-  private[pureconfig] def eitherToResult[T](either: Either[ConfigReaderFailure, T]): Either[ConfigReaderFailures, T] =
-    either match {
-      case r: Right[_, _] => r.asInstanceOf[Either[ConfigReaderFailures, T]]
-      case Left(failure) => Left(ConfigReaderFailures(failure))
-    }
-
-  private[pureconfig] def tryToEither[T](t: Try[T]): Option[ConfigValueLocation] => Either[ConfigReaderFailure, T] = t match {
-    case Success(v) => _ => Right(v)
-    case Failure(e) => location => Left(ThrowableFailure(e, location, ""))
+  private[pureconfig] def tryToEither[T](t: Try[T]): Either[FailureReason, T] = t match {
+    case Success(v) => Right(v)
+    case Failure(e) => Left(ExceptionThrown(e))
   }
 
-  private[pureconfig] def stringToTryConvert[T](fromF: String => Try[T]): ConfigCursor => Either[ConfigReaderFailures, T] =
-    stringToEitherConvert[T](string => location => tryToEither(fromF(string))(location))
-
-  private[pureconfig] def stringToEitherConvert[T](fromF: String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, T]): ConfigCursor => Either[ConfigReaderFailures, T] =
-    cur => {
-      // Because we can't trust Typesafe Config not to throw, we wrap the
-      // evaluation into a `try-catch` to prevent an unintentional exception from escaping.
-      try {
-        val string = cur.asString.fold(_ => cur.value.render(ConfigRenderOptions.concise), identity)
-        eitherToResult(fromF(string)(cur.location)).left.map(_.withImprovedContext(cur.path, cur.location))
-      } catch {
-        case NonFatal(t) => failWithThrowable(t)(cur.location)
+  private[pureconfig] def stringToEitherConvert[T](fromF: String => Either[FailureReason, T]): ConfigCursor => Either[ConfigReaderFailures, T] = { cur =>
+    // Because we can't trust Typesafe Config not to throw, we wrap the
+    // evaluation into a `try-catch` to prevent an unintentional exception from escaping.
+    try {
+      cur.scopeFailures {
+        fromF(cur.asString.fold(_ => cur.value.render(ConfigRenderOptions.concise), identity))
       }
+    } catch {
+      case NonFatal(t) => cur.failed(ExceptionThrown(t))
     }
-
-  private[pureconfig] def ensureNonEmpty[T](implicit ct: ClassTag[T]): String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, String] = {
-    case "" => location => Left(EmptyStringFound(ct.toString(), location, ""))
-    case x => _ => Right(x)
   }
 
-  def catchReadError[T](f: String => T)(implicit ct: ClassTag[T]): String => Option[ConfigValueLocation] => Either[CannotConvert, T] =
-    string => location =>
-      try Right(f(string)) catch {
-        case NonFatal(ex) => Left(CannotConvert(string, ct.toString(), ex.toString, location, ""))
-      }
+  private[pureconfig] def ensureNonEmpty[T](implicit ct: ClassTag[T]): String => Either[FailureReason, String] = {
+    case "" => Left(EmptyStringFound(ct.toString))
+    case x => Right(x)
+  }
+
+  def catchReadError[T](f: String => T)(implicit ct: ClassTag[T]): String => Either[FailureReason, T] = { string =>
+    try Right(f(string)) catch {
+      case NonFatal(ex) => Left(CannotConvert(string, ct.toString(), ex.toString))
+    }
+  }
 
   /**
    * Convert a `String => Try` into a  `String => Option[ConfigValueLocation] => Either` such that after application
    * - `Success(t)` becomes `_ => Right(t)`
    * - `Failure(e)` becomes `location => Left(CannotConvert(value, type, e.getMessage, location)`
    */
-  def tryF[T](f: String => Try[T])(implicit ct: ClassTag[T]): String => Option[ConfigValueLocation] => Either[CannotConvert, T] =
-    string => location =>
-      f(string) match {
-        case Success(t) => Right(t)
-        case Failure(e) => Left(CannotConvert(string, ct.runtimeClass.getName, e.getLocalizedMessage, location, ""))
-      }
+  def tryF[T](f: String => Try[T])(implicit ct: ClassTag[T]): String => Either[FailureReason, T] = { string =>
+    f(string) match {
+      case Success(t) => Right(t)
+      case Failure(e) => Left(CannotConvert(string, ct.runtimeClass.getName, e.getLocalizedMessage))
+    }
+  }
 
   /**
    * Convert a `String => Option` into a `String => Option[ConfigValueLocation] => Either` such that after application
    * - `Some(t)` becomes `_ => Right(t)`
    * - `None` becomes `location => Left(CannotConvert(value, type, "", location)`
    */
-  def optF[T](f: String => Option[T])(implicit ct: ClassTag[T]): String => Option[ConfigValueLocation] => Either[CannotConvert, T] =
-    string => location =>
-      f(string) match {
-        case Some(t) => Right(t)
-        case None => Left(CannotConvert(string, ct.runtimeClass.getName, "", location, ""))
-      }
+  def optF[T](f: String => Option[T])(implicit ct: ClassTag[T]): String => Either[FailureReason, T] = { string =>
+    f(string) match {
+      case Some(t) => Right(t)
+      case None => Left(CannotConvert(string, ct.runtimeClass.getName, ""))
+    }
+  }
 }
 
 object ConvertHelpers extends ConvertHelpers

--- a/core/src/main/scala/pureconfig/ConvertHelpers.scala
+++ b/core/src/main/scala/pureconfig/ConvertHelpers.scala
@@ -34,7 +34,7 @@ trait ConvertHelpers {
     // Because we can't trust Typesafe Config not to throw, we wrap the
     // evaluation into a `try-catch` to prevent an unintentional exception from escaping.
     try {
-      cur.scopeFailures {
+      cur.scopeFailure {
         fromF(cur.asString.fold(_ => cur.value.render(ConfigRenderOptions.concise), identity))
       }
     } catch {

--- a/core/src/main/scala/pureconfig/DurationConvert.scala
+++ b/core/src/main/scala/pureconfig/DurationConvert.scala
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package pureconfig
 
-import pureconfig.error.{ CannotConvert, ConfigReaderFailure, ConfigValueLocation }
-
 import scala.concurrent.duration.Duration.{ Inf, MinusInf }
 import scala.concurrent.duration.{ DAYS, Duration, FiniteDuration, HOURS, MICROSECONDS, MILLISECONDS, MINUTES, NANOSECONDS, SECONDS, TimeUnit }
 import scala.util.Try
+
+import pureconfig.error.{ CannotConvert, FailureReason }
 
 /**
  * Utility functions for converting a Duration to a String and vice versa.
@@ -16,14 +16,14 @@ private[pureconfig] object DurationConvert {
   /**
    * Convert a string to a Duration while trying to maintain compatibility with Typesafe's abbreviations.
    */
-  val fromString: String => Option[ConfigValueLocation] => Either[ConfigReaderFailure, Duration] = { string => location =>
+  val fromString: String => Either[FailureReason, Duration] = { string =>
     if (string == UndefinedDuration) Right(Duration.Undefined)
     else try {
       Right(parseDuration(addZeroUnit(justAMinute(itsGreekToMe(string)))))
     } catch {
       case ex: NumberFormatException =>
         val err = s"${ex.getMessage}. (try a number followed by any of ns, us, ms, s, m, h, d)"
-        Left(CannotConvert(string, "Duration", err, location, ""))
+        Left(CannotConvert(string, "Duration", err))
     }
   }
 

--- a/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
+++ b/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
@@ -41,8 +41,8 @@ object ConfigFactoryWrapper {
         else
           e.getMessage).stripSuffix(".")
         fail(CannotParse(msg, ConfigValueLocation(e.origin())))
-      case e: ConfigException => failWithThrowable(e)(ConfigValueLocation(e.origin()))
-      case NonFatal(e) => failWithThrowable(e)(None)
+      case e: ConfigException => fail(ThrowableFailure(e, ConfigValueLocation(e.origin())))
+      case NonFatal(e) => fail(ThrowableFailure(e, None))
     }
   }
 }

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -61,7 +61,7 @@ case object NoFilesToRead extends ConfigReaderFailure {
 }
 
 /**
- * A failure occurred because an exception was thrown duing the reading process.
+ * A failure occurred because an exception was thrown during the reading process.
  *
  * @param throwable the exception thrown
  * @param location the optional location of the failure

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -6,271 +6,94 @@ package pureconfig.error
 import java.io.FileNotFoundException
 import java.nio.file.Path
 
-import scala.annotation.tailrec
-import scala.collection.mutable
-
-import com.typesafe.config.{ ConfigRenderOptions, ConfigValue, ConfigValueType }
+import pureconfig.ConfigCursor
 
 /**
- * A representation of a failure that might be raised from reading a
- * ConfigValue. The failure contains an optional file system location of the
- * configuration that raised the failure.
+ * A representation of a failure raised from reading a config. The failure contains an optional file system location of
+ * the configuration that raised the failure.
  */
-abstract class ConfigReaderFailure {
+trait ConfigReaderFailure {
+
   /**
    * A human-readable description of the failure.
    */
   def description: String
 
   /**
-   * The optional location of the ConfigReaderFailure.
+   * The optional location of the failure.
    */
   def location: Option[ConfigValueLocation]
-
-  /**
-   * Improves the context of this failure with the key to the parent node and
-   * its optional location.
-   */
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]): ConfigReaderFailure
 }
 
 /**
- * A representation of a failure that might be raised from converting from a
- * `ConfigValue` to a given type. The failure contains a path to the
+ * A failure occurred when converting from a `ConfigValue` to a given type. The failure contains a path to the
  * `ConfigValue` that raised the error.
+ *
+ * @param reason the reason for the conversion failure
+ * @param location the optional location of the failure
+ * @param path the path to the `ConfigValue` that raised the error
  */
-abstract class ConvertFailure extends ConfigReaderFailure {
+case class ConvertFailure(reason: FailureReason, location: Option[ConfigValueLocation], path: String)
+  extends ConfigReaderFailure {
+
+  def description = reason.description
+}
+
+object ConvertFailure {
+
   /**
-   * The path to the `ConfigValue` that raised the failure.
+   * Constructs a `ConvertFailure` from a reason and a `ConfigCursor`.
+   *
+   * @param reason the reason for the conversion failure
+   * @param cur the cursor where the failure ocurred
+   * @return a `ConvertFailure` for the given reason at the given cursor.
    */
-  def path: String
+  def apply(reason: FailureReason, cur: ConfigCursor): ConvertFailure =
+    ConvertFailure(reason, cur.location, cur.path)
 }
 
 /**
- * A failure representing the inability to convert a given value to a desired type.
- *
- * @param value the value that was requested to be converted
- * @param toType the target type that the value was requested to be converted to
- * @param because the reason why the conversion was not possible
- * @param location an optional location of the ConfigValue that raised the
- *                 failure
- * @param path the path to the value that couldn't be converted
+ * A failure occurred because a list of files to load was empty.
  */
-final case class CannotConvert(value: String, toType: String, because: String, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
-
-  def description = s"Cannot convert '$value' to $toType: $because."
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
+case object NoFilesToRead extends ConfigReaderFailure {
+  def description = "The config files to load must not be empty."
+  def location = None
 }
 
 /**
- * A failure representing a collision of keys with different semantics. This
- * error is raised when a key that should be used to disambiguate a coproduct is
- * mapped to a field in a product.
+ * A failure occurred because an exception was thrown duing the reading process.
  *
- * @param key the colliding key
- * @param existingValue the value of the key
- * @param location an optional location of the ConfigValue that raised the
- *                 failure
+ * @param throwable the exception thrown
+ * @param location the optional location of the failure
  */
-final case class CollidingKeys(key: String, existingValue: ConfigValue, location: Option[ConfigValueLocation]) extends ConvertFailure {
-  def path = key
+final case class ThrowableFailure(throwable: Throwable, location: Option[ConfigValueLocation])
+  extends ConfigReaderFailure {
 
-  def description = s"Key with value '{$existingValue.render(ConfigRenderOptions.concise)}' collides with a key necessary to disambiguate a coproduct."
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(key = parentKey + "." + key, location = location orElse parentLocation)
-}
-
-/**
- * A failure representing a key missing from a ConfigObject.
- *
- * @param key the key that is missing
- * @param location an optional location of the ConfigValue that raised the
- *                 failure
- * @param candidates a set of candidate keys that might correspond to the
- *                   desired key in case of a misconfigured ProductHint
- */
-final case class KeyNotFound(key: String, location: Option[ConfigValueLocation], candidates: Set[String] = Set()) extends ConvertFailure {
-  def path = key
-
-  def description = {
-    if (candidates.nonEmpty) {
-      val descLines = mutable.ListBuffer[String]()
-      descLines += "Key not found. You might have a misconfigured ProductHint, since the following similar keys were found:"
-      candidates.foreach { candidate =>
-        descLines += (s" - '$candidate'")
-      }
-      descLines.mkString("\n")
-    } else {
-      "Key not found."
-    }
-  }
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(
-      key = if (key.isEmpty) parentKey else parentKey + "." + key,
-      location = location orElse parentLocation,
-      candidates.map(parentKey + "." + _))
-}
-
-object KeyNotFound {
-  @tailrec
-  private[this] def isSubsequence(s1: String, s2: String): Boolean = {
-    if (s1.isEmpty)
-      true
-    else if (s2.isEmpty)
-      false
-    else if (s1.head == s2.head)
-      isSubsequence(s1.tail, s2.tail)
-    else
-      isSubsequence(s1, s2.tail)
-  }
-
-  def apply(key: String, location: Option[ConfigValueLocation], fieldName: String, keys: Iterable[String]): KeyNotFound = {
-    val lcField = fieldName.toLowerCase.filter(c => c.isDigit || c.isLetter)
-    val objectKeys = keys.map(f => (f, f.toLowerCase))
-    val candidateKeys = objectKeys.filter(k => isSubsequence(lcField, k._2)).map(_._1).toSet
-    KeyNotFound(key, location, candidateKeys)
-  }
-}
-
-/**
- * A failure representing the presence of an unknown key in a ConfigObject. This
- * error is raised when a key of a ConfigObject is not mapped into a field of a
- * given type, and the allowUnknownKeys property of the ProductHint for the type
- * in question is false.
- *
- * @param key the unknown key
- * @param location an optional location of the ConfigValue that raised the
- *                 failure
- */
-final case class UnknownKey(key: String, location: Option[ConfigValueLocation]) extends ConvertFailure {
-  def path = key
-
-  def description = s"Unknown key."
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(key = parentKey + "." + key, location = location orElse parentLocation)
-}
-
-/**
- * A failure representing a wrong type of a given ConfigValue.
- *
- * @param foundType the ConfigValueType that was found
- * @param expectedTypes the ConfigValueTypes that were expected
- * @param location an optional location of the ConfigValue that raised the
- *                 failure
- * @param path the path to the value that had a wrong type
- */
-final case class WrongType(foundType: ConfigValueType, expectedTypes: Set[ConfigValueType], location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
-  def description = s"""Expected type ${expectedTypes.mkString(" or ")}. Found $foundType instead."""
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
-}
-
-/**
- * A failure that resulted in a Throwable being raised.
- *
- * @param throwable the Throwable that was raised
- * @param location an optional location of the ConfigValue that raised the
- *                 failure
- * @param path the path to the value that raised the Throwable
- */
-final case class ThrowableFailure(throwable: Throwable, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
   def description = s"${throwable.getMessage}."
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
 }
 
 /**
- * A failure representing an unexpected empty string.
+ * A failure occurred due to the inability to read a requested file.
  *
- * @param typ the type that was attempted to be converted to from an empty string
- * @param location an optional location of the ConfigValue that raised the
- *                 failure
- * @param path the path to the value which was an unexpected empty string
- */
-final case class EmptyStringFound(typ: String, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
-  def description = s"Empty string found when trying to convert to $typ."
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
-}
-
-/**
- * A failure representing an unexpected non-empty object when using `EnumCoproductHint` to write a config.
- *
- * @param typ the type for which a non-empty object was attempted to be written
- * @param location an optional location of the ConfigValue that raised the failure
- * @param path the path to the value which was an unexpected empty string
- */
-final case class NonEmptyObjectFound(typ: String, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
-  def description = s"Non-empty object found when using EnumCoproductHint to write a $typ."
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
-}
-
-/**
- * A failure representing that a list of an unexpected size was found when attempting to read into an HList.
- *
- * @param expected the expected number of elements
- * @param found the number of elements found
- * @param location an optional location of the ConfigValue that raised the failure
- * @param path the path to the value which was a list of an unexpected size
- */
-final case class WrongSizeList(expected: Int, found: Int, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
-  def description = s"List of wrong size found. Expected $expected elements. Found $found elements instead."
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
-}
-
-/**
- * A failure representing the inability to find a valid choice for a given coproduct.
- *
- * @param value the ConfigValue that was unable to be mapped to a coproduct choice
- * @param location an optional location of the ConfigValue that raised the
- *                 failure
- * @param path the path to the value who doesn't have a valid choice for a
- *             coproduct
- */
-final case class NoValidCoproductChoiceFound(value: ConfigValue, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
-  def description = s"No valid coproduct choice found for '${value.render(ConfigRenderOptions.concise())}'."
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
-}
-
-/**
- * A failure representing the inability to read a requested file.
+ * @param path the file system path of the file that couldn't be read
+ * @param reason an optional exception thrown when trying to read the file
  */
 final case class CannotReadFile(path: Path, reason: Option[Throwable]) extends ConfigReaderFailure {
-  val location = None
-
   def description = reason match {
     case Some(ex: FileNotFoundException) => s"Unable to read file ${ex.getMessage}." // a FileNotFoundException already includes the path
     case Some(ex) => s"Unable to read file $path (${ex.getMessage})."
     case None => s"Unable to read file $path."
   }
 
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) = this
+  def location = None
 }
 
 /**
- * A failure representing the inability to parse the configuration.
+ * A failure occurred due to the inability to parse the configuration.
  *
  * @param msg the error message from the parser
- * @param location an optional location of the ConfigValue that raised the
- *                 failure
+ * @param location the optional location of the failure
  */
 final case class CannotParse(msg: String, location: Option[ConfigValueLocation]) extends ConfigReaderFailure {
   def description = s"Unable to parse the configuration: $msg."
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation)
 }

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
@@ -15,19 +15,6 @@ case class ConfigReaderFailures(head: ConfigReaderFailure, tail: List[ConfigRead
 
   def ++(that: ConfigReaderFailures): ConfigReaderFailures =
     new ConfigReaderFailures(head, tail ++ that.toList)
-
-  /**
-   * Improves the context of this list of failures with the path to the parent node and its optional location.
-   *
-   * @param parentKey the path to the parent node in the config
-   * @param parentLocation the location of the parent
-   * @return a new `ConfigReaderFailures` instance with its context improved.
-   */
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]): ConfigReaderFailures = {
-    ConfigReaderFailures(
-      head.withImprovedContext(parentKey, parentLocation),
-      tail.map(_.withImprovedContext(parentKey, parentLocation)))
-  }
 }
 
 object ConfigReaderFailures {

--- a/core/src/main/scala/pureconfig/error/FailureReason.scala
+++ b/core/src/main/scala/pureconfig/error/FailureReason.scala
@@ -1,0 +1,150 @@
+package pureconfig.error
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+import com.typesafe.config.{ ConfigRenderOptions, ConfigValue, ConfigValueType }
+
+/**
+ * A representation of a reason why a value failed to be converted.
+ */
+trait FailureReason {
+
+  /**
+   * A human-readable description of the failure.
+   */
+  def description: String
+}
+
+/**
+ * A general reason given for the failure of a value to be converted to a desired type.
+ *
+ * @param value the value that was requested to be converted
+ * @param toType the target type that the value was requested to be converted to
+ * @param because the reason why the conversion was not possible
+ */
+final case class CannotConvert(value: String, toType: String, because: String) extends FailureReason {
+  def description = s"Cannot convert '$value' to $toType: $because."
+}
+
+/**
+ * A failure reason given when there is a collision of keys with different semantics. This error is raised when a key
+ * that should be used to disambiguate a coproduct is mapped to a field in a product.
+ *
+ * @param key the colliding key
+ * @param existingValue the value of the key
+ */
+final case class CollidingKeys(key: String, existingValue: ConfigValue) extends FailureReason {
+  def description = s"Key with value '{$existingValue.render(ConfigRenderOptions.concise)}' collides with a key necessary to disambiguate a coproduct."
+}
+
+/**
+ * A failure reason given when a key is missing from a `ConfigObject` or `ConfigList`.
+ *
+ * @param key the key that is missing
+ * @param candidates a set of candidate keys that might correspond to the
+ *                   desired key in case of a misconfigured ProductHint
+ */
+final case class KeyNotFound(key: String, candidates: Set[String] = Set()) extends FailureReason {
+  def description = {
+    if (candidates.nonEmpty) {
+      val descLines = mutable.ListBuffer[String]()
+      descLines += s"Key not found: '$key'. You might have a misconfigured ProductHint, since the following similar keys were found:"
+      candidates.foreach { candidate =>
+        descLines += s" - '$candidate'"
+      }
+      descLines.mkString("\n")
+    } else {
+      s"Key not found: '$key'."
+    }
+  }
+}
+
+object KeyNotFound {
+  @tailrec
+  private[this] def isSubsequence(s1: String, s2: String): Boolean = {
+    if (s1.isEmpty)
+      true
+    else if (s2.isEmpty)
+      false
+    else if (s1.head == s2.head)
+      isSubsequence(s1.tail, s2.tail)
+    else
+      isSubsequence(s1, s2.tail)
+  }
+
+  def forKeys(fieldName: String, keys: Iterable[String]): KeyNotFound = {
+    val lcField = fieldName.toLowerCase.filter(c => c.isDigit || c.isLetter)
+    val objectKeys = keys.map(f => (f, f.toLowerCase))
+    val candidateKeys = objectKeys.filter(k => isSubsequence(lcField, k._2)).map(_._1).toSet
+    KeyNotFound(fieldName, candidateKeys)
+  }
+}
+
+/**
+ * A failure reason given when an unknown key is found in a `ConfigObject`. The failure is raised when a key of a
+ * `ConfigObject` is not mapped into a field of a given type and the `allowUnknownKeys` property of the `ProductHint`
+ * for the type in question is `false`.
+ *
+ * @param key the unknown key
+ */
+final case class UnknownKey(key: String) extends FailureReason {
+  def description = s"Unknown key."
+}
+
+/**
+ * A failure reason given when a `ConfigValue` has the wrong type.
+ *
+ * @param foundType the `ConfigValueType` that was found
+ * @param expectedTypes the `ConfigValueType`s that were expected
+ */
+final case class WrongType(foundType: ConfigValueType, expectedTypes: Set[ConfigValueType]) extends FailureReason {
+  def description = s"""Expected type ${expectedTypes.mkString(" or ")}. Found $foundType instead."""
+}
+
+/**
+ * A failure reason given when an exception is thrown during a conversion.
+ *
+ * @param throwable the `Throwable` that was raised
+ */
+final case class ExceptionThrown(throwable: Throwable) extends FailureReason {
+  def description = s"${throwable.getMessage}."
+}
+
+/**
+ * A failure reason given when an unexpected empty string is found.
+ *
+ * @param typ the type that was attempted to be converted to from an empty string
+ */
+final case class EmptyStringFound(typ: String) extends FailureReason {
+  def description = s"Empty string found when trying to convert to $typ."
+}
+
+/**
+ * A failure reason given when an unexpected non-empty object is found. The failure happens when using
+ * `EnumCoproductHint` to write a config.
+ *
+ * @param typ the type for which a non-empty object was attempted to be written
+ */
+final case class NonEmptyObjectFound(typ: String) extends FailureReason {
+  def description = s"Non-empty object found when using EnumCoproductHint to write a $typ."
+}
+
+/**
+ * A failure reason given when a list of an unexpected size is found when attempting to read into an `HList`.
+ *
+ * @param expected the expected number of elements
+ * @param found the number of elements found
+ */
+final case class WrongSizeList(expected: Int, found: Int) extends FailureReason {
+  def description = s"List of wrong size found. Expected $expected elements. Found $found elements instead."
+}
+
+/**
+ * A failure reason given when a valid choice for a coproduct cannot be found.
+ *
+ * @param value the ConfigValue that was unable to be mapped to a coproduct choice
+ */
+final case class NoValidCoproductChoiceFound(value: ConfigValue) extends FailureReason {
+  def description = s"No valid coproduct choice found for '${value.render(ConfigRenderOptions.concise())}'."
+}

--- a/core/src/main/scala/pureconfig/package.scala
+++ b/core/src/main/scala/pureconfig/package.scala
@@ -32,7 +32,7 @@ package object pureconfig {
 
     // we're not expecting any exception here, this `try` is just for extra safety
     try getValue(ConfigCursor(conf.root(), Nil), splitPath(namespace)) catch {
-      case ex: ConfigException => fail(ThrowableFailure(ex, ConfigValueLocation(ex.origin()), ""))
+      case ex: ConfigException => fail(ThrowableFailure(ex, ConfigValueLocation(ex.origin())))
     }
   }
 
@@ -272,7 +272,7 @@ package object pureconfig {
    */
   def loadConfigFromFiles[Config](files: Traversable[Path])(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] = {
     if (files.isEmpty) {
-      ConfigConvert.failWithThrowable[Config](new IllegalArgumentException("The config files to load must not be empty."))(None)
+      Left(ConfigReaderFailures(NoFilesToRead))
     } else {
       files
         .map(parseFile)

--- a/core/src/main/scala/pureconfig/package.scala
+++ b/core/src/main/scala/pureconfig/package.scala
@@ -24,9 +24,9 @@ package object pureconfig {
     def getValue(cur: ConfigCursor, path: List[String]): Either[ConfigReaderFailures, ConfigCursor] = path match {
       case Nil => Right(cur)
       case key :: remaining => for {
-        objCur <- cur.asObjectCursor
-        keyCur <- if (remaining.nonEmpty || !allowNullLeaf) objCur.atKey(key) else Right(objCur.atKeyOrUndefined(key))
-        finalCur <- getValue(keyCur, remaining)
+        objCur <- cur.asObjectCursor.right
+        keyCur <- (if (remaining.nonEmpty || !allowNullLeaf) objCur.atKey(key) else Right(objCur.atKeyOrUndefined(key))).right
+        finalCur <- getValue(keyCur, remaining).right
       } yield finalCur
     }
 

--- a/core/src/test/scala/pureconfig/ApiSuite.scala
+++ b/core/src/test/scala/pureconfig/ApiSuite.scala
@@ -36,7 +36,7 @@ class ApiSuite extends BaseSuite {
     case class Conf(f: Float)
     val conf = ConfigFactory.parseString("foo.bar { f: 1.0 }")
     loadConfig[Conf](conf = conf, namespace = "foo.bar") shouldBe Right(Conf(1.0F))
-    loadConfig[Conf](conf = conf, namespace = "bar.foo") should failWith(KeyNotFound("bar", None, Set.empty))
+    loadConfig[Conf](conf = conf, namespace = "bar.foo") should failWith(KeyNotFound("bar", Set.empty), "")
   }
 
   it should "loadConfig other values from a Typesafe Config with a namespace" in {
@@ -45,23 +45,23 @@ class ApiSuite extends BaseSuite {
     loadConfig[Float](conf = conf, namespace = "foo.bar.f") shouldBe Right(1.0F)
 
     loadConfig[Float](conf = conf, namespace = "foo.bar.h") should failWith(
-      KeyNotFound("foo.bar.h", None, Set.empty))
+      KeyNotFound("h", Set.empty), "foo.bar")
 
     loadConfig[Float](conf = conf, namespace = "foo.baz.f") should failWith(
-      WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT), None, "foo.baz"))
+      WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), "foo.baz")
 
     loadConfig[Float](conf = conf, namespace = "bar.foo.f") should failWith(
-      KeyNotFound("bar", None, Set.empty))
+      KeyNotFound("bar", Set.empty), "")
 
     loadConfig[Option[Float]](conf = conf, namespace = "foo.bar.f") shouldBe Right(Some(1.0F))
 
     loadConfig[Option[Float]](conf = conf, namespace = "foo.bar.h") shouldBe Right(None)
 
     loadConfig[Option[Float]](conf = conf, namespace = "foo.baz.f") should failWith(
-      WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT), None, "foo.baz"))
+      WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), "foo.baz")
 
     loadConfig[Option[Float]](conf = conf, namespace = "bar.foo.f") should failWith(
-      KeyNotFound("bar", None, Set.empty))
+      KeyNotFound("bar", Set.empty), "")
   }
 
   it should "handle correctly namespaces with special chars" in {
@@ -70,13 +70,13 @@ class ApiSuite extends BaseSuite {
     loadConfig[Float](conf = conf, namespace = "\"fo.o\".\"ba r\".f") shouldBe Right(1.0F)
 
     loadConfig[Float](conf = conf, namespace = "\"fo.o\".\"ba r\".h") should failWith(
-      KeyNotFound("\"fo.o\".\"ba r\".h", None, Set.empty))
+      KeyNotFound("h", Set.empty), "\"fo.o\".\"ba r\"")
 
     loadConfig[Float](conf = conf, namespace = "\"fo.o\".\"ba z\".h") should failWith(
-      WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT), None, "\"fo.o\".\"ba z\""))
+      WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), "\"fo.o\".\"ba z\"")
 
     loadConfig[Float](conf = conf, namespace = "\"b.a.r\".foo.f") should failWith(
-      KeyNotFound("\"b.a.r\"", None, Set.empty))
+      KeyNotFound("b.a.r", Set.empty), "")
   }
 
   it should "loadConfig from a configuration file" in {
@@ -91,7 +91,7 @@ class ApiSuite extends BaseSuite {
     val path = createTempFile("""foo.bar { b: true, s: "str" }""")
     loadConfig[Conf](path = path, namespace = "foo.bar") shouldBe Right(Conf("str", true))
     loadConfig[Conf](path = nonExistingPath, namespace = "foo.bar") should failWithType[CannotReadFile]
-    loadConfig[Conf](path = path, namespace = "bar.foo") should failWith(KeyNotFound("bar", None, Set.empty))
+    loadConfig[Conf](path = path, namespace = "bar.foo") should failWith(KeyNotFound("bar", Set.empty))
   }
 
   it should "be able to load a realistic configuration file" in {
@@ -158,7 +158,7 @@ class ApiSuite extends BaseSuite {
   it should "fail if the list of files is empty" in {
     case class Conf(f: Float)
     val files = Set.empty[Path]
-    loadConfigFromFiles[Conf](files) should failWithType[ThrowableFailure]
+    loadConfigFromFiles[Conf](files) should failWithType[NoFilesToRead.type]
   }
 
   it should "ignore files that don't exist" in {

--- a/core/src/test/scala/pureconfig/ConfigConvertChecks.scala
+++ b/core/src/test/scala/pureconfig/ConfigConvertChecks.scala
@@ -90,13 +90,13 @@ trait ConfigConvertChecks { this: FlatSpec with Matchers with GeneratorDrivenPro
    * @param values the values that should not be conver
    * @param cr the [[ConfigConvert]] to test
    */
-  def checkFailure[T, E <: ConfigReaderFailure](values: ConfigValue*)(implicit cr: ConfigReader[T], tpe: TypeTag[T], eTag: ClassTag[E]): Unit =
+  def checkFailure[T, E <: FailureReason](values: ConfigValue*)(implicit cr: ConfigReader[T], tpe: TypeTag[T], eTag: ClassTag[E]): Unit =
     for (value <- values) {
       it should s"fail when it tries to read a value of type ${tpe.tpe} " +
         s"from ${value.render(ConfigRenderOptions.concise())}" in {
           val result = cr.from(value)
           result.left.value.toList should have size 1
-          result.left.value.head shouldBe a[E]
+          result.left.value.head should matchPattern { case ConvertFailure(_: E, _, _) => }
         }
     }
 

--- a/core/src/test/scala/pureconfig/ConfigConvertSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigConvertSuite.scala
@@ -3,7 +3,7 @@ package pureconfig
 import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
 import org.scalacheck.{ Arbitrary, Gen }
 
-import pureconfig.error.{ CannotConvert, ConfigReaderFailures, ThrowableFailure }
+import pureconfig.error.{ CannotConvert, ExceptionThrown }
 
 class ConfigConvertSuite extends BaseSuite {
   implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
@@ -27,9 +27,9 @@ class ConfigConvertSuite extends BaseSuite {
   it should "have a xmap method that wraps exceptions in a ConfigReaderFailure" in {
     val throwable = new Exception("Exception message.")
     val cc = ConfigConvert[Int].xmap[String]({ _ => throw throwable }, { _: String => 42 })
-    cc.from(ConfigValueFactory.fromAnyRef(1)) shouldEqual Left(ConfigReaderFailures(
-      ThrowableFailure(throwable, None, "")))
-    cc.from(ConfigValueFactory.fromAnyRef("test")) shouldEqual Left(ConfigReaderFailures(
-      CannotConvert("test", "Int", """java.lang.NumberFormatException: For input string: "test"""", None, "")))
+    cc.from(ConfigValueFactory.fromAnyRef(1)) should failWith(
+      ExceptionThrown(throwable))
+    cc.from(ConfigValueFactory.fromAnyRef("test")) should failWith(
+      CannotConvert("test", "Int", """java.lang.NumberFormatException: For input string: "test""""))
   }
 }

--- a/core/src/test/scala/pureconfig/ConfigCursorSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigCursorSuite.scala
@@ -27,40 +27,40 @@ class ConfigCursorSuite extends BaseSuite {
       Right("abc")
 
     cursor("[1, 2]").asString should failWith(
-      WrongType(ConfigValueType.LIST, Set(ConfigValueType.STRING), None, defaultPathStr))
+      WrongType(ConfigValueType.LIST, Set(ConfigValueType.STRING)), defaultPathStr)
 
     cursor("{ a: 1, b: 2 }").asString should failWith(
-      WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.STRING), None, defaultPathStr))
+      WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.STRING)), defaultPathStr)
   }
 
   it should "allow being casted to a list cursor in a safe way" in {
     cursor("abc").asListCursor should failWith(
-      WrongType(ConfigValueType.STRING, Set(ConfigValueType.LIST), None, defaultPathStr))
+      WrongType(ConfigValueType.STRING, Set(ConfigValueType.LIST)), defaultPathStr)
 
     cursor("[1, 2]").asListCursor shouldBe
       Right(ConfigListCursor(conf("[1, 2]").asInstanceOf[ConfigList], defaultPath))
 
     cursor("{ a: 1, b: 2 }").asListCursor should failWith(
-      WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.LIST), None, defaultPathStr))
+      WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.LIST)), defaultPathStr)
   }
 
   it should "allow being casted to a list of cursors in a safe way" in {
     cursor("abc").asList should failWith(
-      WrongType(ConfigValueType.STRING, Set(ConfigValueType.LIST), None, defaultPathStr))
+      WrongType(ConfigValueType.STRING, Set(ConfigValueType.LIST)), defaultPathStr)
 
     cursor("[1, 2]").asList shouldBe
       Right(List(cursor("1", "0" :: defaultPath), cursor("2", "1" :: defaultPath)))
 
     cursor("{ a: 1, b: 2 }").asList should failWith(
-      WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.LIST), None, defaultPathStr))
+      WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.LIST)), defaultPathStr)
   }
 
   it should "allow being casted to an object cursor in a safe way" in {
     cursor("abc").asObjectCursor should failWith(
-      WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT), None, defaultPathStr))
+      WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT)), defaultPathStr)
 
     cursor("[1, 2]").asObjectCursor should failWith(
-      WrongType(ConfigValueType.LIST, Set(ConfigValueType.OBJECT), None, defaultPathStr))
+      WrongType(ConfigValueType.LIST, Set(ConfigValueType.OBJECT)), defaultPathStr)
 
     cursor("{ a: 1, b: 2 }").asObjectCursor shouldBe
       Right(ConfigObjectCursor(conf("{ a: 1, b: 2 }").asInstanceOf[ConfigObject], defaultPath))
@@ -68,10 +68,10 @@ class ConfigCursorSuite extends BaseSuite {
 
   it should "allow being casted to a map of cursors in a safe way" in {
     cursor("abc").asMap should failWith(
-      WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT), None, defaultPathStr))
+      WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT)), defaultPathStr)
 
     cursor("[1, 2]").asMap should failWith(
-      WrongType(ConfigValueType.LIST, Set(ConfigValueType.OBJECT), None, defaultPathStr))
+      WrongType(ConfigValueType.LIST, Set(ConfigValueType.OBJECT)), defaultPathStr)
 
     cursor("{ a: 1, b: 2 }").asMap shouldBe
       Right(Map("a" -> cursor("1", "a" :: defaultPath), "b" -> cursor("2", "b" :: defaultPath)))
@@ -79,7 +79,7 @@ class ConfigCursorSuite extends BaseSuite {
 
   it should "allow being casted to a collection cursor in a safe way" in {
     cursor("abc").asCollectionCursor should failWith(
-      WrongType(ConfigValueType.STRING, Set(ConfigValueType.LIST, ConfigValueType.OBJECT), None, defaultPathStr))
+      WrongType(ConfigValueType.STRING, Set(ConfigValueType.LIST, ConfigValueType.OBJECT)), defaultPathStr)
 
     cursor("[1, 2]").asCollectionCursor shouldBe
       Right(Left(ConfigListCursor(conf("[1, 2]").asInstanceOf[ConfigList], defaultPath)))
@@ -116,7 +116,7 @@ class ConfigCursorSuite extends BaseSuite {
   it should "allow access to a given index in a safe way" in {
     listCursor("[1, 2]").atIndex(0) shouldBe Right(cursor("1", "0" :: defaultPath))
     listCursor("[1, 2]").atIndex(1) shouldBe Right(cursor("2", "1" :: defaultPath))
-    listCursor("[1, 2]").atIndex(2) should failWith(KeyNotFound(s"$defaultPathStr.2", None, Set()))
+    listCursor("[1, 2]").atIndex(2) should failWith(KeyNotFound("2", Set()), defaultPathStr)
   }
 
   it should "allow access to a given index returning an undefined value cursor on out-of-range indices" in {
@@ -128,7 +128,7 @@ class ConfigCursorSuite extends BaseSuite {
   it should "provide a tailOption method that keeps the absolute paths correct" in {
     listCursor("[1, 2]").tailOption shouldBe Some(listCursor("[2]").copy(offset = 1))
     listCursor("[1, 2]").tailOption.get.atIndex(0) shouldBe Right(cursor("2", "1" :: defaultPath))
-    listCursor("[1, 2]").tailOption.get.atIndex(1) should failWith(KeyNotFound(s"$defaultPathStr.2", None, Set()))
+    listCursor("[1, 2]").tailOption.get.atIndex(1) should failWith(KeyNotFound("2", Set()), defaultPathStr)
     listCursor("[]").tailOption shouldBe None
   }
 
@@ -156,7 +156,7 @@ class ConfigCursorSuite extends BaseSuite {
 
   it should "allow access to a given key in a safe way" in {
     objCursor("{ a: 1, b: 2 }").atKey("a") shouldBe Right(cursor("1", "a" :: defaultPath))
-    objCursor("{ a: 1, b: 2 }").atKey("c") should failWith(KeyNotFound(s"$defaultPathStr.c", None, Set()))
+    objCursor("{ a: 1, b: 2 }").atKey("c") should failWith(KeyNotFound("c", Set()), defaultPathStr)
   }
 
   it should "allow access to a given key returning an undefined value cursor on non-existing keys" in {

--- a/core/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
@@ -29,12 +29,11 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
 
     exception.getMessage shouldBe
       s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$Conf. Failures are:
+          |  at the root:
+          |    - Key not found: 'b'.
+          |    - Key not found: 'c'.
           |  at 'a':
           |    - Cannot convert 'string' to Int: java.lang.NumberFormatException: For input string: "string".
-          |  at 'b':
-          |    - Key not found.
-          |  at 'c':
-          |    - Key not found.
           |""".stripMargin
   }
 
@@ -132,8 +131,8 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
       s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$EnclosingA. Failures are:
           |  at 'values.v1':
           |    - No valid coproduct choice found for '{"a":2,"type":"unexpected"}'.
-          |  at 'values.v3.type':
-          |    - Key not found.
+          |  at 'values.v3':
+          |    - Key not found: 'type'.
           |""".stripMargin
   }
 
@@ -167,18 +166,16 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
 
     exception.getMessage shouldBe
       s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$EnclosingConf. Failures are:
-          |  at 'camel-case-conf.camel-case-int':
-          |    - Key not found. You might have a misconfigured ProductHint, since the following similar keys were found:
-          |       - 'camel-case-conf.camelCaseInt'
-          |  at 'camel-case-conf.camel-case-string':
-          |    - Key not found. You might have a misconfigured ProductHint, since the following similar keys were found:
-          |       - 'camel-case-conf.camelCaseString'
-          |  at 'snake-case-conf.snake-case-int':
-          |    - Key not found. You might have a misconfigured ProductHint, since the following similar keys were found:
-          |       - 'snake-case-conf.snake_case_int'
-          |  at 'snake-case-conf.snake-case-string':
-          |    - Key not found. You might have a misconfigured ProductHint, since the following similar keys were found:
-          |       - 'snake-case-conf.snake_case_string'
+          |  at 'camel-case-conf':
+          |    - Key not found: 'camel-case-int'. You might have a misconfigured ProductHint, since the following similar keys were found:
+          |       - 'camelCaseInt'
+          |    - Key not found: 'camel-case-string'. You might have a misconfigured ProductHint, since the following similar keys were found:
+          |       - 'camelCaseString'
+          |  at 'snake-case-conf':
+          |    - Key not found: 'snake-case-int'. You might have a misconfigured ProductHint, since the following similar keys were found:
+          |       - 'snake_case_int'
+          |    - Key not found: 'snake-case-string'. You might have a misconfigured ProductHint, since the following similar keys were found:
+          |       - 'snake_case_string'
           |""".stripMargin
   }
 
@@ -193,8 +190,8 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
 
     exception.getMessage shouldBe
       s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$Conf. Failures are:
-          |  at 'a':
-          |    - (file:${workingDir}${file}:1) Key not found.
+          |  at the root:
+          |    - (file:${workingDir}${file}:1) Key not found: 'a'.
           |  at 'c':
           |    - (file:${workingDir}${file}:3) Cannot convert 'hello' to Int: java.lang.NumberFormatException: For input string: "hello".
           |""".stripMargin

--- a/core/src/test/scala/pureconfig/ConfigReaderFailureLocationSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderFailureLocationSuite.scala
@@ -24,22 +24,27 @@ class ConfigReaderFailureLocationSuite extends FlatSpec with Matchers with Eithe
 
     val failures1 = conf.get("conf").to[Conf].left.value.toList
     failures1 should have size 2
-    failures1 should contain(KeyNotFound("a", Some(ConfigValueLocation(new URL("file", "", workingDir + file), 1))))
-    failures1 should contain(CannotConvert(
-      "hello",
-      "Int",
-      """java.lang.NumberFormatException: For input string: "hello"""",
+    failures1 should contain(ConvertFailure(
+      KeyNotFound("a"),
+      Some(ConfigValueLocation(new URL("file", "", workingDir + file), 1)),
+      ""))
+    failures1 should contain(ConvertFailure(
+      CannotConvert("hello", "Int", """java.lang.NumberFormatException: For input string: "hello""""),
       Some(ConfigValueLocation(new URL("file", "", workingDir + file), 3)),
       "c"))
 
     val failures2 = conf.get("other-conf").to[Conf].left.value.toList
     failures2 should have size 3
-    failures2 should contain(KeyNotFound("a", Some(ConfigValueLocation(new URL("file", "", workingDir + file), 7))))
-    failures2 should contain(KeyNotFound("b", Some(ConfigValueLocation(new URL("file", "", workingDir + file), 7))))
-    failures2 should contain(CannotConvert(
-      "hello",
-      "Int",
-      """java.lang.NumberFormatException: For input string: "hello"""",
+    failures2 should contain(ConvertFailure(
+      KeyNotFound("a"),
+      Some(ConfigValueLocation(new URL("file", "", workingDir + file), 7)),
+      ""))
+    failures2 should contain(ConvertFailure(
+      KeyNotFound("b"),
+      Some(ConfigValueLocation(new URL("file", "", workingDir + file), 7)),
+      ""))
+    failures2 should contain(ConvertFailure(
+      CannotConvert("hello", "Int", """java.lang.NumberFormatException: For input string: "hello""""),
       Some(ConfigValueLocation(new URL("file", "", workingDir + file), 9)),
       "c"))
   }
@@ -55,10 +60,8 @@ class ConfigReaderFailureLocationSuite extends FlatSpec with Matchers with Eithe
 
     val failures = conf.get("conf").to[Conf].left.value.toList
     failures should have size 1
-    failures should contain(CannotConvert(
-      "string",
-      "Int",
-      """java.lang.NumberFormatException: For input string: "string"""",
+    failures should contain(ConvertFailure(
+      CannotConvert("string", "Int", """java.lang.NumberFormatException: For input string: "string""""),
       Some(ConfigValueLocation(new URL("file", "", workingDir + file2), 2)),
       "a"))
   }

--- a/core/src/test/scala/pureconfig/ConfigReaderMatchers.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderMatchers.scala
@@ -4,14 +4,26 @@ import scala.reflect.ClassTag
 
 import org.scalatest._
 import org.scalatest.matchers.{ MatchResult, Matcher }
-import pureconfig.error.{ ConfigReaderFailure, ConfigReaderFailures }
+import pureconfig.error._
 
 trait ConfigReaderMatchers { this: FlatSpec with Matchers =>
+
+  def failWith(reason: FailureReason): Matcher[Either[ConfigReaderFailures, Any]] =
+    matchPattern { case Left(ConfigReaderFailures(ConvertFailure(`reason`, _, _), Nil)) => }
+
+  def failWith(
+    reason: FailureReason,
+    path: String,
+    location: Option[ConfigValueLocation] = None): Matcher[Either[ConfigReaderFailures, Any]] =
+    be(Left(ConfigReaderFailures(ConvertFailure(reason, location, path), Nil)))
 
   def failWith(failure: ConfigReaderFailure): Matcher[Either[ConfigReaderFailures, Any]] =
     be(Left(ConfigReaderFailures(failure, Nil)))
 
-  def failWithType[Failure <: ConfigReaderFailure: ClassTag]: Matcher[Either[ConfigReaderFailures, Any]] =
+  def failWithType[Reason <: FailureReason: ClassTag]: Matcher[Either[ConfigReaderFailures, Any]] =
+    matchPattern { case Left(ConfigReaderFailures(ConvertFailure(_: Reason, _, _), Nil)) => }
+
+  def failWithType[Failure <: ConfigReaderFailure: ClassTag](implicit dummy: DummyImplicit): Matcher[Either[ConfigReaderFailures, Any]] =
     matchPattern { case Left(ConfigReaderFailures(_: Failure, Nil)) => }
 
   def failLike(pf: PartialFunction[ConfigReaderFailure, MatchResult]) =

--- a/core/src/test/scala/pureconfig/CoproductConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/CoproductConvertersSuite.scala
@@ -29,15 +29,11 @@ class CoproductConvertersSuite extends BaseSuite {
 
   it should "return a proper ConfigReaderFailure if the hint field in a coproduct is missing" in {
     val conf = ConfigFactory.parseString("{ can-fly = true }")
-    val failures = ConfigConvert[AnimalConfig].from(conf.root()).left.value.toList
-    failures should have size 1
-    failures.head shouldBe a[KeyNotFound]
+    ConfigConvert[AnimalConfig].from(conf.root()) should failWithType[KeyNotFound]
   }
 
   it should "return a proper ConfigReaderFailure when a coproduct config is missing" in {
     case class AnimalCage(animal: AnimalConfig)
-    val failures = ConfigConvert[AnimalCage].from(ConfigFactory.empty().root()).left.value.toList
-    failures should have size 1
-    failures.head shouldBe a[KeyNotFound]
+    ConfigConvert[AnimalCage].from(ConfigFactory.empty().root()) should failWithType[KeyNotFound]
   }
 }

--- a/core/src/test/scala/pureconfig/CoproductHintSuite.scala
+++ b/core/src/test/scala/pureconfig/CoproductHintSuite.scala
@@ -25,8 +25,8 @@ class CoproductHintSuite extends BaseSuite {
 
     it should "fail to read values that are not objects when using a FieldCoproductHint" in {
       val conf = ConfigValueFactory.fromAnyRef("Dog")
-      ConfigConvert[AnimalConfig].from(conf) shouldEqual Left(ConfigReaderFailures(
-        WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT), None, "")))
+      ConfigConvert[AnimalConfig].from(conf) should failWith(
+        WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT)))
     }
 
     it should "throw an exception when the hint field conflicts with a field of an option when using a FieldCoproductHint" in {
@@ -40,7 +40,8 @@ class CoproductHintSuite extends BaseSuite {
       cc.from(conf.root()) should failWithType[KeyNotFound] // "typ" should not be passed to the coproduct option
 
       val ex = the[ConfigReaderException[_]] thrownBy cc.to(AmbiguousConf("ambiguousconf"))
-      ex.failures.toList shouldEqual List(CollidingKeys("typ", ConfigValueFactory.fromAnyRef("ambiguousconf"), None))
+      ex.failures.toList shouldEqual List(ConvertFailure(
+        CollidingKeys("typ", ConfigValueFactory.fromAnyRef("ambiguousconf")), None, ""))
     }
   }
 
@@ -71,13 +72,13 @@ class CoproductHintSuite extends BaseSuite {
 
     it should "fail to read values that are not case objects when using an EnumCoproductHint" in {
       val conf = ConfigFactory.parseString("{ which-animal = Dog, age = 2 }")
-      ConfigConvert[AnimalConfig].from(conf.root()) shouldEqual Left(ConfigReaderFailures(
-        WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.STRING), None, "")))
+      ConfigConvert[AnimalConfig].from(conf.root()) should failWith(
+        WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.STRING)))
     }
 
     it should "fail to write values that are not case objects when using an EnumCoproductHint" in {
       val ex = the[ConfigReaderException[_]] thrownBy ConfigConvert[AnimalConfig].to(DogConfig(2))
-      ex.failures.toList shouldEqual List(NonEmptyObjectFound("DogConfig", None, ""))
+      ex.failures.toList shouldEqual List(ConvertFailure(NonEmptyObjectFound("DogConfig"), None, ""))
     }
   }
 

--- a/core/src/test/scala/pureconfig/ProductConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/ProductConvertersSuite.scala
@@ -68,7 +68,7 @@ class ProductConvertersSuite extends BaseSuite {
       def from(cur: ConfigCursor) =
         if (cur.isUndefined) Right(42) else {
           val s = cur.value.render(ConfigRenderOptions.concise)
-          cur.scopeFailures(catchReadError(_.toInt)(implicitly)(s))
+          cur.scopeFailure(catchReadError(_.toInt)(implicitly)(s))
         }
       def to(v: Int) = ???
     }

--- a/core/src/test/scala/pureconfig/ProductConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/ProductConvertersSuite.scala
@@ -1,14 +1,13 @@
 package pureconfig
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable.Seq
 
 import com.typesafe.config.{ ConfigFactory, ConfigRenderOptions }
 import org.joda.time.format.ISODateTimeFormat
 import org.scalacheck.ScalacheckShapeless._
 import pureconfig.ConfigConvert.catchReadError
 import pureconfig.arbitrary._
-import pureconfig.error.{ ConfigReaderFailures, KeyNotFound, WrongType }
+import pureconfig.error.{ KeyNotFound, WrongType }
 
 class ProductConvertersSuite extends BaseSuite {
 
@@ -45,7 +44,7 @@ class ProductConvertersSuite extends BaseSuite {
 
   it should s"return a ${classOf[KeyNotFound]} when a key is not in the configuration" in {
     case class Foo(i: Int)
-    ConfigConvert[Foo].from(emptyConf).left.value.toList should contain theSameElementsAs Seq(KeyNotFound("i", None))
+    ConfigConvert[Foo].from(emptyConf) should failWith(KeyNotFound("i"))
   }
 
   it should s"return a ${classOf[KeyNotFound]} when a custom convert is used and when a key is not in the configuration" in {
@@ -57,19 +56,19 @@ class ProductConvertersSuite extends BaseSuite {
       def to(conf: InnerConf) = ConfigFactory.parseString(s"{ v: ${conf.v} }").root()
     }
 
-    ConfigConvert[EnclosingConf].from(emptyConf).left.value.toList should contain theSameElementsAs Seq(KeyNotFound("conf", None))
+    ConfigConvert[EnclosingConf].from(emptyConf) should failWith(KeyNotFound("conf"))
   }
 
   it should "allow custom ConfigConverts to handle missing keys" in {
     case class Conf(a: Int, b: Int)
     val conf = ConfigFactory.parseString("""{ a: 1 }""").root()
-    ConfigConvert[Conf].from(conf).left.value.toList should contain theSameElementsAs Seq(KeyNotFound("b", None))
+    ConfigConvert[Conf].from(conf) should failWith(KeyNotFound("b"))
 
     implicit val defaultInt = new ConfigConvert[Int] with AllowMissingKey {
-      def from(v: ConfigCursor) =
-        if (v.value == null) Right(42) else {
-          val s = v.value.render(ConfigRenderOptions.concise)
-          catchReadError(_.toInt)(implicitly)(s)(None).left.map(ConfigReaderFailures.apply)
+      def from(cur: ConfigCursor) =
+        if (cur.isUndefined) Right(42) else {
+          val s = cur.value.render(ConfigRenderOptions.concise)
+          cur.scopeFailures(catchReadError(_.toInt)(implicitly)(s))
         }
       def to(v: Int) = ???
     }
@@ -81,9 +80,7 @@ class ProductConvertersSuite extends BaseSuite {
     case class Bar(foo: Foo)
     case class FooBar(foo: Foo, bar: Bar)
     val conf = ConfigFactory.parseMap(Map("foo.i" -> 1, "bar.foo" -> "").asJava).root()
-    val failures = ConfigConvert[FooBar].from(conf).left.value.toList
-    failures should have size 1
-    failures.head shouldBe a[WrongType]
+    ConfigConvert[FooBar].from(conf) should failWithType[WrongType]
   }
 
   it should "consider default arguments by default" in {
@@ -97,18 +94,16 @@ class ProductConvertersSuite extends BaseSuite {
     ConfigConvert[Conf].from(conf2).right.value shouldBe Conf(2, "default", 50, InnerConf(43, 44), Some(45))
 
     val conf3 = ConfigFactory.parseMap(Map("c" -> 50).asJava).root()
-    ConfigConvert[Conf].from(conf3).left.value.toList should contain theSameElementsAs Seq(KeyNotFound("a", None))
+    ConfigConvert[Conf].from(conf3) should failWith(KeyNotFound("a"))
 
     val conf4 = ConfigFactory.parseMap(Map("a" -> 2, "d.e" -> 5).asJava).root()
-    ConfigConvert[Conf].from(conf4).left.value.toList should contain theSameElementsAs Seq(KeyNotFound("d.g", None))
+    ConfigConvert[Conf].from(conf4) should failWith(KeyNotFound("g"), "d")
 
     val conf5 = ConfigFactory.parseMap(Map("a" -> 2, "d.e" -> 5, "d.g" -> 6).asJava).root()
     ConfigConvert[Conf].from(conf5).right.value shouldBe Conf(2, "default", 42, InnerConf(5, 6), Some(45))
 
     val conf6 = ConfigFactory.parseMap(Map("a" -> 2, "d" -> "notAnInnerConf").asJava).root()
-    val failures = ConfigConvert[Conf].from(conf6).left.value.toList
-    failures should have size 1
-    failures.head shouldBe a[WrongType]
+    ConfigConvert[Conf].from(conf6) should failWithType[WrongType]
 
     val conf7 = ConfigFactory.parseMap(Map("a" -> 2, "c" -> 50, "e" -> 1).asJava).root()
     ConfigConvert[Conf].from(conf7).right.value shouldBe Conf(2, "default", 50, InnerConf(43, 44), Some(1))

--- a/core/src/test/scala/pureconfig/TupleConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/TupleConvertersSuite.scala
@@ -32,13 +32,17 @@ class TupleConvertersSuite extends BaseSuite {
   // Check errors
   checkFailure[(String, Int), CannotConvert](ConfigValueFactory.fromAnyRef(Map("_1" -> "one", "_2" -> "two").asJava))
   checkFailure[(String, Int), CannotConvert](ConfigValueFactory.fromIterable(List("one", "two").asJava))
+
   checkFailures[(Int, Int, Int)](
-    ConfigValueFactory.fromIterable(List(1, "one").asJava) -> ConfigReaderFailures(WrongSizeList(3, 2, None, ""), Nil))
+    ConfigValueFactory.fromIterable(List(1, "one").asJava) -> ConfigReaderFailures(
+      ConvertFailure(WrongSizeList(3, 2), None, ""), Nil))
+
   checkFailures[(Int, Int, Int)](
     ConfigValueFactory.fromAnyRef(Map("_1" -> "one", "_2" -> 2).asJava) -> ConfigReaderFailures(
-      CannotConvert("one", "Int", """java.lang.NumberFormatException: For input string: "one"""", None, "_1"),
-      List(KeyNotFound("_3", None, Set()))))
+      ConvertFailure(CannotConvert("one", "Int", """java.lang.NumberFormatException: For input string: "one""""), None, "_1"),
+      List(ConvertFailure(KeyNotFound("_3", Set()), None, ""))))
+
   checkFailures[(String, Int)](
     ConfigValueFactory.fromAnyRef("str") -> ConfigReaderFailures(
-      WrongType(ConfigValueType.STRING, Set(ConfigValueType.LIST, ConfigValueType.OBJECT), None, "")))
+      ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.LIST, ConfigValueType.OBJECT)), None, "")))
 }

--- a/core/src/test/scala/pureconfig/ValueClassSuite.scala
+++ b/core/src/test/scala/pureconfig/ValueClassSuite.scala
@@ -41,7 +41,7 @@ class ValueClassSuite extends BaseSuite {
 
   {
     implicit def genericValueReader[T](implicit readT: Read[T]): ConfigReader[GenericValue[T]] =
-      ConfigReader.fromString(s => _ => Right(GenericValue.from(readT.read(s))))
+      ConfigReader.fromString(s => Right(GenericValue.from(readT.read(s))))
 
     "ConfigReader" should " should be able to override value classes ConfigReader" in {
       val reader = ConfigReader[GenericValue[String]]

--- a/core/src/test/scala/pureconfig/data/Percentage.scala
+++ b/core/src/test/scala/pureconfig/data/Percentage.scala
@@ -1,7 +1,7 @@
 package pureconfig.data
 
 import pureconfig.ConfigConvert
-import pureconfig.error.{ CannotConvert, ConfigValueLocation }
+import pureconfig.error.CannotConvert
 
 final case class Percentage(value: Int) {
   def toDoubleFraction: Double = value.toDouble / 100D
@@ -9,9 +9,9 @@ final case class Percentage(value: Int) {
 }
 
 object Percentage {
-  private val failConfigReadPercentage =
-    (s: String) => (l: Option[ConfigValueLocation]) =>
-      Left(CannotConvert(s, "Percentage", "Percentage is a dummy type, you should not read it", l, ""))
+  private val failConfigReadPercentage = { s: String =>
+    Left(CannotConvert(s, "Percentage", "Percentage is a dummy type, you should not read it"))
+  }
 
   implicit val percentageConfigWriter =
     ConfigConvert.viaNonEmptyString[Percentage](failConfigReadPercentage, percentage => s"${percentage.value} %")

--- a/docs/add-support-for-complex-types.md
+++ b/docs/add-support-for-complex-types.md
@@ -88,54 +88,35 @@ Similarly to adding support for simple types, it is possible to manually create 
 `ConfigReader[Identifiable]`:
 
 ```scala
-import com.typesafe.config._
 import pureconfig._
 import pureconfig.error._
 
-def extractId(obj: ConfigObject): Either[ConfigReaderFailures, String] =
-  Option(obj.get("id")) match {
-    case None =>
-      Left(ConfigReaderFailures(KeyNotFound("id", ConfigValueLocation(obj))))
-    case Some(id) =>
-      ConfigReader[String].from(id)
-  }
+def extractId(objCur: ConfigObjectCursor): Either[ConfigReaderFailures, String] =
+  objCur.atKey("id").right.flatMap(_.asString)
 
-def extractValue(obj: ConfigObject): Either[ConfigReaderFailures, Int] =
-  Option(obj.get("value")) match {
-    case None =>
-      Left(ConfigReaderFailures(KeyNotFound("value", ConfigValueLocation(obj))))
-    case Some(value) =>
-      ConfigReader[Int].from(value)
-  }
+def extractValue(objCur: ConfigObjectCursor): Either[ConfigReaderFailures, Int] =
+  objCur.atKey("value").right.flatMap(ConfigReader[Int].from(_))
 
-implicit val identifiableConfigReader = ConfigReader.fromFunction({
-case obj: ConfigObject =>
- Option(obj.get("type")) match {
-   case None =>
-     Left(ConfigReaderFailures(KeyNotFound("type", ConfigValueLocation(obj))))
-   case Some(t) if t.valueType() == ConfigValueType.STRING =>
-     t.unwrapped().asInstanceOf[String] match {
-       case "class1" => extractId(obj).right.map(new Class1(_))
-       case "class2" =>
-         for {
-           id <- extractId(obj).right
-           value <- extractValue(obj).right
-         } yield new Class2(id, value)
-       case x =>
-         Left(ConfigReaderFailures(CannotConvert(obj.toString,
-           "Identifiable", s"type has value $t instead of class1 or class2",
-           ConfigValueLocation(obj),
-           "")))
-     }
-   case Some(t) =>
-     Left(ConfigReaderFailures(CannotConvert(obj.toString,
-       "Identifiable", s"type has value $t instead of class1 or class2",
-       ConfigValueLocation(obj),
-       "")))
- }
-case wrong =>
-  Left(ConfigReaderFailures(WrongType(wrong.valueType(), Set(ConfigValueType.OBJECT), ConfigValueLocation(wrong), "")))
-})
+def extractByType(typ: String, objCur: ConfigObjectCursor): Either[ConfigReaderFailures, Identifiable] = typ match {
+  case "class1" => extractId(objCur).right.map(new Class1(_))
+  case "class2" =>
+    for {
+      id <- extractId(objCur).right
+      value <- extractValue(objCur).right
+    } yield new Class2(id, value)
+  case t =>
+    objCur.failed(CannotConvert(objCur.value.toString, "Identifiable",
+      s"type has value $t instead of class1 or class2"))
+}
+
+implicit val identifiableConfigReader = ConfigReader.fromCursor { cur =>
+  for {
+    objCur <- cur.asObjectCursor.right
+    typeCur <- objCur.atKey("type").right
+    typeStr <- typeCur.asString.right
+    ident <- extractByType(typeStr, objCur).right
+  } yield ident
+}
 ```
 
 **pros**: The main feature of this method is that PureConfig delegates to it when decoding your configuration.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -18,7 +18,7 @@ import pureconfig.error._
 import java.nio.file.{ Path, Paths }
 
 val cv = ConfigFactory.load.root().get("conf")
-val notFound = KeyNotFound("xpto", ConfigValueLocation(cv)).location.get
+val notFound = ConvertFailure(KeyNotFound("xpto"), ConfigValueLocation(cv), "conf").location.get
 ```
 
 We can extract useful error data:

--- a/docs/handling-missing-keys.md
+++ b/docs/handling-missing-keys.md
@@ -20,7 +20,7 @@ Loading a `Foo` results in a `Left` because of missing keys, but loading a `FooO
 
 ```scala
 ConfigFactory.empty.to[Foo]
-// res1: Either[pureconfig.error.ConfigReaderFailures,Foo] = Left(ConfigReaderFailures(KeyNotFound(a,None,Set()),List()))
+// res1: Either[pureconfig.error.ConfigReaderFailures,Foo] = Left(ConfigReaderFailures(ConvertFailure(KeyNotFound(a,Set()),None,),List()))
 
 ConfigFactory.empty.to[FooOpt]
 // res2: Either[pureconfig.error.ConfigReaderFailures,FooOpt] = Right(FooOpt(None))

--- a/docs/override-behaviour-for-case-classes.md
+++ b/docs/override-behaviour-for-case-classes.md
@@ -123,7 +123,7 @@ implicit val hint = ProductHint[Holiday](useDefaultArgs = false)
 // hint: pureconfig.ProductHint[Holiday] = ProductHintImpl(<function1>,false,true)
 
 loadConfig[Holiday](parseString("""{ how-long: 21 days }"""))
-// res9: Either[pureconfig.error.ConfigReaderFailures,Holiday] = Left(ConfigReaderFailures(KeyNotFound(where,None,Set()),List()))
+// res9: Either[pureconfig.error.ConfigReaderFailures,Holiday] = Left(ConfigReaderFailures(ConvertFailure(KeyNotFound(where,Set()),None,),List()))
 ```
 
 ### Unknown keys
@@ -146,5 +146,5 @@ implicit val hint = ProductHint[Holiday](allowUnknownKeys = false)
 // hint: pureconfig.ProductHint[Holiday] = ProductHintImpl(<function1>,true,false)
 
 loadConfig[Holiday](parseString("""{ wher: Texas, how-long: 21 days }"""))
-// res2: Either[pureconfig.error.ConfigReaderFailures,Holiday] = Left(ConfigReaderFailures(UnknownKey(wher,None),List()))
+// res2: Either[pureconfig.error.ConfigReaderFailures,Holiday] = Left(ConfigReaderFailures(ConvertFailure(UnknownKey(wher),None,wher),List()))
 ```

--- a/docs/src/main/tut/add-support-for-complex-types.md
+++ b/docs/src/main/tut/add-support-for-complex-types.md
@@ -88,54 +88,35 @@ Similarly to adding support for simple types, it is possible to manually create 
 `ConfigReader[Identifiable]`:
 
 ```tut:silent
-import com.typesafe.config._
 import pureconfig._
 import pureconfig.error._
 
-def extractId(obj: ConfigObject): Either[ConfigReaderFailures, String] =
-  Option(obj.get("id")) match {
-    case None =>
-      Left(ConfigReaderFailures(KeyNotFound("id", ConfigValueLocation(obj))))
-    case Some(id) =>
-      ConfigReader[String].from(id)
-  }
+def extractId(objCur: ConfigObjectCursor): Either[ConfigReaderFailures, String] =
+  objCur.atKey("id").right.flatMap(_.asString)
 
-def extractValue(obj: ConfigObject): Either[ConfigReaderFailures, Int] =
-  Option(obj.get("value")) match {
-    case None =>
-      Left(ConfigReaderFailures(KeyNotFound("value", ConfigValueLocation(obj))))
-    case Some(value) =>
-      ConfigReader[Int].from(value)
-  }
+def extractValue(objCur: ConfigObjectCursor): Either[ConfigReaderFailures, Int] =
+  objCur.atKey("value").right.flatMap(ConfigReader[Int].from(_))
 
-implicit val identifiableConfigReader = ConfigReader.fromFunction({
-case obj: ConfigObject =>
- Option(obj.get("type")) match {
-   case None =>
-     Left(ConfigReaderFailures(KeyNotFound("type", ConfigValueLocation(obj))))
-   case Some(t) if t.valueType() == ConfigValueType.STRING =>
-     t.unwrapped().asInstanceOf[String] match {
-       case "class1" => extractId(obj).right.map(new Class1(_))
-       case "class2" =>
-         for {
-           id <- extractId(obj).right
-           value <- extractValue(obj).right
-         } yield new Class2(id, value)
-       case x =>
-         Left(ConfigReaderFailures(CannotConvert(obj.toString,
-           "Identifiable", s"type has value $t instead of class1 or class2",
-           ConfigValueLocation(obj),
-           "")))
-     }
-   case Some(t) =>
-     Left(ConfigReaderFailures(CannotConvert(obj.toString,
-       "Identifiable", s"type has value $t instead of class1 or class2",
-       ConfigValueLocation(obj),
-       "")))
- }
-case wrong =>
-  Left(ConfigReaderFailures(WrongType(wrong.valueType(), Set(ConfigValueType.OBJECT), ConfigValueLocation(wrong), "")))
-})
+def extractByType(typ: String, objCur: ConfigObjectCursor): Either[ConfigReaderFailures, Identifiable] = typ match {
+  case "class1" => extractId(objCur).right.map(new Class1(_))
+  case "class2" =>
+    for {
+      id <- extractId(objCur).right
+      value <- extractValue(objCur).right
+    } yield new Class2(id, value)
+  case t =>
+    objCur.failed(CannotConvert(objCur.value.toString, "Identifiable",
+      s"type has value $t instead of class1 or class2"))
+}
+
+implicit val identifiableConfigReader = ConfigReader.fromCursor { cur =>
+  for {
+    objCur <- cur.asObjectCursor.right
+    typeCur <- objCur.atKey("type").right
+    typeStr <- typeCur.asString.right
+    ident <- extractByType(typeStr, objCur).right
+  } yield ident
+}
 ```
 
 **pros**: The main feature of this method is that PureConfig delegates to it when decoding your configuration.

--- a/docs/src/main/tut/error-handling.md
+++ b/docs/src/main/tut/error-handling.md
@@ -18,7 +18,7 @@ import pureconfig.error._
 import java.nio.file.{ Path, Paths }
 
 val cv = ConfigFactory.load.root().get("conf")
-val notFound = KeyNotFound("xpto", ConfigValueLocation(cv)).location.get
+val notFound = ConvertFailure(KeyNotFound("xpto"), ConfigValueLocation(cv), "conf").location.get
 ```
 
 We can extract useful error data:

--- a/modules/cats/README.md
+++ b/modules/cats/README.md
@@ -103,7 +103,7 @@ val conf = parseString("{}")
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({}))
 
 val res = loadConfig[MyConfig2](conf).left.map(_.toNonEmptyList)
-// res: scala.util.Either[cats.data.NonEmptyList[pureconfig.error.ConfigReaderFailure],MyConfig2] = Left(NonEmptyList(KeyNotFound(a,None,Set()), KeyNotFound(b,None,Set())))
+// res: scala.util.Either[cats.data.NonEmptyList[pureconfig.error.ConfigReaderFailure],MyConfig2] = Left(NonEmptyList(ConvertFailure(KeyNotFound(a,Set()),None,), ConvertFailure(KeyNotFound(b,Set()),None,)))
 ```
 
 This allows cats users to easily convert a result of a `ConfigReader` into a `ValidatedNel`:
@@ -116,5 +116,5 @@ import pureconfig.error.ConfigReaderFailure
 ```scala
 val catsRes: ValidatedNel[ConfigReaderFailure, MyConfig2] =
   Validated.fromEither(res)
-// catsRes: cats.data.ValidatedNel[pureconfig.error.ConfigReaderFailure,MyConfig2] = Invalid(NonEmptyList(KeyNotFound(a,None,Set()), KeyNotFound(b,None,Set())))
+// catsRes: cats.data.ValidatedNel[pureconfig.error.ConfigReaderFailure,MyConfig2] = Invalid(NonEmptyList(ConvertFailure(KeyNotFound(a,Set()),None,), ConvertFailure(KeyNotFound(b,Set()),None,)))
 ```

--- a/modules/cats/src/main/scala/pureconfig/module/Cats.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/Cats.scala
@@ -1,6 +1,6 @@
 package pureconfig.module
 
-import pureconfig.error.{ ConvertFailure, ConfigValueLocation }
+import pureconfig.error.FailureReason
 
 object Cats {
 
@@ -8,15 +8,8 @@ object Cats {
    * A failure representing an unexpected empty traversable
    *
    * @param typ the type that was attempted to be converted to from an empty string
-   * @param location an optional location of the ConfigValue that raised the
-   *                 failure
-   * @param path the path to the value which was an unexpected empty string
    */
-  final case class EmptyTraversableFound(typ: String, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
+  final case class EmptyTraversableFound(typ: String) extends FailureReason {
     def description = s"Empty collection found when trying to convert to $typ."
-
-    def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-      this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
   }
-
 }

--- a/modules/cats/src/main/scala/pureconfig/module/cats/EmptyTraversableFound.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/cats/EmptyTraversableFound.scala
@@ -1,18 +1,12 @@
 package pureconfig.module.cats
 
-import pureconfig.error.{ ConvertFailure, ConfigValueLocation }
+import pureconfig.error.FailureReason
 
 /**
  * A failure representing an unexpected empty traversable
  *
  * @param typ the type that was attempted to be converted to from an empty string
- * @param location an optional location of the ConfigValue that raised the
- *                 failure
- * @param path the path to the value which was an unexpected empty string
  */
-final case class EmptyTraversableFound(typ: String, location: Option[ConfigValueLocation], path: String) extends ConvertFailure {
+final case class EmptyTraversableFound(typ: String) extends FailureReason {
   def description = s"Empty collection found when trying to convert to $typ."
-
-  def withImprovedContext(parentKey: String, parentLocation: Option[ConfigValueLocation]) =
-    this.copy(location = location orElse parentLocation, path = if (path.isEmpty) parentKey else parentKey + "." + path)
 }

--- a/modules/cats/src/main/scala/pureconfig/module/cats/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/cats/package.scala
@@ -15,7 +15,7 @@ package object cats {
   private[pureconfig] def fromNonEmpty[F[_], G[_], T](fromFT: F[T] => Option[G[T]])(cur: ConfigCursor)(implicit ct: ClassTag[F[T]], fReader: ConfigReader[F[T]]): Either[ConfigReaderFailures, G[T]] =
     fReader.from(cur).right.flatMap { ft =>
       fromFT(ft) match {
-        case None => Left(ConfigReaderFailures(EmptyTraversableFound(ct.toString, cur.location, cur.path)))
+        case None => cur.failed(EmptyTraversableFound(ct.toString))
         case Some(nonEmpty) => Right(nonEmpty)
       }
     }

--- a/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
@@ -2,11 +2,10 @@ package pureconfig.module.cats
 
 import cats.data.{ NonEmptyList, NonEmptyVector }
 import com.typesafe.config.ConfigFactory.parseString
-import org.scalatest._
-import pureconfig.error.ConfigReaderFailures
+import pureconfig.BaseSuite
 import pureconfig.syntax._
 
-class CatsSuite extends FlatSpec with Matchers with EitherValues {
+class CatsSuite extends BaseSuite {
 
   case class Numbers(numbers: NonEmptyList[Int])
 
@@ -17,8 +16,7 @@ class CatsSuite extends FlatSpec with Matchers with EitherValues {
 
   it should "return an EmptyTraversableFound when reading empty lists into NonEmptyList" in {
     val config = parseString("{ numbers: [] }")
-    config.to[Numbers] shouldEqual
-      Left(ConfigReaderFailures(EmptyTraversableFound("scala.collection.immutable.List", None, "numbers"), Nil))
+    config.to[Numbers] should failWith(EmptyTraversableFound("scala.collection.immutable.List"), "numbers")
   }
 
   case class NumVec(numbers: NonEmptyVector[Int])
@@ -30,7 +28,6 @@ class CatsSuite extends FlatSpec with Matchers with EitherValues {
 
   it should "return an EmptyTraversableFound when reading empty lists into NonEmptyVector" in {
     val config = parseString("{ numbers: [] }")
-    config.to[NumVec] shouldEqual
-      Left(ConfigReaderFailures(EmptyTraversableFound("scala.collection.immutable.Vector", None, "numbers"), Nil))
+    config.to[NumVec] should failWith(EmptyTraversableFound("scala.collection.immutable.Vector"), "numbers")
   }
 }

--- a/modules/cats/src/test/scala/pureconfig/module/cats/arbitrary/package.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/arbitrary/package.scala
@@ -6,7 +6,7 @@ import org.scalacheck.Arbitrary.{ arbitrary => arb }
 import pureconfig.{ ConfigConvert, ConfigReader, ConfigWriter, Derivation }
 import scala.collection.JavaConverters._
 
-import pureconfig.error.ConfigReaderFailures
+import pureconfig.error.{ ConfigReaderFailures, ConvertFailure }
 
 package object arbitrary {
 
@@ -42,7 +42,7 @@ package object arbitrary {
     Cogen[String].contramap[ConfigValue](_.render)
 
   implicit val arbConfigReaderFailures: Arbitrary[ConfigReaderFailures] = Arbitrary {
-    Gen.const(ConfigReaderFailures(EmptyTraversableFound("List", None, "")))
+    Gen.const(ConfigReaderFailures(ConvertFailure(EmptyTraversableFound("List"), None, "")))
   }
 
   implicit val cogenConfigReaderFailures: Cogen[ConfigReaderFailures] =

--- a/modules/enum/src/main/scala/pureconfig/module/enum.scala
+++ b/modules/enum/src/main/scala/pureconfig/module/enum.scala
@@ -10,8 +10,8 @@ import scala.reflect.ClassTag
 package object enum {
   implicit def enumConfigConvert[T](implicit e: Enum[T], ct: ClassTag[T]): ConfigConvert[T] = {
     viaNonEmptyString(
-      s => location =>
-        e.decode(s).left.map(failure => CannotConvert(s, ct.runtimeClass.getSimpleName, failure.toString, location, "")),
+      s =>
+        e.decode(s).left.map(failure => CannotConvert(s, ct.runtimeClass.getSimpleName, failure.toString)),
       e.encode)
   }
 }

--- a/modules/enum/src/test/scala/pureconfig/module/enum/EnumTest.scala
+++ b/modules/enum/src/test/scala/pureconfig/module/enum/EnumTest.scala
@@ -1,11 +1,11 @@
 package pureconfig.module.enum
 
-import com.typesafe.config.ConfigFactory
-import org.scalatest.{ EitherValues, FlatSpec, Matchers }
-import pureconfig.syntax._
-import org.scalatest.Inspectors._
 import _root_.enum.Enum
+import com.typesafe.config.ConfigFactory
+import org.scalatest.Inspectors
+import pureconfig.BaseSuite
 import pureconfig.error.CannotConvert
+import pureconfig.syntax._
 
 sealed trait Greeting
 
@@ -17,8 +17,9 @@ object Greeting {
   final implicit val EnumInstance: Enum[Greeting] = Enum.derived[Greeting]
 }
 
-class EnumTest extends FlatSpec with Matchers with EitherValues {
-  "enum config convert" should "parse an enum" in forAll(Greeting.EnumInstance.values) { greeting =>
+class EnumTest extends BaseSuite {
+
+  "enum config convert" should "parse an enum" in Inspectors.forAll(Greeting.EnumInstance.values) { greeting =>
     val conf = ConfigFactory.parseString(s"""{greeting:"$greeting"}""")
     case class Conf(greeting: Greeting)
     conf.to[Conf].right.value shouldEqual Conf(greeting)
@@ -27,10 +28,6 @@ class EnumTest extends FlatSpec with Matchers with EitherValues {
   it should "politely refuse an invalid member" in {
     val conf = ConfigFactory.parseString(s"""{greeting:"Psych"}""")
     case class Conf(greeting: Greeting)
-    val failures = conf.to[Conf].left.value.toList
-    failures should have size 1
-    failures.head shouldBe a[CannotConvert]
+    conf.to[Conf] should failWithType[CannotConvert]
   }
-
 }
-

--- a/modules/enumeratum/src/main/scala/pureconfig/module/enumeratum.scala
+++ b/modules/enumeratum/src/main/scala/pureconfig/module/enumeratum.scala
@@ -30,9 +30,9 @@ package object enumeratum {
 
   implicit def enumeratumCharConfigConvert[A <: CharEnumEntry](implicit enum: CharEnum[A], ct: ClassTag[A]): ConfigConvert[A] =
     viaNonEmptyString[A](
-      s => location => ensureOneChar(s) match {
+      s => ensureOneChar(s) match {
         case Right(v) => Right(enum.withValue(v))
-        case Left(msg) => Left(CannotConvert(s, ct.runtimeClass.getSimpleName, msg, location, ""))
+        case Left(msg) => Left(CannotConvert(s, ct.runtimeClass.getSimpleName, msg))
       },
       _.value.toString)
 

--- a/modules/enumeratum/src/test/scala/pureconfig/module/enumeratum/EnumeratumConvertTest.scala
+++ b/modules/enumeratum/src/test/scala/pureconfig/module/enumeratum/EnumeratumConvertTest.scala
@@ -4,12 +4,12 @@ import com.typesafe.config.ConfigFactory
 import enumeratum.EnumEntry.{ Snakecase, Uppercase }
 import enumeratum._
 import enumeratum.values._
-import org.scalatest.{ EitherValues, FlatSpec, Matchers }
+import org.scalatest.Inspectors
 import pureconfig.syntax._
-import org.scalatest.Inspectors._
+import pureconfig.BaseSuite
 import pureconfig.error.CannotConvert
 
-class EnumeratumConvertTest extends FlatSpec with Matchers with EitherValues {
+class EnumeratumConvertTest extends BaseSuite {
   sealed trait Greeting extends EnumEntry with Snakecase
 
   object Greeting extends Enum[Greeting] {
@@ -19,7 +19,7 @@ class EnumeratumConvertTest extends FlatSpec with Matchers with EitherValues {
     case object ShoutGoodBye extends Greeting with Uppercase
   }
 
-  "Enumeratum ConfigConvert" should "parse an enum" in forAll(Greeting.values) {
+  "Enumeratum ConfigConvert" should "parse an enum" in Inspectors.forAll(Greeting.values) {
     greeting =>
       val conf = ConfigFactory.parseString(s"""{greeting:"${greeting.entryName}"}""")
       case class Conf(greeting: Greeting)
@@ -36,7 +36,7 @@ class EnumeratumConvertTest extends FlatSpec with Matchers with EitherValues {
     case object CD extends IntLibraryItem(4, name = "cd")
   }
 
-  it should "parse an int enum" in forAll(IntLibraryItem.values) {
+  it should "parse an int enum" in Inspectors.forAll(IntLibraryItem.values) {
     item =>
       val conf = ConfigFactory.parseString(s"""{item:"${item.value}"}""")
       case class Conf(item: IntLibraryItem)
@@ -53,7 +53,7 @@ class EnumeratumConvertTest extends FlatSpec with Matchers with EitherValues {
     case object CD extends LongLibraryItem(4L, name = "cd")
   }
 
-  it should "parse a long value enum" in forAll(LongLibraryItem.values) {
+  it should "parse a long value enum" in Inspectors.forAll(LongLibraryItem.values) {
     item =>
       val conf = ConfigFactory.parseString(s"""{item:"${item.value}"}""")
       case class Conf(item: LongLibraryItem)
@@ -70,7 +70,7 @@ class EnumeratumConvertTest extends FlatSpec with Matchers with EitherValues {
     case object CD extends ShortLibraryItem(4, name = "cd")
   }
 
-  it should "parse a short value enum" in forAll(ShortLibraryItem.values) {
+  it should "parse a short value enum" in Inspectors.forAll(ShortLibraryItem.values) {
     item =>
       val conf = ConfigFactory.parseString(s"""{item:"${item.value}"}""")
       case class Conf(item: ShortLibraryItem)
@@ -88,7 +88,7 @@ class EnumeratumConvertTest extends FlatSpec with Matchers with EitherValues {
     case object Empty extends StringLibraryItem("", number = 5)
   }
 
-  it should "parse a string value enum" in forAll(StringLibraryItem.values) {
+  it should "parse a string value enum" in Inspectors.forAll(StringLibraryItem.values) {
     item =>
       val conf = ConfigFactory.parseString(s"""{item:"${item.value}"}""")
       case class Conf(item: StringLibraryItem)
@@ -105,7 +105,7 @@ class EnumeratumConvertTest extends FlatSpec with Matchers with EitherValues {
     case object CD extends ByteLibraryItem(4, name = "cd")
   }
 
-  it should "parse a byte value enum" in forAll(ByteLibraryItem.values) {
+  it should "parse a byte value enum" in Inspectors.forAll(ByteLibraryItem.values) {
     item =>
       val conf = ConfigFactory.parseString(s"""{item:"${item.value}"}""")
       case class Conf(item: ByteLibraryItem)
@@ -122,7 +122,7 @@ class EnumeratumConvertTest extends FlatSpec with Matchers with EitherValues {
     case object CD extends CharLibraryItem('d', number = 4)
   }
 
-  it should "parse a char value enum" in forAll(CharLibraryItem.values) {
+  it should "parse a char value enum" in Inspectors.forAll(CharLibraryItem.values) {
     item =>
       val conf = ConfigFactory.parseString(s"""{item:"${item.value}"}""")
       case class Conf(item: CharLibraryItem)
@@ -132,8 +132,6 @@ class EnumeratumConvertTest extends FlatSpec with Matchers with EitherValues {
   it should "not parse a char value enum when given a string with more than one character" in {
     val conf = ConfigFactory.parseString(s"""{item:"string"}""")
     case class Conf(item: CharLibraryItem)
-    val failures = conf.to[Conf].left.value.toList
-    failures should have size 1
-    failures.head shouldBe a[CannotConvert]
+    conf.to[Conf] should failWithType[CannotConvert]
   }
 }


### PR DESCRIPTION
This PR focuses on refactoring our failure models to better support scoping by `ConfigCursor`.

The main problem with our current failures is that they all require a `ConfigValueLocation` and a config path to be provided the moment they are instantiated. This is not a very flexible design because:

- That information is not always available the moment the failure is being created. In particular, when we delegate the reading part to the user without providing a `ConfigCursor` (for example, when they use `ConfigReader.fromString` or use `emap` on an existing reader) they have no access to that information and have to fill those with `None` and `""`, respectively. Because of that, many functions in `ConvertHelpers` are unecessarily complicated by having an extra `Option[ConfigValueLocation]` argument;
- Users always have to remember to fill those fields, even when they have access to the necessary context;
- Functions like `improveFailures` and `withImprovedContext` had to be created to correctly scope the pre-created failures.

The new model improves that by splitting our failures into two distinct types:

- A `FailureReason` represents the reason why a conversion failed, agnostic of locations and paths in the config. Most of our `ConfigReaderFailure` subclasses were converted to `FailureReason` subclasses;
- A `ConfigReaderFailure` represents a higher-level failure. This can be a `ConvertFailure(reason: FailureReason, location: Option[ConfigValueLocation], path: String)` or a more fundamental failure such as `CannotReadFile` or `CannotParse`.

`ConfigCursor` was updated to provide three new methods for users to easily create failures with the correct context. Since now classes such as `KeyNotFound` and `WrongType` are `FailureReason`s and cannot be returned directly as `ConfigReaderFailures`, users are encouraged to use the `ConfigCursor` methods that provide that bridge.

I'm not very convinced of the names I chose for the failure traits and for the new `ConfigCursor` methods. Suggestions are welcome :)

I think that after the `ConfigCursor` introduction and this PR, we're in dire need of a thorough documentation review in order to update best practises and outdated text. I didn't do anything about it on this PR because I'll dedicate a PR to it later.

Closes #287.
