### PR TITLE
Fix Derivation usage outside the pureconfig package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
     of `ConfigReaderFailures`;
   - The `CannotConvertNull` failure was removed, being superseeded by `KeyNotFound`;
   - Methods deprecated in previous versions were removed.
+  
+- Bug fixes
+  - Fixed a bug where some or all `Derivation` cases outside the `pureconfig` package were not showing the full error
+    description.
 
 ### 0.8.0 (Aug 27, 2017)
 

--- a/macros/src/main/scala-2.11+/pureconfig/Derivation.scala
+++ b/macros/src/main/scala-2.11+/pureconfig/Derivation.scala
@@ -18,7 +18,7 @@ object Derivation {
   // A derivation for which an implicit `A` could be found. This is only used internally by the `materializeDerivation`
   // macro - when a derivation requested directly by a user is successfully materialized, it is guaranteed to be a
   // `Derivation.Successful`.
-  private[pureconfig] case class Failed[A]() extends Derivation[A] {
+  case class Failed[A]() extends Derivation[A] {
     def value = throw new IllegalStateException("Illegal Derivation")
   }
 


### PR DESCRIPTION
Even though the `Failed` derivation constructor is only used internally by the macro, apparently it still needs to be accessible on the macro application points. As such, (some?) `Derivation`s outside the `pureconfig` package were failing without the full error description.

Fixes #330.
