### PR TITLE
Add a failOnReadError option to loadConfigFromFiles

### DIFF
--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -55,6 +55,7 @@ object ConvertFailure {
 /**
  * A failure occurred because a list of files to load was empty.
  */
+@deprecated("`loadConfigFromFiles` won't return this failure anymore", "0.10.0")
 case object NoFilesToRead extends ConfigReaderFailure {
   def description = "The config files to load must not be empty."
   def location = None

--- a/core/src/main/scala/pureconfig/package.scala
+++ b/core/src/main/scala/pureconfig/package.scala
@@ -274,7 +274,7 @@ package object pureconfig {
    * defined by the `failOnReadError` flag. With `failOnReadError = false`, such files will silently be ignored while
    * otherwise they would yield a failure (a `Left` value).
    *
-   * @param files Files ordered in decreasing priority containing part or all of a `Config`. Must not be empty.
+   * @param files Files ordered in decreasing priority containing part or all of a `Config`
    */
   def loadConfigFromFiles[Config](files: Traversable[Path], failOnReadError: Boolean = false)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] = {
     files.map(parseFile)

--- a/core/src/test/scala/pureconfig/ApiSuite.scala
+++ b/core/src/test/scala/pureconfig/ApiSuite.scala
@@ -155,16 +155,22 @@ class ApiSuite extends BaseSuite {
     loadConfigFromFiles[Conf](files) shouldBe Right(Conf(0.99F))
   }
 
-  it should "fail if the list of files is empty" in {
+  it should "use an empty config if the list of files is empty" in {
     case class Conf(f: Float)
     val files = Set.empty[Path]
-    loadConfigFromFiles[Conf](files) should failWithType[NoFilesToRead.type]
+    loadConfigFromFiles[Conf](files) should failWithType[KeyNotFound] // f is missing
   }
 
-  it should "ignore files that don't exist" in {
+  it should "ignore files that don't exist when failOnReadError is false" in {
     case class Conf(b: Boolean, d: Double)
     val files = listResourcesFromNames("/conf/loadConfigFromFiles/priority2.conf") :+ nonExistingPath
     loadConfigFromFiles[Conf](files) shouldBe Right(Conf(false, 0.001D))
+  }
+
+  it should "fail if any of the files doesn't exist and failOnReadError is true" in {
+    case class Conf(f: Float)
+    val files = listResourcesFromNames("/conf/loadConfigFromFiles/priority2.conf") :+ nonExistingPath
+    loadConfigFromFiles[Conf](files, failOnReadError = true) should failWithType[CannotReadFile]
   }
 
   "loadConfigWithFallback" should "fallback if no config keys are found" in {


### PR DESCRIPTION
Closes #335.

I also chose to change the behavior of `loadConfigFromFiles` when an empty list is passed. IMO this should not be handled in a special way, since on dynamically generated lists of config files it may even make sense to call this with an empty list and get an empty config back (even if we were to actually fail it would make more sense to me to throw an `IllegalArgumentException` rather than returning a `Left`, since it was not really a PureConfig error).
