### PR TITLE
Switch to parallel effects in cats instances

### DIFF
--- a/modules/cats/README.md
+++ b/modules/cats/README.md
@@ -73,7 +73,7 @@ We are now ready to use the new syntax:
 
 ```scala
 // a reader that returns a constant value
-val constIntReader = Monad[ConfigReader].pure(42)
+val constIntReader = 42.pure[ConfigReader]
 
 // a Int reader that returns -1 if an error occurs
 val safeIntReader = ConfigReader[Int].handleError(_ => -1)

--- a/modules/cats/src/main/scala/pureconfig/module/cats/instances/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/cats/instances/package.scala
@@ -27,17 +27,43 @@ package object instances {
         }
     }
 
-  implicit val configWriterCatsInstance: Contravariant[ConfigWriter] = new Contravariant[ConfigWriter] {
-    def contramap[A, B](fa: ConfigWriter[A])(f: B => A): ConfigWriter[B] =
-      fa.contramap(f)
-  }
+  implicit val configWriterCatsInstance: ContravariantSemigroupal[ConfigWriter] =
+    new ContravariantSemigroupal[ConfigWriter] {
+      def contramap[A, B](fa: ConfigWriter[A])(f: B => A): ConfigWriter[B] =
+        fa.contramap(f)
 
-  implicit val configConvertCatsInstance: Invariant[ConfigConvert] = new Invariant[ConfigConvert] {
-    def imap[A, B](fa: ConfigConvert[A])(f: A => B)(g: B => A): ConfigConvert[B] =
-      fa.xmap(f, g)
-  }
+      def product[A, B](fa: ConfigWriter[A], fb: ConfigWriter[B]) =
+        ConfigWriter.fromFunction[(A, B)] {
+          case (a, b) =>
+            fb.to(b).withFallback(fa.to(a))
+        }
+    }
+
+  implicit val configConvertCatsInstance: InvariantSemigroupal[ConfigConvert] =
+    new InvariantSemigroupal[ConfigConvert] {
+      def imap[A, B](fa: ConfigConvert[A])(f: A => B)(g: B => A): ConfigConvert[B] =
+        fa.xmap(f, g)
+
+      def product[A, B](fa: ConfigConvert[A], fb: ConfigConvert[B]): ConfigConvert[(A, B)] = {
+        val reader = fa.zip(fb)
+        val writer = ConfigWriter.fromFunction[(A, B)] {
+          case (a, b) =>
+            fb.to(b).withFallback(fa.to(a))
+        }
+
+        ConfigConvert.fromReaderAndWriter(
+          Derivation.Successful(reader),
+          Derivation.Successful(writer))
+      }
+    }
 
   implicit val configValueEq: Eq[ConfigValue] = Eq.fromUniversalEquals
   implicit val configReaderFailureEq: Eq[ConfigReaderFailure] = Eq.fromUniversalEquals
   implicit val configReaderFailuresEq: Eq[ConfigReaderFailures] = Eq.fromUniversalEquals
+
+  implicit val configReaderFailuresSemigroup: Semigroup[ConfigReaderFailures] =
+    Semigroup.instance(_ ++ _)
+
+  implicit val configValueCatsSemigroup: Semigroup[ConfigValue] =
+    Semigroup.instance((a, b) => b.withFallback(a))
 }

--- a/modules/cats/src/main/scala/pureconfig/module/cats/instances/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/cats/instances/package.scala
@@ -1,31 +1,19 @@
 package pureconfig.module.cats
 
-import scala.annotation.tailrec
-import cats.{ Contravariant, Eq, Invariant, MonadError }
+import cats._
 import com.typesafe.config.ConfigValue
 import pureconfig._
 import pureconfig.error.{ ConfigReaderFailure, ConfigReaderFailures }
 
 package object instances {
 
-  implicit val configReaderCatsInstance: MonadError[ConfigReader, ConfigReaderFailures] = {
-    new MonadError[ConfigReader, ConfigReaderFailures] {
-
+  implicit val configReaderInstance: ApplicativeError[ConfigReader, ConfigReaderFailures] =
+    new ApplicativeError[ConfigReader, ConfigReaderFailures] {
       def pure[A](x: A): ConfigReader[A] =
-        ConfigReader.fromFunction { _ => Right(x) }
+        ConfigReader(ConfigReader.fromFunction { _ => Right(x) })
 
-      def flatMap[A, B](fa: ConfigReader[A])(f: A => ConfigReader[B]): ConfigReader[B] =
-        fa.flatMap(f)
-
-      def tailRecM[A, B](a: A)(f: A => ConfigReader[Either[A, B]]): ConfigReader[B] = ConfigReader.fromFunction { cv =>
-        @tailrec
-        def loop(currA: A): Either[ConfigReaderFailures, B] = f(currA).from(cv) match {
-          case Left(failures) => Left(failures)
-          case Right(Right(b)) => Right(b)
-          case Right(Left(nextA)) => loop(nextA)
-        }
-        loop(a)
-      }
+      def ap[A, B](ff: ConfigReader[A => B])(fa: ConfigReader[A]): ConfigReader[B] =
+        ff.zip(fa).map { case (f, a) => f(a) }
 
       def raiseError[A](e: ConfigReaderFailures): ConfigReader[A] =
         ConfigReader.fromFunction { _ => Left(e) }
@@ -38,7 +26,6 @@ package object instances {
           }
         }
     }
-  }
 
   implicit val configWriterCatsInstance: Contravariant[ConfigWriter] = new Contravariant[ConfigWriter] {
     def contramap[A, B](fa: ConfigWriter[A])(f: B => A): ConfigWriter[B] =

--- a/modules/cats/src/main/tut/README.md
+++ b/modules/cats/src/main/tut/README.md
@@ -68,7 +68,7 @@ We are now ready to use the new syntax:
 
 ```tut:silent
 // a reader that returns a constant value
