### PR TITLE
Add support of NonEmptySet into the cat's module.

### DIFF
--- a/modules/cats/README.md
+++ b/modules/cats/README.md
@@ -19,7 +19,7 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats" % "0.9.1"
 To load a `NonEmptyList[Int]` into a configuration, we need a class to hold our configuration:
 
 ```scala
-import cats.data.{NonEmptyList, NonEmptyVector}
+import cats.data.{NonEmptyList, NonEmptySet, NonEmptyVector}
 import com.typesafe.config.ConfigFactory.parseString
 import pureconfig._
 import pureconfig.module.cats._
@@ -46,6 +46,16 @@ then load the config:
 ```scala
 loadConfig[MyVecConfig](conf)
 // res2: Either[pureconfig.error.ConfigReaderFailures,MyVecConfig] = Right(MyVecConfig(NonEmptyVector(1, 2, 3)))
+```
+
+Similarly, `NonEmptySet` is also supported:
+
+```scala
+case class MySetConfig(numbers: NonEmptySet[Int])
+```
+```scala
+loadConfig[MySetConfig](conf)
+// res3: Either[pureconfig.error.ConfigReaderFailures,MySetConfig] = Right(MySetConfig(TreeSet(1, 2, 3)))
 ```
 
 ### Using cats type class instances for readers and writers
@@ -76,13 +86,13 @@ And we can finally put them to use:
 
 ```scala
 constIntReader.from(conf.root())
-// res8: Either[pureconfig.error.ConfigReaderFailures,Int] = Right(42)
+// res9: Either[pureconfig.error.ConfigReaderFailures,Int] = Right(42)
 
 safeIntReader.from(conf.root())
-// res9: Either[pureconfig.error.ConfigReaderFailures,Int] = Right(-1)
+// res10: Either[pureconfig.error.ConfigReaderFailures,Int] = Right(-1)
 
 someWriter[String].to(Some("abc"))
