### PR TITLE
Define a method `ConfigCursor#atPath`

### DIFF
--- a/core/src/main/scala/pureconfig/PathSegment.scala
+++ b/core/src/main/scala/pureconfig/PathSegment.scala
@@ -1,0 +1,13 @@
+package pureconfig
+
+import language.implicitConversions
+
+sealed trait PathSegment extends Product with Serializable
+
+object PathSegment {
+  final case class Key(k: String) extends PathSegment
+  final case class Index(i: Int) extends PathSegment
+
+  implicit def intToPathSegment(i: Int): PathSegment = Index(i)
+  implicit def stringToPathSegment(k: String): PathSegment = Key(k)
+}

--- a/core/src/test/scala/pureconfig/ConfigCursorSuite.scala
+++ b/core/src/test/scala/pureconfig/ConfigCursorSuite.scala
@@ -92,6 +92,14 @@ class ConfigCursorSuite extends BaseSuite {
       Right(Right(ConfigObjectCursor(conf("{ a: 1, b: 2 }").asInstanceOf[ConfigObject], defaultPath)))
   }
 
+  it should "allow access to a given path" in {
+    cursor("{ a: 2 }").atPath() shouldBe Right(cursor("{ a: 2 }", defaultPath))
+    cursor("{ a: 2 }").atPath("a") shouldBe Right(cursor("2", "a" :: defaultPath))
+    cursor("{ a: { b: 2 } }").atPath("a", "b") shouldBe Right(cursor("2", "b" :: "a" :: defaultPath))
+    cursor("{ a: { b: [{ c: 2 }] } }").atPath("a", "b", 0, "c") shouldBe Right(cursor("2", "c" :: "0" :: "b" :: "a" :: defaultPath))
+    cursor("{ a: { b: { c: 2 } } }").atPath("a", "c") should failWith(KeyNotFound("c", Set()), s"$defaultPathStr.a")
+  }
+
   it should "handle in a safe way cursors to undefined values" in {
     val cur = ConfigCursor(null, defaultPath)
     cur.path shouldBe defaultPathStr


### PR DESCRIPTION
Similar to `ConfigCursor#atKey` but for deeper nested paths. We have this in our project's utils, but were wondering if this could be put in PureConfig itself.