### PR TITLE
Use UTF-8 charset when saving configs

### DIFF
--- a/core/src/main/scala/pureconfig/package.scala
+++ b/core/src/main/scala/pureconfig/package.scala
@@ -4,7 +4,8 @@
 /**
  * @author Mario Pastorelli
  */
-import java.io.{ OutputStream, PrintStream }
+import java.io.{ OutputStream, OutputStreamWriter }
+import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{ Files, Path }
 
 import scala.reflect.ClassTag
@@ -255,9 +256,10 @@ package object pureconfig {
    * @param outputStream The stream in which the configuration should be written
    */
   def saveConfigToStream[Config](conf: Config, outputStream: OutputStream)(implicit writer: Derivation[ConfigWriter[Config]]): Unit = {
-    val printOutputStream = new PrintStream(outputStream)
+    // HOCON requires UTF-8
+    val printOutputStream = new OutputStreamWriter(outputStream, UTF_8)
     val rawConf = writer.value.to(conf)
-    printOutputStream.print(rawConf.render())
+    printOutputStream.write(rawConf.render())
     printOutputStream.close()
   }
 

--- a/core/src/main/scala/pureconfig/package.scala
+++ b/core/src/main/scala/pureconfig/package.scala
@@ -256,7 +256,8 @@ package object pureconfig {
    * @param outputStream The stream in which the configuration should be written
    */
   def saveConfigToStream[Config](conf: Config, outputStream: OutputStream)(implicit writer: Derivation[ConfigWriter[Config]]): Unit = {
-    // HOCON requires UTF-8
+    // HOCON requires UTF-8:
+    // https://github.com/lightbend/config/blob/master/HOCON.md#unchanged-from-json
     val printOutputStream = new OutputStreamWriter(outputStream, UTF_8)
     val rawConf = writer.value.to(conf)
     printOutputStream.write(rawConf.render())


### PR DESCRIPTION
Using the default charset is generally bad practice, and HOCON must always be in UTF-8 anyway.