-// res10: com.typesafe.config.ConfigValue = Quoted("abc")
+// res11: com.typesafe.config.ConfigValue = Quoted("abc")
 ```
 
 ### Extra syntatic sugar

--- a/modules/cats/src/main/scala/pureconfig/module/cats/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/cats/package.scala
@@ -1,11 +1,12 @@
 package pureconfig.module
 
-import scala.language.higherKinds
-import scala.reflect.ClassTag
-
-import _root_.cats.data.{ NonEmptyList, NonEmptyVector }
+import _root_.cats.data.{ NonEmptyList, NonEmptySet, NonEmptyVector }
 import pureconfig.error.ConfigReaderFailures
 import pureconfig.{ ConfigCursor, ConfigReader, ConfigWriter }
+
+import scala.collection.immutable.SortedSet
+import scala.language.higherKinds
+import scala.reflect.ClassTag
 
 /**
  * `ConfigReader` and `ConfigWriter` instances for cats data structures.
@@ -31,4 +32,10 @@ package object cats {
 
   implicit def nonEmptyVectorWriter[T](implicit vectorWriter: ConfigWriter[Vector[T]]): ConfigWriter[NonEmptyVector[T]] =
     ConfigWriter.fromFunction(nonEmptyVector => vectorWriter.to(nonEmptyVector.toVector))
+
+  implicit def nonEmptySetReader[T](implicit listReader: ConfigReader[SortedSet[T]]): ConfigReader[NonEmptySet[T]] =
+    ConfigReader.fromCursor(fromNonEmpty[SortedSet, NonEmptySet, T](NonEmptySet.fromSet))
+
+  implicit def nonEmptySetWriter[T](implicit listWriter: ConfigWriter[SortedSet[T]]): ConfigWriter[NonEmptySet[T]] =
+    ConfigWriter.fromFunction(nel => listWriter.to(nel.toSortedSet))
 }

--- a/modules/cats/src/main/scala/pureconfig/module/cats/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/cats/package.scala
@@ -21,21 +21,18 @@ package object cats {
       }
     }
 
-  implicit def nonEmptyListReader[T](implicit listReader: ConfigReader[List[T]]): ConfigReader[NonEmptyList[T]] =
+  implicit def nonEmptyListReader[T](implicit reader: ConfigReader[List[T]]): ConfigReader[NonEmptyList[T]] =
     ConfigReader.fromCursor(fromNonEmpty[List, NonEmptyList, T](NonEmptyList.fromList))
+  implicit def nonEmptyListWriter[T](implicit writer: ConfigWriter[List[T]]): ConfigWriter[NonEmptyList[T]] =
+    ConfigWriter.fromFunction(nel => writer.to(nel.toList))
 
-  implicit def nonEmptyListWriter[T](implicit listWriter: ConfigWriter[List[T]]): ConfigWriter[NonEmptyList[T]] =
-    ConfigWriter.fromFunction(nel => listWriter.to(nel.toList))
-
-  implicit def nonEmptyVectorReader[T](implicit vectorReader: ConfigReader[Vector[T]]): ConfigReader[NonEmptyVector[T]] =
+  implicit def nonEmptyVectorReader[T](implicit reader: ConfigReader[Vector[T]]): ConfigReader[NonEmptyVector[T]] =
     ConfigReader.fromCursor(fromNonEmpty[Vector, NonEmptyVector, T](NonEmptyVector.fromVector))
+  implicit def nonEmptyVectorWriter[T](implicit writer: ConfigWriter[Vector[T]]): ConfigWriter[NonEmptyVector[T]] =
+    ConfigWriter.fromFunction(nonEmptyVector => writer.to(nonEmptyVector.toVector))
 
-  implicit def nonEmptyVectorWriter[T](implicit vectorWriter: ConfigWriter[Vector[T]]): ConfigWriter[NonEmptyVector[T]] =
-    ConfigWriter.fromFunction(nonEmptyVector => vectorWriter.to(nonEmptyVector.toVector))
-
-  implicit def nonEmptySetReader[T](implicit listReader: ConfigReader[SortedSet[T]]): ConfigReader[NonEmptySet[T]] =
+  implicit def nonEmptySetReader[T](implicit reader: ConfigReader[SortedSet[T]]): ConfigReader[NonEmptySet[T]] =
     ConfigReader.fromCursor(fromNonEmpty[SortedSet, NonEmptySet, T](NonEmptySet.fromSet))
-
-  implicit def nonEmptySetWriter[T](implicit listWriter: ConfigWriter[SortedSet[T]]): ConfigWriter[NonEmptySet[T]] =
-    ConfigWriter.fromFunction(nel => listWriter.to(nel.toSortedSet))
+  implicit def nonEmptySetWriter[T](implicit writer: ConfigWriter[SortedSet[T]]): ConfigWriter[NonEmptySet[T]] =
+    ConfigWriter.fromFunction(nel => writer.to(nel.toSortedSet))
 }

--- a/modules/cats/src/main/tut/README.md
+++ b/modules/cats/src/main/tut/README.md
@@ -19,7 +19,7 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats" % "0.9.1"
 To load a `NonEmptyList[Int]` into a configuration, we need a class to hold our configuration:
 
 ```tut:silent
-import cats.data.{NonEmptyList, NonEmptyVector}
+import cats.data.{NonEmptyList, NonEmptySet, NonEmptyVector}
 import com.typesafe.config.ConfigFactory.parseString
 import pureconfig._
 import pureconfig.module.cats._
@@ -42,6 +42,15 @@ case class MyVecConfig(numbers: NonEmptyVector[Int])
 then load the config:
 ```tut:book
 loadConfig[MyVecConfig](conf)
+```
+
+Similarly, `NonEmptySet` is also supported:
+
+```tut:silent
+case class MySetConfig(numbers: NonEmptySet[Int])
+```
+```tut:book
+loadConfig[MySetConfig](conf)
 ```
 
 ### Using cats type class instances for readers and writers

--- a/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
@@ -1,9 +1,12 @@
 package pureconfig.module.cats
 
-import cats.data.{ NonEmptyList, NonEmptyVector }
+import cats.data.{ NonEmptyList, NonEmptySet, NonEmptyVector }
+import cats.instances.int._
 import com.typesafe.config.ConfigFactory.parseString
 import pureconfig.BaseSuite
 import pureconfig.syntax._
