### PR TITLE
Update Scala version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ uses the raw configurations to do its magic.
 In the sbt configuration file use Scala `2.10`, `2.11` or `2.12`:
 
 ```scala
-scalaVersion := "2.12.3" // or "2.11.11", "2.10.6"
+scalaVersion := "2.12.4" // or "2.11.11", "2.10.6"
 ```
 
 Add PureConfig to your library dependencies. For Scala `2.11` and `2.12`:
@@ -97,7 +97,7 @@ For a full example of `build.sbt` you can have a look at this [build.sbt](https:
 used for the example.
 
 Earlier versions of Scala had bugs which can cause subtle compile-time problems in PureConfig.
-As a result we recommend only using 2.11.11 or 2.12.1 or newer within the minor series.
+As a result we recommend only using the latest Scala versions within the minor series.
 
 ## Use PureConfig
 

--- a/core/src/main/tut/README.md
+++ b/core/src/main/tut/README.md
@@ -73,7 +73,7 @@ uses the raw configurations to do its magic.
 In the sbt configuration file use Scala `2.10`, `2.11` or `2.12`:
 
 ```scala
-scalaVersion := "2.12.3" // or "2.11.11", "2.10.6"
+scalaVersion := "2.12.4" // or "2.11.11", "2.10.6"
 ```
 
 Add PureConfig to your library dependencies. For Scala `2.11` and `2.12`:
@@ -97,7 +97,7 @@ For a full example of `build.sbt` you can have a look at this [build.sbt](https:
 used for the example.
 
 Earlier versions of Scala had bugs which can cause subtle compile-time problems in PureConfig.
-As a result we recommend only using 2.11.11 or 2.12.1 or newer within the minor series.
+As a result we recommend only using the latest Scala versions within the minor series.
 
 ## Use PureConfig
 


### PR DESCRIPTION
I forgot to update the Scala versions in the README after #317.