### PR TITLE
Check PureConfig's GitHub links against the local tree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,11 @@ jobs:
       script:
         - sbt makeMicrosite
           # we're ignoring www.47deg.com due to SSL errors; we should check this again later
-        - htmlproofer --allow_hash_href --url-ignore '/www.47deg.com/' docs/target/site
+        - htmlproofer \
+            --allow_hash_href \
+            --url-ignore '/www.47deg.com/' \
+            --url-swap "https\://github\.com/pureconfig/pureconfig/tree/master:file\://$(pwd)" \
+            docs/target/site
       after_success: ignore
 
 cache:


### PR DESCRIPTION
This should better handle links from our documentation to our own project page on GitHub (not only to added pages, but also to deleted ones). Fixes the build issues on #361 and #367.