-val constIntReader = Monad[ConfigReader].pure(42)
+val constIntReader = 42.pure[ConfigReader]
 
 // a Int reader that returns -1 if an error occurs
 val safeIntReader = ConfigReader[Int].handleError(_ => -1)

--- a/modules/cats/src/test/scala/pureconfig/module/cats/CatsLawsSuite.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/CatsLawsSuite.scala
@@ -15,6 +15,6 @@ import pureconfig.module.cats.instances._
 
 class CatsLawsSuite extends FunSuite with Matchers with Discipline {
   checkAll("ConfigReader[Int]", ApplicativeErrorTests[ConfigReader, ConfigReaderFailures].applicativeError[Int, Int, Int])
-  checkAll("ConfigWriter[Int]", ContravariantTests[ConfigWriter].contravariant[Int, Int, Int])
-  checkAll("ConfigConvert[Int]", InvariantTests[ConfigConvert].invariant[Int, Int, Int])
+  checkAll("ConfigWriter[Int]", ContravariantSemigroupalTests[ConfigWriter].contravariantSemigroupal[Int, Int, Int])
+  checkAll("ConfigConvert[Int]", InvariantSemigroupalTests[ConfigConvert].invariantSemigroupal[Int, Int, Int])
 }

--- a/modules/cats/src/test/scala/pureconfig/module/cats/CatsLawsSuite.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/CatsLawsSuite.scala
@@ -4,7 +4,9 @@ import cats.instances.either._
 import cats.instances.int._
 import cats.instances.tuple._
 import cats.instances.unit._
+import cats.kernel.laws.discipline.SemigroupTests
 import cats.laws.discipline._
+import com.typesafe.config.ConfigValue
 import org.scalatest.{ FunSuite, Matchers }
 import org.typelevel.discipline.scalatest.Discipline
 import pureconfig._
@@ -17,4 +19,7 @@ class CatsLawsSuite extends FunSuite with Matchers with Discipline {
   checkAll("ConfigReader[Int]", ApplicativeErrorTests[ConfigReader, ConfigReaderFailures].applicativeError[Int, Int, Int])
   checkAll("ConfigWriter[Int]", ContravariantSemigroupalTests[ConfigWriter].contravariantSemigroupal[Int, Int, Int])
   checkAll("ConfigConvert[Int]", InvariantSemigroupalTests[ConfigConvert].invariantSemigroupal[Int, Int, Int])
+
+  checkAll("ConfigValue", SemigroupTests[ConfigValue].semigroup)
+  checkAll("ConfigReaderFailures", SemigroupTests[ConfigReaderFailures].semigroup)
 }

--- a/modules/cats/src/test/scala/pureconfig/module/cats/CatsLawsSuite.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/CatsLawsSuite.scala
@@ -14,7 +14,7 @@ import pureconfig.module.cats.eq._
 import pureconfig.module.cats.instances._
 
 class CatsLawsSuite extends FunSuite with Matchers with Discipline {
-  checkAll("ConfigReader[Int]", MonadErrorTests[ConfigReader, ConfigReaderFailures].monadError[Int, Int, Int])
+  checkAll("ConfigReader[Int]", ApplicativeErrorTests[ConfigReader, ConfigReaderFailures].applicativeError[Int, Int, Int])
   checkAll("ConfigWriter[Int]", ContravariantTests[ConfigWriter].contravariant[Int, Int, Int])
   checkAll("ConfigConvert[Int]", InvariantTests[ConfigConvert].invariant[Int, Int, Int])
 }


### PR DESCRIPTION
Fixes #397.

The instances follow `cats.data.Validated` in that the errors are accumulated.

Tuple syntax is now supported for all three typeclasses:
```scala
val configReader1: ConfigReader[T1] = ...
...
val f: (T1, T2) => X
val g: X => (T1, T2)

// This was already present, but now it's parallel.
(configReader1,
  configReader2
).mapN(f)

// This is new
(configWriter1,
  configWriter2
).contramapN(g)

(configConvert1,
  configConvert2
).imapN(f)(g)
```

The new `Semigroup[ConfigReaderFailures]` also means we can use `.parMapN` syntax for the conversion result (`Either[ConfigReaderFailures, A]`):
```scala
(cursor.to[T1],
  cursor.to[T2]
).parMapN(f)
```

Some issues:
1. This is definitely breaking. We don't have a full `MonadError[ConfigReader]` now, and the behavior of the `ApplicativeError[ConfigReader]` has changed.
2. The `ApplicativeError[ConfigReader]` instance doesn't match the monad implied by the `ConfigReader.flatMap` method. `Validated` takes the high road here by providing the monadic bind under a different name (`.andThen`), however that would probably break a lot of existing code in our case.