+
+import scala.collection.immutable.SortedSet
 
 class CatsSuite extends BaseSuite {
 
@@ -29,5 +32,17 @@ class CatsSuite extends BaseSuite {
   it should "return an EmptyTraversableFound when reading empty lists into NonEmptyVector" in {
     val config = parseString("{ numbers: [] }")
     config.to[NumVec] should failWith(EmptyTraversableFound("scala.collection.immutable.Vector"), "numbers")
+  }
+
+  case class NumSet(numbers: NonEmptySet[Int])
+
+  it should "be able to read a config with an NonEmptySet" in {
+    val config = parseString(s"""{ numbers: [1,2,3] }""")
+    config.to[NumSet] shouldEqual Right(NumSet(NonEmptySet(1, SortedSet(2, 3))))
+  }
+
+  it should "return an EmptyTraversableFound when reading empty set into NonEmptySet" in {
+    val config = parseString("{ numbers: [] }")
+    config.to[NumSet] should failWith(EmptyTraversableFound("scala.collection.immutable.SortedSet"), "numbers")
   }
 }

--- a/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/CatsSuite.scala
@@ -3,42 +3,29 @@ package pureconfig.module.cats
 import cats.data.{ NonEmptyList, NonEmptySet, NonEmptyVector }
 import cats.instances.int._
 import com.typesafe.config.ConfigFactory.parseString
-import pureconfig.BaseSuite
 import pureconfig.syntax._
+import pureconfig.{ BaseSuite, ConfigConvertChecks }
 
 import scala.collection.immutable.SortedSet
 
-class CatsSuite extends BaseSuite {
+class CatsSuite extends BaseSuite with ConfigConvertChecks {
 
   case class Numbers(numbers: NonEmptyList[Int])
+  case class NumVec(numbers: NonEmptyVector[Int])
+  case class NumSet(numbers: NonEmptySet[Int])
 
-  it should "be able to read a config with a NonEmptyList" in {
-    val config = parseString(s"""{ numbers: [1,2,3] }""")
-    config.to[Numbers] shouldEqual Right(Numbers(NonEmptyList(1, List(2, 3))))
-  }
+  checkReadWrite[Numbers](parseString(s"""{ numbers: [1,2,3] }""").root() → Numbers(NonEmptyList(1, List(2, 3))))
+  checkReadWrite[NumVec](parseString(s"""{ numbers: [1,2,3] }""").root() → NumVec(NonEmptyVector(1, Vector(2, 3))))
+  checkReadWrite[NumSet](parseString(s"""{ numbers: [1,2,3] }""").root() → NumSet(NonEmptySet(1, SortedSet(2, 3))))
 
   it should "return an EmptyTraversableFound when reading empty lists into NonEmptyList" in {
     val config = parseString("{ numbers: [] }")
     config.to[Numbers] should failWith(EmptyTraversableFound("scala.collection.immutable.List"), "numbers")
   }
 
-  case class NumVec(numbers: NonEmptyVector[Int])
-
-  it should "be able to read a config with an NonEmptyVector" in {
-    val config = parseString(s"""{ numbers: [1,2,3] }""")
-    config.to[NumVec] shouldEqual Right(NumVec(NonEmptyVector(1, Vector(2, 3))))
-  }
-
   it should "return an EmptyTraversableFound when reading empty lists into NonEmptyVector" in {
     val config = parseString("{ numbers: [] }")
     config.to[NumVec] should failWith(EmptyTraversableFound("scala.collection.immutable.Vector"), "numbers")
-  }
-
-  case class NumSet(numbers: NonEmptySet[Int])
-
-  it should "be able to read a config with an NonEmptySet" in {
-    val config = parseString(s"""{ numbers: [1,2,3] }""")
-    config.to[NumSet] shouldEqual Right(NumSet(NonEmptySet(1, SortedSet(2, 3))))
   }
 
   it should "return an EmptyTraversableFound when reading empty set into NonEmptySet" in {


### PR DESCRIPTION
Cats 1.1.0 added the support of `NonEmptySet`. Add the pureconfig convertors to support it.