### PR TITLE
Ignore broken links to www.47deg.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ jobs:
         - gem install sass jekyll:3.2.1 html-proofer
       script:
         - sbt makeMicrosite
-        - htmlproofer --allow_hash_href docs/target/site
+          # we're ignoring www.47deg.com due to SSL errors; we should check this again later
+        - htmlproofer --allow_hash_href --url-ignore '/www.47deg.com/' docs/target/site
       after_success: ignore
 
 cache:


### PR DESCRIPTION
Ignores the URL that's causing the builds to fail on #360 and #361.

It seems that this is not a problem with html-proofer (which uses `libcurl` behind the scenes). I booted up a Docker container on my local machine and `curl` also finds there some issues with https://www.47deg.com:

```
root@24a14c364d53:/# curl -v https://www.47deg.com
* Rebuilt URL to: https://www.47deg.com/
*   Trying 54.225.152.117...
* Connected to www.47deg.com (54.225.152.117) port 443 (#0)
* found 148 certificates in /etc/ssl/certs/ca-certificates.crt
* found 592 certificates in /etc/ssl/certs
* ALPN, offering http/1.1
* SSL connection using TLS1.2 / ECDHE_RSA_AES_128_GCM_SHA256
* server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
* Closing connection 0
curl: (60) server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
```

I opted to ignore this specific URL. We should probably check back later to see if the issue persists.
