### PR TITLE
Make `asString` read any scalar config type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,3 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
-    - $HOME/.rvm

--- a/core/src/main/scala/pureconfig/ConfigCursor.scala
+++ b/core/src/main/scala/pureconfig/ConfigCursor.scala
@@ -57,7 +57,7 @@ sealed trait ConfigCursor {
    *         failures otherwise.
    */
   def asString: Either[ConfigReaderFailures, String] =
-    castOrFail(STRING, Set(NUMBER, BOOLEAN, NULL, STRING), { cv => String.valueOf(cv.unwrapped) })
+    castOrFail(STRING, Set(NUMBER, BOOLEAN, STRING), { cv => String.valueOf(cv.unwrapped) })
 
   /**
    * Casts this cursor to a `ConfigListCursor`.

--- a/core/src/test/scala/pureconfig/ConfigCursorSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigCursorSuite.scala
@@ -26,7 +26,9 @@ class ConfigCursorSuite extends BaseSuite {
     cursor("abc").asString shouldBe Right("abc")
     cursor("4").asString shouldBe Right("4")
     cursor("true").asString shouldBe Right("true")
-    cursor("null").asString shouldBe Right("null")
+
+    cursor("null").asString should failWith(
+      WrongType(ConfigValueType.NULL, Set(ConfigValueType.STRING)), defaultPathStr)
 
     cursor("[1, 2]").asString should failWith(
       WrongType(ConfigValueType.LIST, Set(ConfigValueType.STRING)), defaultPathStr)

--- a/core/src/test/scala/pureconfig/ConfigCursorSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigCursorSuite.scala
@@ -9,7 +9,7 @@ class ConfigCursorSuite extends BaseSuite {
   val defaultPathStr = "key1.key2"
 
   def conf(confStr: String): ConfigValue = {
-    ConfigFactory.parseString(s"aux = $confStr").getValue("aux")
+    ConfigFactory.parseString(s"aux = $confStr").root.get("aux")
   }
 
   def cursor(confStr: String, pathElems: List[String] = defaultPath): ConfigCursor =
@@ -23,8 +23,10 @@ class ConfigCursorSuite extends BaseSuite {
   }
 
   it should "allow being casted to string in a safe way" in {
-    cursor("abc").asString shouldBe
-      Right("abc")
+    cursor("abc").asString shouldBe Right("abc")
+    cursor("4").asString shouldBe Right("4")
+    cursor("true").asString shouldBe Right("true")
+    cursor("null").asString shouldBe Right("null")
 
     cursor("[1, 2]").asString should failWith(
       WrongType(ConfigValueType.LIST, Set(ConfigValueType.STRING)), defaultPathStr)


### PR DESCRIPTION
Makes `asString` read any scalar config type, just like the Typesafe Config API does. Since the underlying config format allows strings to be defined without quotes and primitives like `true` and `null` can arguably be seen as strings, this "cast" makes sense to me in PureConfig.

Fixes #338.