### PR TITLE
Use the fully qualified name of `implicitly` in Derivation

### DIFF
--- a/macros/src/main/scala-2.10/pureconfig/Derivation.scala
+++ b/macros/src/main/scala-2.10/pureconfig/Derivation.scala
@@ -21,6 +21,6 @@ class DerivationMacros(val c: whitebox.Context) {
 
   // Derivations are not supported on Scala 2.10. This is a shim executing a regular implicit search.
   def materializeDerivation[A: WeakTypeTag]: Tree = {
-    q"_root_.pureconfig.Derivation.Successful(implicitly[${weakTypeOf[A]}])"
+    q"_root_.pureconfig.Derivation.Successful(_root_.scala.Predef.implicitly[${weakTypeOf[A]}])"
   }
 }

--- a/macros/src/main/scala-2.11+/pureconfig/Derivation.scala
+++ b/macros/src/main/scala-2.11+/pureconfig/Derivation.scala
@@ -53,7 +53,7 @@ class DerivationMacros(val c: whitebox.Context) extends LazyContextParser with M
     if (!isDerivationEnabled || !isHeadImplicitADerivation) {
       // when not present, simply render the base `Derivation` constructor with `implcitly[A]`. This results in the same
       // behavior as without `Derivation` (apart from the extra wrapper).
-      q"_root_.pureconfig.Derivation.Successful(implicitly[${weakTypeOf[A]}])"
+      q"_root_.pureconfig.Derivation.Successful(_root_.scala.Predef.implicitly[${weakTypeOf[A]}])"
 
     } else {
       // if `isRootDerivation` is `false`, then this is a `Derivation` triggered inside another `Derivation`


### PR DESCRIPTION
Fixes #382.