### PR TITLE
Make emap use FailureReason instead of ConfigReaderFailures

### DIFF
--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -50,8 +50,8 @@ trait ConfigReader[A] {
    * @return a `ConfigReader` returning the results of this reader mapped by `f`, with the resulting `Either` flattened
    *         as a success or failure.
    */
-  def emap[B](f: A => Either[ConfigReaderFailures, B]): ConfigReader[B] =
-    fromCursor[B] { cur => from(cur).right.flatMap(f) }
+  def emap[B](f: A => Either[FailureReason, B]): ConfigReader[B] =
+    fromCursor[B] { cur => from(cur).right.flatMap { v => cur.scopeFailure(f(v)) } }
 
   /**
    * Monadically bind a function over the results of this reader.

--- a/core/src/test/scala/pureconfig/ConfigReaderSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigReaderSuite.scala
@@ -2,7 +2,7 @@ package pureconfig
 
 import com.typesafe.config.{ ConfigFactory, ConfigObject, ConfigValue, ConfigValueFactory }
 import org.scalacheck.{ Arbitrary, Gen }
-import pureconfig.error.{ ConfigReaderFailures, ConvertFailure, ExceptionThrown, UnknownKey }
+import pureconfig.error._
 
 class ConfigReaderSuite extends BaseSuite {
   implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
@@ -19,11 +19,11 @@ class ConfigReaderSuite extends BaseSuite {
     Gen.frequency(80 -> Gen.chooseNum(Int.MinValue, Int.MaxValue), 20 -> Gen.alphaStr)
       .map(ConfigValueFactory.fromAnyRef)
 
-  val genReaderFailure: Gen[ConfigReaderFailures] =
-    Gen.const(ConfigReaderFailures(ConvertFailure(UnknownKey(""), None, "")))
+  val genFailureReason: Gen[FailureReason] =
+    Gen.const(UnknownKey(""))
 
   implicit val arbConfig = Arbitrary(genConfig)
-  implicit val arbReaderFailure = Arbitrary(genReaderFailure)
+  implicit val arbFailureReason = Arbitrary(genFailureReason)
 
   behavior of "ConfigReader"
 
@@ -37,8 +37,13 @@ class ConfigReaderSuite extends BaseSuite {
     cr.from(ConfigValueFactory.fromAnyRef(1)) should failWith(ExceptionThrown(throwable))
   }
 
-  it should "have a correct emap method" in forAll { (conf: ConfigValue, f: Int => Either[ConfigReaderFailures, String]) =>
-    intReader.emap(f).from(conf) shouldEqual intReader.from(conf).right.flatMap(f)
+  it should "have a correct emap method" in forAll { (conf: ConfigValue, f: Int => Either[FailureReason, String]) =>
+    def getReason[A](failures: ConfigReaderFailures): FailureReason = failures match {
+      case ConfigReaderFailures(ConvertFailure(reason, _, _), Nil) => reason
+      case _ => throw new Exception(s"Unexpected value: $failures")
+    }
+    intReader.emap(f).from(conf).left.map(getReason) shouldEqual
+      intReader.from(conf).left.map(getReason).right.flatMap(f)
   }
 
   it should "have a correct flatMap method" in forAll { conf: ConfigValue =>


### PR DESCRIPTION
`ConfigReader#emap` should require an `Either` with `FailureReason` as a failure type and not a `ConfigReaderFailures`, since users do not have the necessary context to create a `ConfigReaderFailure`. I must have forgotten about this method when I wrote #321.
