### PR TITLE
Generalize AllowMissingKeys behavior to writers

### DIFF
--- a/core/src/main/scala/pureconfig/CollectionReaders.scala
+++ b/core/src/main/scala/pureconfig/CollectionReaders.scala
@@ -11,8 +11,8 @@ import pureconfig.error._
  * A marker trait signaling that a `ConfigReader` accepts missing (undefined) values.
  *
  * The standard behavior of `ConfigReader`s that expect required keys in config objects is to return a `KeyNotFound`
- * failure when one or more of them are missing. Mixing in this trait into the key's `ConfigReader` signals that a
- * value is missing for the key, the `ConfigReader` can be called with an cursor in the "undefined" state.
+ * failure when one or more of them are missing. Mixing in this trait into the key's `ConfigReader` signals that if
+ * a value is missing for the key, the `ConfigReader` can be called with a cursor in the "undefined" state.
  */
 trait ReadsMissingKeys { this: ConfigReader[_] => }
 

--- a/core/src/main/scala/pureconfig/CollectionWriters.scala
+++ b/core/src/main/scala/pureconfig/CollectionWriters.scala
@@ -6,11 +6,29 @@ import scala.language.higherKinds
 import com.typesafe.config._
 
 /**
+ * A trait signaling that a `ConfigWriter` can write missing (undefined) values.
+ *
+ * `ConfigWriter`s always produce a valid `ConfigValue` with their `to` method. This trait adds an extra `toOpt`
+ * method that parent writers and use in order to decide whether or not they should write a value using this writer.
+ */
+trait WritesMissingKeys[A] { this: ConfigWriter[A] =>
+  def toOpt(a: A): Option[ConfigValue]
+}
+
+/**
  * Trait containing `ConfigWriter` instances for collection types.
  */
 trait CollectionWriters {
 
-  implicit def optionWriter[T](implicit conv: Derivation[ConfigWriter[T]]) = new CollectionWriters.OptionConfigWriter[T]
+  implicit def optionWriter[T](implicit conv: Derivation[ConfigWriter[T]]): ConfigWriter[Option[T]] =
+    new ConfigWriter[Option[T]] with WritesMissingKeys[Option[T]] {
+      override def to(t: Option[T]): ConfigValue = t match {
+        case Some(v) => conv.value.to(v)
+        case None => ConfigValueFactory.fromAnyRef(null)
+      }
+
+      def toOpt(t: Option[T]): Option[ConfigValue] = t.map(conv.value.to)
+    }
 
   implicit def traversableWriter[T, F[T] <: TraversableOnce[T]](
     implicit
@@ -28,15 +46,4 @@ trait CollectionWriters {
   }
 }
 
-object CollectionWriters extends CollectionWriters {
-
-  // TODO: change this to an `AllowMissingKey`-like trait for better extensibility
-  class OptionConfigWriter[T](implicit conv: Derivation[ConfigWriter[T]]) extends ConfigWriter[Option[T]] {
-    override def to(t: Option[T]): ConfigValue = t match {
-      case Some(v) => conv.value.to(v)
-      case None => ConfigValueFactory.fromAnyRef(null)
-    }
-
-    def toOption(t: Option[T]): Option[ConfigValue] = t.map(conv.value.to)
-  }
-}
+object CollectionWriters extends CollectionWriters

--- a/core/src/main/scala/pureconfig/CollectionWriters.scala
+++ b/core/src/main/scala/pureconfig/CollectionWriters.scala
@@ -9,7 +9,7 @@ import com.typesafe.config._
  * A trait signaling that a `ConfigWriter` can write missing (undefined) values.
  *
  * `ConfigWriter`s always produce a valid `ConfigValue` with their `to` method. This trait adds an extra `toOpt`
- * method that parent writers and use in order to decide whether or not they should write a value using this writer.
+ * method that parent writers can use in order to decide whether or not they should write a value using this writer.
  */
 trait WritesMissingKeys[A] { this: ConfigWriter[A] =>
   def toOpt(a: A): Option[ConfigValue]

--- a/core/src/main/scala/pureconfig/package.scala
+++ b/core/src/main/scala/pureconfig/package.scala
@@ -40,7 +40,7 @@ package object pureconfig {
   // loads a value from a config in a given namespace. All `loadConfig` methods _must_ use this method to get correct
   // namespace handling, both in the values to load and in the error messages.
   private[this] def loadValue[A](conf: TypesafeConfig, namespace: String)(implicit reader: Derivation[ConfigReader[A]]): Either[ConfigReaderFailures, A] = {
-    getValue(conf, namespace, reader.value.isInstanceOf[AllowMissingKey]).right.flatMap(reader.value.from)
+    getValue(conf, namespace, reader.value.isInstanceOf[ReadsMissingKeys]).right.flatMap(reader.value.from)
   }
 
   /**

--- a/docs/src/main/tut/docs/overriding-behavior-for-case-classes.md
+++ b/docs/src/main/tut/docs/overriding-behavior-for-case-classes.md
@@ -175,14 +175,14 @@ loadConfig[Foo](ConfigFactory.empty)
 loadConfig[FooOpt](ConfigFactory.empty)
 ```
 
-However, if you want to allow your custom `ConfigReader`s to handle missing keys, you can extend the `AllowMissingKey`
-trait. For `ConfigReader`s extending `AllowMissingKey`, a missing key will issue a call to the `from` method of the
+However, if you want to allow your custom `ConfigReader`s to handle missing keys, you can extend the `ReadsMissingKeys`
+trait. For `ConfigReader`s extending `ReadsMissingKeys`, a missing key will issue a call to the `from` method of the
 available `ConfigReader` for that type with a [cursor](config-cursors.html) to an undefined value.
 
 Under this setup:
 
 ```tut:silent
-implicit val maybeIntReader = new ConfigReader[Int] with AllowMissingKey {
+implicit val maybeIntReader = new ConfigReader[Int] with ReadsMissingKeys {
   override def from(cur: ConfigCursor) =
     if (cur.isUndefined) Right(42) else ConfigReader[Int].from(cur)
 }

--- a/modules/generic/src/main/scala/pureconfig/generic/MapShapedReader.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/MapShapedReader.scala
@@ -56,7 +56,7 @@ object MapShapedReader {
         case keyCur if keyCur.isUndefined =>
           default.head match {
             case Some(defaultValue) if hint.useDefaultArgs => Right(defaultValue)
-            case _ if headReader.isInstanceOf[AllowMissingKey] => headReader.from(keyCur)
+            case _ if headReader.isInstanceOf[ReadsMissingKeys] => headReader.from(keyCur)
             case _ => cur.failed(KeyNotFound.forKeys(keyStr, cur.keys))
           }
         case keyCur => headReader.from(keyCur)

--- a/modules/generic/src/main/scala/pureconfig/generic/MapShapedWriter.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/MapShapedWriter.scala
@@ -34,8 +34,8 @@ object MapShapedWriter {
       val rem = tConfigWriter.value.to(t.tail)
       // TODO check that all keys are unique
       vFieldConvert.value.value match {
-        case f: CollectionWriters.OptionConfigWriter[_] =>
-          f.toOption(t.head) match {
+        case f: WritesMissingKeys[V @unchecked] =>
+          f.toOpt(t.head) match {
             case Some(v) =>
               rem.asInstanceOf[ConfigObject].withValue(keyStr, v)
             case None =>

--- a/tests/src/test/scala/pureconfig/ProductConvertersSuite.scala
+++ b/tests/src/test/scala/pureconfig/ProductConvertersSuite.scala
@@ -73,7 +73,7 @@ class ProductConvertersSuite extends BaseSuite {
     val conf = ConfigFactory.parseString("""{ a: 1 }""").root()
     ConfigConvert[Conf].from(conf) should failWith(KeyNotFound("b"))
 
-    implicit val defaultInt = new ConfigConvert[Int] with AllowMissingKey {
+    implicit val defaultInt = new ConfigConvert[Int] with ReadsMissingKeys {
       def from(cur: ConfigCursor) =
         if (cur.isUndefined) Right(42) else {
           val s = cur.value.render(ConfigRenderOptions.concise)

--- a/tests/src/test/scala/pureconfig/ProductConvertersSuite.scala
+++ b/tests/src/test/scala/pureconfig/ProductConvertersSuite.scala
@@ -2,7 +2,7 @@ package pureconfig
 
 import scala.collection.JavaConverters._
 
-import com.typesafe.config.{ ConfigFactory, ConfigRenderOptions }
+import com.typesafe.config.{ ConfigFactory, ConfigRenderOptions, ConfigValueFactory }
 import org.scalacheck.Arbitrary
 import org.scalacheck.ScalacheckShapeless._
 import pureconfig.ConfigConvert.catchReadError
@@ -68,20 +68,30 @@ class ProductConvertersSuite extends BaseSuite {
     ConfigConvert[EnclosingConf].from(emptyConf) should failWith(KeyNotFound("conf"))
   }
 
-  it should "allow custom ConfigConverts to handle missing keys" in {
+  it should "allow custom ConfigReaders to handle missing keys" in {
     case class Conf(a: Int, b: Int)
     val conf = ConfigFactory.parseString("""{ a: 1 }""").root()
-    ConfigConvert[Conf].from(conf) should failWith(KeyNotFound("b"))
+    ConfigReader[Conf].from(conf) should failWith(KeyNotFound("b"))
 
-    implicit val defaultInt = new ConfigConvert[Int] with ReadsMissingKeys {
+    implicit val defaultInt = new ConfigReader[Int] with ReadsMissingKeys {
       def from(cur: ConfigCursor) =
         if (cur.isUndefined) Right(42) else {
           val s = cur.value.render(ConfigRenderOptions.concise)
           cur.scopeFailure(catchReadError(_.toInt)(implicitly)(s))
         }
-      def to(v: Int) = ???
     }
-    ConfigConvert[Conf].from(conf).right.value shouldBe Conf(1, 42)
+    ConfigReader[Conf].from(conf).right.value shouldBe Conf(1, 42)
+  }
+
+  it should "allow custom ConfigWriters to handle missing keys" in {
+    case class Conf(a: Int, b: Int)
+    ConfigWriter[Conf].to(Conf(0, 3)) shouldBe ConfigFactory.parseString("""{ a: 0, b: 3 }""").root()
+
+    implicit val nonZeroInt = new ConfigWriter[Int] with WritesMissingKeys[Int] {
+      def to(v: Int) = ConfigValueFactory.fromAnyRef(v)
+      def toOpt(a: Int) = if (a == 0) None else Some(to(a))
+    }
+    ConfigWriter[Conf].to(Conf(0, 3)) shouldBe ConfigFactory.parseString("""{ b: 3 }""").root()
   }
 
   it should "not write empty option fields" in {


### PR DESCRIPTION
Currently, we have a pluggable system for readers that can handle missing (undefined) keys. On the writing side we currently aren't doing the same, and instead we statically check if writers are instances of `OptionConfigWriter` (a private internal class).

This PR renames `AllowMissingKeys` to `ReadsMissingKeys` and creates a new `WritesMissingKeys` trait that provides the mechanisms to allow any custom type to have option-like semantics on write.
