### PR TITLE
Support the HOCON unit syntax in Period

### DIFF
--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -95,7 +95,7 @@ trait JavaTimeReaders {
     ConfigReader.fromNonEmptyString[ZoneId](catchReadError(ZoneId.of))
 
   implicit val periodConfigReader: ConfigReader[Period] =
-    ConfigReader.fromNonEmptyString[Period](catchReadError(Period.parse))
+    ConfigReader.fromNonEmptyString[Period](PeriodUtils.fromString)
 
   implicit val javaDurationConfigReader: ConfigReader[JavaDuration] =
     ConfigReader.fromNonEmptyString[JavaDuration](catchReadError(JavaDuration.parse))
@@ -111,11 +111,11 @@ trait JavaTimeReaders {
 trait DurationReaders {
 
   implicit val durationConfigReader: ConfigReader[Duration] =
-    ConfigReader.fromNonEmptyString[Duration](DurationConvert.fromString)
+    ConfigReader.fromNonEmptyString[Duration](DurationUtils.fromString)
 
   implicit val finiteDurationConfigReader: ConfigReader[FiniteDuration] = {
     val fromString: String => Either[FailureReason, FiniteDuration] = { string =>
-      DurationConvert.fromString(string).right.flatMap {
+      DurationUtils.fromString(string).right.flatMap {
         case d: FiniteDuration => Right(d)
         case _ => Left(CannotConvert(string, "FiniteDuration",
           s"Couldn't parse '$string' into a FiniteDuration because it's infinite."))

--- a/core/src/main/scala/pureconfig/BasicWriters.scala
+++ b/core/src/main/scala/pureconfig/BasicWriters.scala
@@ -83,8 +83,8 @@ trait JavaTimeWriters {
  */
 trait DurationWriters {
 
-  implicit val durationConfigWriter = ConfigWriter.toString[Duration](DurationConvert.fromDuration)
-  implicit val finiteDurationConfigWriter = ConfigWriter.toString[FiniteDuration](DurationConvert.fromDuration)
+  implicit val durationConfigWriter = ConfigWriter.toString[Duration](DurationUtils.fromDuration)
+  implicit val finiteDurationConfigWriter = ConfigWriter.toString[FiniteDuration](DurationUtils.fromDuration)
 }
 
 /**

--- a/core/src/main/scala/pureconfig/DurationUtils.scala
+++ b/core/src/main/scala/pureconfig/DurationUtils.scala
@@ -20,7 +20,7 @@ private[pureconfig] object DurationUtils {
   val fromString: String => Either[FailureReason, Duration] = { string =>
     if (string == UndefinedDuration) Right(Duration.Undefined)
     else try {
-      Right(parseDuration(addZeroUnit(justAMinute(itsGreekToMe(string)))))
+      Right(parseDuration(addDefaultUnit(justAMinute(itsGreekToMe(string)))))
     } catch {
       case ex: NumberFormatException =>
         val err = s"${ex.getMessage}. (try a number followed by any of ns, us, ms, s, m, h, d)"
@@ -75,11 +75,12 @@ private[pureconfig] object DurationUtils {
 
   ////////////////////////////////////
 
-  private val zeroRegex = "\\s*[+-]?0+\\s*$".r
+  private val onlyNumberRegex = "\\s*[+-]?[0-9]+\\s*$".r
   private val fauxMuRegex = "([0-9])(\\s*)us(\\s*)$".r
   private val shortMinuteRegex = "([0-9])(\\s*)m(\\s*)$".r
 
-  private val addZeroUnit = { s: String => if (zeroRegex.unapplySeq(s).isDefined) "0d" else s }
+  // To maintain compatibility with Typesafe Config, use "ms" as default unit.
+  private val addDefaultUnit = { s: String => if (onlyNumberRegex.unapplySeq(s).isDefined) s + " ms" else s }
 
   // To maintain compatibility with Typesafe Config, replace "us" with "µs".
   private val itsGreekToMe = fauxMuRegex.replaceSomeIn(_: String, m => Some(s"${m.group(1)}${m.group(2)}µs${m.group(3)}"))

--- a/core/src/main/scala/pureconfig/DurationUtils.scala
+++ b/core/src/main/scala/pureconfig/DurationUtils.scala
@@ -10,9 +10,10 @@ import scala.util.Try
 import pureconfig.error.{ CannotConvert, FailureReason }
 
 /**
- * Utility functions for converting a Duration to a String and vice versa.
+ * Utility functions for converting a `String` to a `Duration` and vice versa. The parser accepts the HOCON unit
+ * syntax.
  */
-private[pureconfig] object DurationConvert {
+private[pureconfig] object DurationUtils {
   /**
    * Convert a string to a Duration while trying to maintain compatibility with Typesafe's abbreviations.
    */

--- a/core/src/main/scala/pureconfig/PeriodUtils.scala
+++ b/core/src/main/scala/pureconfig/PeriodUtils.scala
@@ -1,0 +1,64 @@
+package pureconfig
+
+import java.time.Period
+import java.time.temporal.ChronoUnit
+import java.time.temporal.ChronoUnit._
+
+import scala.util.Try
+
+import com.typesafe.config.impl.ConfigImplUtil
+import pureconfig.error.{ CannotConvert, FailureReason }
+
+/**
+ * Utility functions for converting a `String` to a `Period`. The parser accepts the HOCON unit syntax.
+ */
+private[pureconfig] object PeriodUtils {
+
+  /**
+   * Convert a string to a Period while trying to maintain compatibility with Typesafe's abbreviations.
+   */
+  val fromString: String => Either[FailureReason, Period] = { str =>
+    Try(Right(Period.parse(str))).getOrElse(typesafeConfigParsePeriod(str))
+  }
+
+  // This is a copy of the period parser in `com.typesafe.config.impl.SimpleConfig` adapted to be safer (dealing with
+  // `Either` values instead of throwing exceptions). Try not to refactor this too much so as to be easy for anyone
+  // to compare this code with the original.
+  def typesafeConfigParsePeriod(input: String): Either[FailureReason, Period] = {
+    val s = ConfigImplUtil.unicodeTrim(input)
+    val originalUnitString = getUnits(s)
+    var unitString = originalUnitString
+    val numberString = ConfigImplUtil.unicodeTrim(s.substring(0, s.length - unitString.length))
+    var units: ChronoUnit = null
+    // this would be caught later anyway, but the error message
+    // is more helpful if we check it here.
+    if (numberString.length == 0) return Left(CannotConvert(input, "Period", "No number in period value"))
+    if (unitString.length > 2 && !unitString.endsWith("s")) unitString = unitString + "s"
+    // note that this is deliberately case-sensitive
+    if (unitString == "" || unitString == "d" || unitString == "days") units = ChronoUnit.DAYS
+    else if (unitString == "w" || unitString == "weeks") units = ChronoUnit.WEEKS
+    else if (unitString == "m" || unitString == "mo" || unitString == "months") units = ChronoUnit.MONTHS
+    else if (unitString == "y" || unitString == "years") units = ChronoUnit.YEARS
+    else return Left(CannotConvert(input, "Period", s"Could not parse time unit '$originalUnitString' (try d, w, mo, y)"))
+    try
+      periodOf(numberString.toInt, units).left.map(CannotConvert(input, "Period", _))
+    catch {
+      case _: NumberFormatException =>
+        Left(CannotConvert(input, "Period", s"Could not parse duration number '$numberString'"))
+    }
+  }
+
+  private def periodOf(n: Int, unit: ChronoUnit): Either[String, Period] = {
+    if (unit.isTimeBased) Left(unit + " cannot be converted to a java.time.Period")
+    unit match {
+      case DAYS => Right(Period.ofDays(n))
+      case WEEKS => Right(Period.ofWeeks(n))
+      case MONTHS => Right(Period.ofMonths(n))
+      case YEARS => Right(Period.ofYears(n))
+      case _ => Left(unit + " cannot be converted to a java.time.Period")
+    }
+  }
+
+  private def getUnits(s: String): String =
+    s.substring(s.lastIndexWhere(!_.isLetter) + 1)
+}

--- a/core/src/main/scala/pureconfig/PeriodUtils.scala
+++ b/core/src/main/scala/pureconfig/PeriodUtils.scala
@@ -48,15 +48,12 @@ private[pureconfig] object PeriodUtils {
     }
   }
 
-  private def periodOf(n: Int, unit: ChronoUnit): Either[String, Period] = {
-    if (unit.isTimeBased) Left(unit + " cannot be converted to a java.time.Period")
-    unit match {
-      case DAYS => Right(Period.ofDays(n))
-      case WEEKS => Right(Period.ofWeeks(n))
-      case MONTHS => Right(Period.ofMonths(n))
-      case YEARS => Right(Period.ofYears(n))
-      case _ => Left(unit + " cannot be converted to a java.time.Period")
-    }
+  private def periodOf(n: Int, unit: ChronoUnit): Either[String, Period] = unit match {
+    case DAYS => Right(Period.ofDays(n))
+    case WEEKS => Right(Period.ofWeeks(n))
+    case MONTHS => Right(Period.ofMonths(n))
+    case YEARS => Right(Period.ofYears(n))
+    case _ => Left(unit + " cannot be converted to a java.time.Period") // cannot happen
   }
 
   private def getUnits(s: String): String =

--- a/core/src/main/scala/pureconfig/PeriodUtils.scala
+++ b/core/src/main/scala/pureconfig/PeriodUtils.scala
@@ -1,10 +1,8 @@
 package pureconfig
 
 import java.time.Period
-import java.time.temporal.ChronoUnit
-import java.time.temporal.ChronoUnit._
 
-import scala.util.Try
+import scala.util.{ Success, Try }
 
 import com.typesafe.config.impl.ConfigImplUtil
 import pureconfig.error.{ CannotConvert, FailureReason }
@@ -25,37 +23,29 @@ private[pureconfig] object PeriodUtils {
   // `Either` values instead of throwing exceptions). Try not to refactor this too much so as to be easy for anyone
   // to compare this code with the original.
   def typesafeConfigParsePeriod(input: String): Either[FailureReason, Period] = {
-    val s = ConfigImplUtil.unicodeTrim(input)
-    val originalUnitString = getUnits(s)
-    var unitString = originalUnitString
-    val numberString = ConfigImplUtil.unicodeTrim(s.substring(0, s.length - unitString.length))
-    var units: ChronoUnit = null
-    // this would be caught later anyway, but the error message
-    // is more helpful if we check it here.
-    if (numberString.length == 0) return Left(CannotConvert(input, "Period", "No number in period value"))
-    if (unitString.length > 2 && !unitString.endsWith("s")) unitString = unitString + "s"
-    // note that this is deliberately case-sensitive
-    if (unitString == "" || unitString == "d" || unitString == "days") units = ChronoUnit.DAYS
-    else if (unitString == "w" || unitString == "weeks") units = ChronoUnit.WEEKS
-    else if (unitString == "m" || unitString == "mo" || unitString == "months") units = ChronoUnit.MONTHS
-    else if (unitString == "y" || unitString == "years") units = ChronoUnit.YEARS
-    else return Left(CannotConvert(input, "Period", s"Could not parse time unit '$originalUnitString' (try d, w, mo, y)"))
-    try
-      periodOf(numberString.toInt, units).left.map(CannotConvert(input, "Period", _))
-    catch {
-      case _: NumberFormatException =>
-        Left(CannotConvert(input, "Period", s"Could not parse duration number '$numberString'"))
+    val (rawValueStr, rawUnitStr) = splitUnits(ConfigImplUtil.unicodeTrim(input))
+    val valueStr = ConfigImplUtil.unicodeTrim(rawValueStr)
+    val unitStr = pluralize(rawUnitStr)
+
+    // we use days as the default value in order to be compatible with Typesafe Config
+    // (https://github.com/lightbend/config/blob/master/HOCON.md#period-format)
+    Try(valueStr.toInt) match {
+      case Success(n) =>
+        unitStr match {
+          case "" | "d" | "days" => Right(Period.ofDays(n))
+          case "w" | "weeks" => Right(Period.ofWeeks(n))
+          case "m" | "mo" | "months" => Right(Period.ofMonths(n))
+          case "y" | "years" => Right(Period.ofYears(n))
+          case _ => Left(CannotConvert(input, "Period", s"Could not parse time unit '$unitStr' (try d, w, mo, y)"))
+        }
+      case _ =>
+        Left(CannotConvert(input, "Period", s"Could not parse duration number '$valueStr'"))
     }
   }
 
-  private def periodOf(n: Int, unit: ChronoUnit): Either[String, Period] = unit match {
-    case DAYS => Right(Period.ofDays(n))
-    case WEEKS => Right(Period.ofWeeks(n))
-    case MONTHS => Right(Period.ofMonths(n))
-    case YEARS => Right(Period.ofYears(n))
-    case _ => Left(unit + " cannot be converted to a java.time.Period") // cannot happen
-  }
+  private def splitUnits(s: String): (String, String) =
+    s.splitAt(s.lastIndexWhere(!_.isLetter) + 1)
 
-  private def getUnits(s: String): String =
-    s.substring(s.lastIndexWhere(!_.isLetter) + 1)
+  private def pluralize(s: String): String =
+    if (s.length > 2 && !s.endsWith("s")) s + "s" else s
 }

--- a/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -41,11 +41,11 @@ class BasicConvertersSuite extends BaseSuite {
     ConfigConvert[Duration].to(Duration.Inf))
 
   checkReadString[FiniteDuration](
-    5.seconds -> "5 seconds",
-    28.millis -> "28 ms",
-    28.millis -> "28ms",
-    28.millis -> "28 milliseconds",
-    1.day -> "1d")
+    "5 seconds" -> 5.seconds,
+    "28 ms" -> 28.millis,
+    "28ms" -> 28.millis,
+    "28 milliseconds" -> 28.millis,
+    "1d" -> 1.day)
 
   checkArbitrary[Instant]
 
@@ -56,10 +56,10 @@ class BasicConvertersSuite extends BaseSuite {
   checkArbitrary[Period]
 
   checkReadString[Period](
-    Period.ofDays(1) -> "1d",
-    Period.ofWeeks(4) -> "4 weeks",
-    Period.ofMonths(13) -> "13 months",
-    Period.ofYears(2) -> "2y")
+    "1d" -> Period.ofDays(1),
+    "4 weeks" -> Period.ofWeeks(4),
+    "13 months" -> Period.ofMonths(13),
+    "2y" -> Period.ofYears(2))
 
   checkArbitrary[Year]
 
@@ -71,10 +71,10 @@ class BasicConvertersSuite extends BaseSuite {
 
   checkArbitrary[Boolean]
   checkRead[Boolean](
-    true -> ConfigValueFactory.fromAnyRef("yes"),
-    true -> ConfigValueFactory.fromAnyRef("on"),
-    false -> ConfigValueFactory.fromAnyRef("no"),
-    false -> ConfigValueFactory.fromAnyRef("off"))
+    ConfigValueFactory.fromAnyRef("yes") -> true,
+    ConfigValueFactory.fromAnyRef("on") -> true,
+    ConfigValueFactory.fromAnyRef("no") -> false,
+    ConfigValueFactory.fromAnyRef("off") -> false)
 
   checkArbitrary[Double]
   checkArbitrary2[Double, Percentage](_.toDoubleFraction)
@@ -101,8 +101,8 @@ class BasicConvertersSuite extends BaseSuite {
 
   checkArbitrary[File]
 
-  checkRead[DayOfWeek]((DayOfWeek.MONDAY, ConfigValueFactory.fromAnyRef("MONDAY")))
-  checkRead[Month]((Month.JULY, ConfigValueFactory.fromAnyRef("JULY")))
+  checkReadString[DayOfWeek]("MONDAY" -> DayOfWeek.MONDAY)
+  checkReadString[Month]("JULY" -> Month.JULY)
   checkFailure[DayOfWeek, CannotConvert](
     ConfigValueFactory.fromAnyRef("thursday"), // lowercase string vs upper case enum
     ConfigValueFactory.fromAnyRef("this is not a day")) // no such value
@@ -112,8 +112,8 @@ class BasicConvertersSuite extends BaseSuite {
   checkArbitrary[immutable.List[Float]]
   checkRead[immutable.List[Int]](
     // order of keys maintained
-    (List(2, 3, 1), ConfigValueFactory.fromMap(Map("2" -> 1, "0" -> 2, "1" -> 3).asJava)),
-    (List(4, 2), ConfigValueFactory.fromMap(Map("3" -> 2, "1" -> 4).asJava)))
+    ConfigValueFactory.fromMap(Map("2" -> 1, "0" -> 2, "1" -> 3).asJava) -> List(2, 3, 1),
+    ConfigValueFactory.fromMap(Map("3" -> 2, "1" -> 4).asJava) -> List(4, 2))
   checkFailure[immutable.List[Int], CannotConvert](
     ConfigValueFactory.fromMap(Map("1" -> 1, "a" -> 2).asJava))
 
@@ -128,7 +128,7 @@ class BasicConvertersSuite extends BaseSuite {
 
   checkArbitrary[immutable.Set[Double]]
   checkRead[immutable.Set[Int]](
-    (Set(4, 5, 6), ConfigValueFactory.fromMap(Map("1" -> 4, "2" -> 5, "3" -> 6).asJava)))
+    ConfigValueFactory.fromMap(Map("1" -> 4, "2" -> 5, "3" -> 6).asJava) -> Set(4, 5, 6))
 
   checkArbitrary[immutable.Stream[String]]
 
@@ -138,22 +138,22 @@ class BasicConvertersSuite extends BaseSuite {
 
   checkArbitrary[Option[Int]]
 
-  checkRead[Pattern](Pattern.compile("(a|b)") -> ConfigValueFactory.fromAnyRef("(a|b)"))
+  checkReadString[Pattern]("(a|b)" -> Pattern.compile("(a|b)"))
 
-  checkRead[Regex](new Regex("(a|b)") -> ConfigValueFactory.fromAnyRef("(a|b)"))
+  checkReadString[Regex]("(a|b)" -> new Regex("(a|b)"))
 
   checkFailure[Pattern, CannotConvert](ConfigValueFactory.fromAnyRef("(a|b")) // missing closing ')'
   checkFailure[Regex, CannotConvert](ConfigValueFactory.fromAnyRef("(a|b")) // missing closing ')'
 
-  checkRead[URL](
-    new URL("http://host/path?with=query&param") -> ConfigValueFactory.fromAnyRef("http://host/path?with=query&param"))
+  checkReadString[URL](
+    "http://host/path?with=query&param" -> new URL("http://host/path?with=query&param"))
 
-  checkRead[URI](
-    new URI("http://host/path?with=query&param") -> ConfigValueFactory.fromAnyRef("http://host/path?with=query&param"))
+  checkReadString[URI](
+    "http://host/path?with=query&param" -> new URI("http://host/path?with=query&param"))
 
   checkRead[ConfigList](
     ConfigValueFactory.fromIterable(List().asJava) -> ConfigValueFactory.fromIterable(List().asJava),
-    ConfigValueFactory.fromIterable(List(1, 2, 3).asJava) -> ConfigValueFactory.fromAnyRef(List(1, 2, 3).asJava))
+    ConfigValueFactory.fromAnyRef(List(1, 2, 3).asJava) -> ConfigValueFactory.fromIterable(List(1, 2, 3).asJava))
 
   checkRead[ConfigValue](
     ConfigValueFactory.fromAnyRef(4) -> ConfigValueFactory.fromAnyRef(4),
@@ -164,9 +164,9 @@ class BasicConvertersSuite extends BaseSuite {
     val conf = ConfigFactory.parseString("""{ v1 = 3, v2 = 4 }""".stripMargin)
 
     checkRead[ConfigObject](
-      ConfigValueFactory.fromMap(Map("v1" -> 3, "v2" -> 4).asJava) -> conf.root().asInstanceOf[ConfigValue])
+      conf.root() -> ConfigValueFactory.fromMap(Map("v1" -> 3, "v2" -> 4).asJava))
 
     checkRead[Config](
-      conf -> conf.root().asInstanceOf[ConfigValue])
+      conf.root() -> conf)
   }
 }

--- a/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -43,8 +43,12 @@ class BasicConvertersSuite extends BaseSuite {
     "5 seconds" -> 5.seconds,
     "28 ms" -> 28.millis,
     "28ms" -> 28.millis,
+    "28" -> 28.millis,
     "28 milliseconds" -> 28.millis,
     "1d" -> 1.day)
+
+  checkRead[FiniteDuration](
+    ConfigValueFactory.fromAnyRef(28) -> 28.millis)
 
   checkArbitrary[Instant]
 
@@ -56,9 +60,13 @@ class BasicConvertersSuite extends BaseSuite {
 
   checkReadString[Period](
     "1d" -> Period.ofDays(1),
+    "42" -> Period.ofDays(42),
     "4 weeks" -> Period.ofWeeks(4),
     "13 months" -> Period.ofMonths(13),
     "2y" -> Period.ofYears(2))
+
+  checkRead[Period](
+    ConfigValueFactory.fromAnyRef(42) -> Period.ofDays(42))
 
   checkFailure[Period, CannotConvert](
     ConfigValueFactory.fromAnyRef("4kb"),

--- a/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -1,7 +1,7 @@
 package pureconfig
 
 import java.io.File
-import java.math.{ BigDecimal => JavaBigDecimal, BigInteger }
+import java.math.{ BigInteger, BigDecimal => JavaBigDecimal }
 import java.net.{ URI, URL }
 import java.nio.file.Path
 import java.time._
@@ -14,10 +14,9 @@ import pureconfig.arbitrary._
 import pureconfig.data.Percentage
 import pureconfig.equality._
 import pureconfig.error.{ CannotConvert, EmptyStringFound, WrongSizeString }
-
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.concurrent.duration.{ Duration, FiniteDuration, _ }
 import scala.util.matching.Regex
 
 class BasicConvertersSuite extends BaseSuite {
@@ -41,6 +40,13 @@ class BasicConvertersSuite extends BaseSuite {
     ConfigConvert[Duration].to(Duration.MinusInf),
     ConfigConvert[Duration].to(Duration.Inf))
 
+  checkReadString[FiniteDuration](
+    5.seconds -> "5 seconds",
+    28.millis -> "28 ms",
+    28.millis -> "28ms",
+    28.millis -> "28 milliseconds",
+    1.day -> "1d")
+
   checkArbitrary[Instant]
 
   checkArbitrary[ZoneOffset]
@@ -48,6 +54,12 @@ class BasicConvertersSuite extends BaseSuite {
   checkArbitrary[ZoneId]
 
   checkArbitrary[Period]
+
+  checkReadString[Period](
+    Period.ofDays(1) -> "1d",
+    Period.ofWeeks(4) -> "4 weeks",
+    Period.ofMonths(13) -> "13 months",
+    Period.ofYears(2) -> "2y")
 
   checkArbitrary[Year]
 

--- a/core/src/test/scala/pureconfig/ConfigConvertChecks.scala
+++ b/core/src/test/scala/pureconfig/ConfigConvertChecks.scala
@@ -80,6 +80,26 @@ trait ConfigConvertChecks { this: FlatSpec with Matchers with GeneratorDrivenPro
       }
     }
 
+  /** Similar to [[checkWrite()]] but work on ConfigValues of type String */
+  def checkWriteString[T: ConfigWriter: TypeTag: Equality](valuesToStrs: (T, String)*): Unit =
+    checkWrite[T](valuesToStrs.map { case (t, s) => t -> ConfigValueFactory.fromAnyRef(s) }: _*)
+
+  /**
+   * For each pair of value of type `T` and `ConfigValue`, check that `ConfigReader[T].from`
+   * successfully converts the latter into to former and `ConfigWriter[T].to` successfully converts the former into the
+   * latter.
+   */
+  def checkReadWrite[T: ConfigReader: ConfigWriter: TypeTag: Equality](reprsValues: (ConfigValue, T)*): Unit = {
+    checkRead[T](reprsValues: _*)
+    checkWrite[T](reprsValues.map(_.swap): _*)
+  }
+
+  /** Similar to [[checkReadWrite()]] but work on ConfigValues of type String */
+  def checkReadWriteString[T: ConfigReader: ConfigWriter: TypeTag: Equality](strsValues: (String, T)*): Unit = {
+    checkReadString[T](strsValues: _*)
+    checkWriteString[T](strsValues.map(_.swap): _*)
+  }
+
   /**
    * Check that `cc` returns error of type `E` when trying to read each value passed with `values`
    *

--- a/core/src/test/scala/pureconfig/DurationUtilsSuite.scala
+++ b/core/src/test/scala/pureconfig/DurationUtilsSuite.scala
@@ -6,10 +6,10 @@ import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigValueFactory
 import org.scalatest.Inspectors
-import pureconfig.DurationConvertSuite._
+import pureconfig.DurationUtilsSuite._
 import pureconfig.error.{ CannotConvert, ConvertFailure, ExceptionThrown }
 
-class DurationConvertSuite extends BaseSuite {
+class DurationUtilsSuite extends BaseSuite {
 
   "Converting a Duration to a String" should "pick an appropriate unit when dealing with whole units less than the next step up" in {
     fromD(Duration(14, TimeUnit.DAYS)) shouldBe "14d"
@@ -112,9 +112,9 @@ class DurationConvertSuite extends BaseSuite {
   }
 }
 
-object DurationConvertSuite {
+object DurationUtilsSuite {
   val scc = implicitly[ConfigConvert[String]]
   val dcc = implicitly[ConfigConvert[Duration]]
-  val fromD = DurationConvert.fromDuration(_: Duration)
-  val fromS = DurationConvert.fromString(_: String)
+  val fromD = DurationUtils.fromDuration(_: Duration)
+  val fromS = DurationUtils.fromString(_: String)
 }

--- a/core/src/test/scala/pureconfig/HListConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/HListConvertersSuite.scala
@@ -21,6 +21,6 @@ class HListConvertersSuite extends BaseSuite {
 
   // Check HNil
   val emptyConfigList = ConfigValueFactory.fromIterable(List().asJava)
-  checkRead[HNil](HNil -> emptyConfigList)
+  checkRead[HNil](emptyConfigList -> HNil)
   checkWrite[HNil](HNil -> emptyConfigList)
 }

--- a/core/src/test/scala/pureconfig/TupleConvertersSuite.scala
+++ b/core/src/test/scala/pureconfig/TupleConvertersSuite.scala
@@ -21,11 +21,11 @@ class TupleConvertersSuite extends BaseSuite {
   checkArbitrary[(Long, Foo, Boolean, Foo)]
 
   // Check readers from objects and lists
-  checkRead[(String, Int)](("one", 2) -> ConfigValueFactory.fromAnyRef(Map("_1" -> "one", "_2" -> 2).asJava))
-  checkRead[(String, Int)](("one", 2) -> ConfigValueFactory.fromIterable(List("one", 2).asJava))
+  checkRead[(String, Int)](ConfigValueFactory.fromMap(Map("_1" -> "one", "_2" -> 2).asJava) -> (("one", 2)))
+  checkRead[(String, Int)](ConfigValueFactory.fromIterable(List("one", 2).asJava) -> (("one", 2)))
 
   // Check writers
-  checkWrite[Tuple1[Int]](new Tuple1(1) -> ConfigValueFactory.fromIterable(List(1).asJava))
+  checkWrite[Tuple1[Int]](Tuple1(1) -> ConfigValueFactory.fromIterable(List(1).asJava))
   checkWrite[(String, Int)](("one", 2) -> ConfigValueFactory.fromIterable(List("one", 2).asJava))
   checkWrite[(Int, (Long, String), Boolean)]((1, (2l, "three"), false) -> ConfigValueFactory.fromIterable(List(1, List(2l, "three").asJava, false).asJava))
 

--- a/core/src/test/scala/pureconfig/ValueClassSuite.scala
+++ b/core/src/test/scala/pureconfig/ValueClassSuite.scala
@@ -32,7 +32,7 @@ class ValueClassSuite extends BaseSuite {
 
   behavior of "ConfigConvert for Value Classes"
 
-  checkRead[IntWrapper](new IntWrapper(1) -> ConfigWriter.forPrimitive[Int].to(1))
+  checkRead[IntWrapper](ConfigWriter.forPrimitive[Int].to(1) -> new IntWrapper(1))
   checkWrite[IntWrapper](new IntWrapper(1) -> ConfigWriter.forPrimitive[Int].to(1))
 
   "ConfigReader[PrivateFloatValue]" should "not be derivable because the constructor is private" in {

--- a/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
+++ b/core/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
@@ -3,92 +3,38 @@ package pureconfig.configurable
 import java.time._
 import java.time.format.DateTimeFormatter
 
+import scala.collection.JavaConverters._
+
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigRenderOptions.concise
 import org.scalacheck.{ Arbitrary, Gen }
-import org.scalatest._
-import org.scalatest.prop.PropertyChecks
+import pureconfig.BaseSuite
 import pureconfig.configurable.ConfigurableSuite._
 import pureconfig.error.UnknownKey
 import pureconfig.syntax._
 
-import scala.collection.JavaConverters._
+class ConfigurableSuite extends BaseSuite {
+  implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
 
-class ConfigurableSuite extends FlatSpec with Matchers with EitherValues with PropertyChecks {
+  behavior of "configurable converters"
 
   implicit val localTimeInstance = localTimeConfigConvert(DateTimeFormatter.ISO_TIME)
-
-  "pureconfig" should "parse LocalTime" in forAll {
-    (localTime: LocalTime) =>
-      val conf = ConfigFactory.parseString(s"""{time:"${localTime.format(DateTimeFormatter.ISO_TIME)}"}""")
-      case class Conf(time: LocalTime)
-      conf.to[Conf].right.value shouldEqual Conf(localTime)
-  }
-
   implicit val localDateInstance = localDateConfigConvert(DateTimeFormatter.ISO_DATE)
-
-  it should "parse LocalDate" in forAll {
-    (localDate: LocalDate) =>
-      val conf = ConfigFactory.parseString(s"""{date:"${localDate.format(DateTimeFormatter.ISO_DATE)}"}""")
-      case class Conf(date: LocalDate)
-      conf.to[Conf].right.value shouldEqual Conf(localDate)
-  }
-
   implicit val localDateTimeInstance = localDateTimeConfigConvert(DateTimeFormatter.ISO_DATE_TIME)
-
-  it should "parse LocalDateTime" in forAll {
-    (localDateTime: LocalDateTime) =>
-      val conf = ConfigFactory.parseString(s"""{date-time:"${localDateTime.format(DateTimeFormatter.ISO_DATE_TIME)}"}""")
-      case class Conf(dateTime: LocalDateTime)
-      conf.to[Conf].right.value shouldEqual Conf(localDateTime)
-  }
-
-  val monthDayFormat = DateTimeFormatter.ofPattern("MM-dd")
-  implicit val monthDayInstance = monthDayConfigConvert(monthDayFormat)
-
-  it should "parse MonthDay" in forAll {
-    (monthDay: MonthDay) =>
-      val conf = ConfigFactory.parseString(s"""{month-day:"${monthDay.format(monthDayFormat)}"}""")
-      case class Conf(monthDay: MonthDay)
-      conf.to[Conf].right.value shouldEqual Conf(monthDay)
-  }
-
+  implicit val monthDayInstance = monthDayConfigConvert(DateTimeFormatter.ofPattern("MM-dd"))
   implicit val offsetDateTimeInstance = offsetDateTimeConfigConvert(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-
-  it should "parse OffsetDateTime" in forAll {
-    (offsetDateTime: OffsetDateTime) =>
-      val conf = ConfigFactory.parseString(s"""{offset-date-time:"${offsetDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)}"}""")
-      case class Conf(offsetDateTime: OffsetDateTime)
-      conf.to[Conf].right.value shouldEqual Conf(offsetDateTime)
-  }
-
   implicit val offsetTimeInstance = offsetTimeConfigConvert(DateTimeFormatter.ISO_OFFSET_TIME)
-
-  it should "parse OffsetTime" in forAll {
-    (offsetTime: OffsetTime) =>
-      val conf = ConfigFactory.parseString(s"""{offset-time:"${offsetTime.format(DateTimeFormatter.ISO_OFFSET_TIME)}"}""")
-      case class Conf(offsetTime: OffsetTime)
-      conf.to[Conf].right.value shouldEqual Conf(offsetTime)
-  }
-
-  val yearMonthFormat = DateTimeFormatter.ofPattern("yyyy-MM")
-  implicit val yearMonthInstance = yearMonthConfigConvert(yearMonthFormat)
-
-  it should "parse YearMonth" in forAll {
-    (yearMonth: YearMonth) =>
-      val conf = ConfigFactory.parseString(s"""{year-month:"${yearMonth.format(yearMonthFormat)}"}""")
-      case class Conf(yearMonth: YearMonth)
-      conf.to[Conf].right.value shouldEqual Conf(yearMonth)
-  }
-
+  implicit val yearMonthInstance = yearMonthConfigConvert(DateTimeFormatter.ofPattern("yyyy-MM"))
   implicit val zonedDateTimeInstance = zonedDateTimeConfigConvert(DateTimeFormatter.ISO_ZONED_DATE_TIME)
 
-  it should "parse ZonedDateTime" in forAll {
-    (zonedDateTime: ZonedDateTime) =>
-      val conf = ConfigFactory.parseString(s"""{zoned-date-time:"${zonedDateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)}"}""")
-      case class Conf(zonedDateTime: ZonedDateTime)
-      conf.to[Conf].right.value shouldEqual Conf(zonedDateTime)
-  }
+  checkArbitrary[LocalTime]
+  checkArbitrary[LocalDate]
+  checkArbitrary[LocalDateTime]
+  checkArbitrary[MonthDay]
+  checkArbitrary[OffsetDateTime]
+  checkArbitrary[OffsetTime]
+  checkArbitrary[YearMonth]
+  checkArbitrary[ZonedDateTime]
 
   sealed trait Animal
   final case object Bird extends Animal

--- a/modules/joda/src/test/scala/pureconfig/module/joda/JodaSuite.scala
+++ b/modules/joda/src/test/scala/pureconfig/module/joda/JodaSuite.scala
@@ -1,6 +1,5 @@
 package pureconfig.module.joda
 
-import com.typesafe.config.ConfigValueFactory
 import org.joda.time._
 import org.scalacheck.Arbitrary
 import JodaSuite._
@@ -18,9 +17,8 @@ class JodaSuite extends BaseSuite {
 
   checkArbitrary[DateTimeZone]
 
-  checkRead[DateTimeFormatter](
-    DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZZ") ->
-      ConfigValueFactory.fromAnyRef("yyyy-MM-dd'T'HH:mm:ss.SSSZZZ"))
+  checkReadString[DateTimeFormatter](
+    "yyyy-MM-dd'T'HH:mm:ss.SSSZZZ" -> DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZZ"))
 }
 
 object JodaSuite {


### PR DESCRIPTION
I also did a little refactoring on our `checkRead` test utility method, which had a misleading signature, and made use of `checkReadString` in more places.

3faed69 adds `checkWriteString`, `checkReadWrite` and `checkReadWriteString`, which I use to increase our test coverage.

Closes #359.
