### PR TITLE
Add Scaladoc for `forProduct` methods

### DIFF
--- a/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
+++ b/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
@@ -34,8 +34,8 @@ trait ProductReaders {
         a1Result
       }
   }
-  [2..22#
-  /**
+
+  [2..22#/**
    * Builds a `ConfigReader` for an object created from the values of 1 keys.
    *
    * @param f the function converting the tuple of values to the target object

--- a/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
+++ b/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
@@ -15,6 +15,14 @@ trait ProductReaders {
       else
         cursor.atKey(key).right.flatMap(reader.from))(_(_))
 
+  /**
+   * Builds a `ConfigReader` for an object created from the value of 1 key.
+   *
+   * @param f the function converting the value to the target object
+   * @tparam B the type of the target object
+   * @return a `ConfigReader` for an object of type `B` that is created from the value in the
+   *         provided key using `f`.
+   */
   // Special case because f can't be curried.
   final def forProduct1[B, A0](keyA0: String)(f: A0 => B)(implicit
     readerA0: ConfigReader[A0]
@@ -26,8 +34,16 @@ trait ProductReaders {
         a1Result
       }
   }
-
-  [2..22#final def forProduct1[B, [#A0#]]([#keyA0: String#])(f: ([#A0#]) => B)(implicit
+  [2..22#
+  /**
+   * Builds a `ConfigReader` for an object created from the values of 1 keys.
+   *
+   * @param f the function converting the tuple of values to the target object
+   * @tparam B the type of the target object
+   * @return a `ConfigReader` for an object of type `B` that is created from the values in the
+   *         provided keys using `f`.
+   */
+  final def forProduct1[B, [#A0#]]([#keyA0: String#])(f: ([#A0#]) => B)(implicit
     [#readerA0: ConfigReader[A0]#]
   ): ConfigReader[B] = new ConfigReader[B] {
     def from(cur: ConfigCursor): Either[ConfigReaderFailures, B] =

--- a/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
+++ b/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
@@ -18,7 +18,7 @@ trait ProductReaders {
   /**
    * Builds a `ConfigReader` for an object created from the value of 1 key.
    *
-   * @param f the function converting the value to the target object
+   * @param f the function converting the read value to the target object
    * @tparam B the type of the target object
    * @return a `ConfigReader` for an object of type `B` that is created from the value in the
    *         provided key using `f`.
@@ -38,7 +38,7 @@ trait ProductReaders {
   [2..22#/**
    * Builds a `ConfigReader` for an object created from the values of 1 keys.
    *
-   * @param f the function converting the tuple of values to the target object
+   * @param f the function converting the read values to the target object
    * @tparam B the type of the target object
    * @return a `ConfigReader` for an object of type `B` that is created from the values in the
    *         provided keys using `f`.

--- a/core/src/main/boilerplate/pureconfig/ProductWriters.scala.template
+++ b/core/src/main/boilerplate/pureconfig/ProductWriters.scala.template
@@ -36,8 +36,8 @@ trait ProductWriters {
       a1Conf.root()
     }
   }
-  [2..22#
-  /**
+
+  [2..22#/**
    * Builds a `ConfigWriter` for an object written as 1 keys.
    *
    * @param f the function converting the source object to a tuple of values

--- a/core/src/main/boilerplate/pureconfig/ProductWriters.scala.template
+++ b/core/src/main/boilerplate/pureconfig/ProductWriters.scala.template
@@ -17,6 +17,14 @@ trait ProductWriters {
       case _ => previousResult.withValue(key, writer.to(value))
     }
 
+  /**
+   * Builds a `ConfigWriter` for an object written as 1 key.
+   *
+   * @param f the function converting the source object to a value
+   * @tparam B the type of the source object
+   * @return a `ConfigWriter` for an object of type `B` that is written as the value
+   *         generated using `f`.
+   */
   // Special case because we don't want f to be B => Product1[A0].
   final def forProduct1[B, A0](keyA0: String)(f: B => A0)(implicit
     writerA0: ConfigWriter[A0]
@@ -28,8 +36,16 @@ trait ProductWriters {
       a1Conf.root()
     }
   }
-
-  [2..22#final def forProduct1[B, [#A0#]]([#keyA0: String#])(f: B => Product1[[#A0#]])(implicit
+  [2..22#
+  /**
+   * Builds a `ConfigWriter` for an object written as 1 keys.
+   *
+   * @param f the function converting the source object to a tuple of values
+   * @tparam B the type of the source object
+   * @return a `ConfigWriter` for an object of type `B` that is written as the values
+   *         generated using `f`.
+   */
+  final def forProduct1[B, [#A0#]]([#keyA0: String#])(f: B => Product1[[#A0#]])(implicit
     [#writerA0: ConfigWriter[A0]#]
   ): ConfigWriter[B] = new ConfigWriter[B] {
     def to(a: B): ConfigValue = {


### PR DESCRIPTION
Adds Scaladoc for the new methods so that basic documentation is available for them. Even though it was possible to generate the `@param` entries for the `keyN` parameters, I opted not to do that since I think that it would actually make the Scaladoc pages less readable.
