### PR TITLE
Fix DateTime arbitrary in tests

### DIFF
--- a/modules/joda/src/test/scala/pureconfig/module/joda/configurable/ConfigurableSuite.scala
+++ b/modules/joda/src/test/scala/pureconfig/module/joda/configurable/ConfigurableSuite.scala
@@ -76,8 +76,8 @@ object ConfigurableSuite {
   implicit val dateTimeArbitrary: Arbitrary[DateTime] =
     Arbitrary(
       for {
-        localDateTime <- localDateTimeArbitrary.arbitrary
         zoneId <- zoneIdArbitrary.arbitrary
+        localDateTime <- localDateTimeArbitrary.arbitrary if !zoneId.isLocalDateTimeGap(localDateTime)
       } yield localDateTime.toDateTime(zoneId))
 
   implicit val periodArbitrary: Arbitrary[Period] =


### PR DESCRIPTION
As explained [here](http://joda-time.sourceforge.net/faq.html#illegalinstant), not every combination of `DateTimeZone` and `LocalDateTime` form a valid `DateTime`, as in spring there's a gap where a local time for that time zone doesn't exist. This PR makes us validate the pair before trying to create a `DateTime`.

Hopefully fixes #266.