### PR TITLE
Perform an implicit search in the `Derivation` materialization instead of relying on `implicitly`

### DIFF
--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -37,7 +37,7 @@ trait ConfigConvert[A] extends ConfigReader[A] with ConfigWriter[A] { outer =>
  */
 object ConfigConvert extends ConvertHelpers {
 
-  def apply[T](implicit conv: ConfigConvert[T]): ConfigConvert[T] = conv
+  def apply[T](implicit conv: Derivation[ConfigConvert[T]]): ConfigConvert[T] = conv.value
 
   implicit def fromReaderAndWriter[T](
     implicit

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -120,7 +120,7 @@ trait ConfigReader[A] {
  */
 object ConfigReader extends BasicReaders with CollectionReaders with ProductReaders with ExportedReaders {
 
-  def apply[A](implicit reader: ConfigReader[A]): ConfigReader[A] = reader
+  def apply[A](implicit reader: Derivation[ConfigReader[A]]): ConfigReader[A] = reader.value
 
   /**
    * Creates a `ConfigReader` from a function reading a `ConfigCursor`.

--- a/core/src/main/scala/pureconfig/ConfigWriter.scala
+++ b/core/src/main/scala/pureconfig/ConfigWriter.scala
@@ -43,7 +43,7 @@ trait ConfigWriter[A] {
  */
 object ConfigWriter extends BasicWriters with CollectionWriters with ProductWriters with ExportedWriters {
 
-  def apply[A](implicit writer: ConfigWriter[A]): ConfigWriter[A] = writer
+  def apply[A](implicit writer: Derivation[ConfigWriter[A]]): ConfigWriter[A] = writer.value
 
   /**
    * Creates a `ConfigWriter` from a function.

--- a/core/src/main/scala/pureconfig/syntax/package.scala
+++ b/core/src/main/scala/pureconfig/syntax/package.scala
@@ -6,8 +6,8 @@ import pureconfig.error.{ ConfigReaderException, ConfigReaderFailures }
 import scala.reflect.ClassTag
 
 package object syntax {
-  implicit class PimpedAny[T](val any: T) extends AnyVal {
-    def toConfig(implicit writer: ConfigWriter[T]): ConfigValue = writer.to(any)
+  implicit class RichAny[T](val any: T) extends AnyVal {
+    def toConfig(implicit writer: Derivation[ConfigWriter[T]]): ConfigValue = writer.value.to(any)
   }
 
   private def getResultOrThrow[Config](failuresOrResult: Either[ConfigReaderFailures, Config])(implicit ct: ClassTag[Config]): Config = {
@@ -17,17 +17,17 @@ package object syntax {
     }
   }
 
-  implicit class PimpedConfigValue(val conf: ConfigValue) extends AnyVal {
+  implicit class RichConfigValue(val conf: ConfigValue) extends AnyVal {
     def to[T](implicit reader: Derivation[ConfigReader[T]]): Either[ConfigReaderFailures, T] = reader.value.from(conf)
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(reader.value.from(conf))(cl)
   }
 
-  implicit class PimpedConfigCursor(val cur: ConfigCursor) extends AnyVal {
+  implicit class RichConfigCursor(val cur: ConfigCursor) extends AnyVal {
     def to[T](implicit reader: Derivation[ConfigReader[T]]): Either[ConfigReaderFailures, T] = reader.value.from(cur)
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(reader.value.from(cur))(cl)
   }
 
-  implicit class PimpedConfig(val conf: TypesafeConfig) extends AnyVal {
+  implicit class RichConfig(val conf: TypesafeConfig) extends AnyVal {
     def to[T](implicit reader: Derivation[ConfigReader[T]]): Either[ConfigReaderFailures, T] = conf.root().to[T]
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(conf.root().to[T])(cl)
   }

--- a/core/src/main/scala/pureconfig/syntax/package.scala
+++ b/core/src/main/scala/pureconfig/syntax/package.scala
@@ -6,7 +6,7 @@ import pureconfig.error.{ ConfigReaderException, ConfigReaderFailures }
 import scala.reflect.ClassTag
 
 package object syntax {
-  implicit class RichAny[T](val any: T) extends AnyVal {
+  implicit class AnyWriterOps[T](val any: T) extends AnyVal {
     def toConfig(implicit writer: Derivation[ConfigWriter[T]]): ConfigValue = writer.value.to(any)
   }
 
@@ -17,17 +17,17 @@ package object syntax {
     }
   }
 
-  implicit class RichConfigValue(val conf: ConfigValue) extends AnyVal {
+  implicit class ConfigValueReaderOps(val conf: ConfigValue) extends AnyVal {
     def to[T](implicit reader: Derivation[ConfigReader[T]]): Either[ConfigReaderFailures, T] = reader.value.from(conf)
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(reader.value.from(conf))(cl)
   }
 
-  implicit class RichConfigCursor(val cur: ConfigCursor) extends AnyVal {
+  implicit class ConfigCursorReaderOps(val cur: ConfigCursor) extends AnyVal {
     def to[T](implicit reader: Derivation[ConfigReader[T]]): Either[ConfigReaderFailures, T] = reader.value.from(cur)
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(reader.value.from(cur))(cl)
   }
 
-  implicit class RichConfig(val conf: TypesafeConfig) extends AnyVal {
+  implicit class ConfigReaderOps(val conf: TypesafeConfig) extends AnyVal {
     def to[T](implicit reader: Derivation[ConfigReader[T]]): Either[ConfigReaderFailures, T] = conf.root().to[T]
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(conf.root().to[T])(cl)
   }

--- a/macros/src/main/scala/pureconfig/Derivation.scala
+++ b/macros/src/main/scala/pureconfig/Derivation.scala
@@ -52,7 +52,7 @@ class DerivationMacros(val c: whitebox.Context) extends LazyContextParser with M
     // messages
     val isMaterializationExplicitCall = {
       val firstMacroCall = c.enclosingMacros.reverse.find(ctx => ctx.prefix.tree.tpe =:= ctx.typeOf[Derivation.type])
-      firstMacroCall.fold(false)(_.openImplicits.isEmpty)
+      firstMacroCall.exists(_.openImplicits.isEmpty)
     }
 
     // Determine what to do if an implicit search fails. If we're in the context of an implicit search, we want to set

--- a/macros/src/main/scala/pureconfig/Derivation.scala
+++ b/macros/src/main/scala/pureconfig/Derivation.scala
@@ -51,8 +51,8 @@ class DerivationMacros(val c: whitebox.Context) extends LazyContextParser with M
     // check if the materialization was called explicitly, in which case we want to have the nicer compiler error
     // messages
     val isMaterializationExplicitCall = {
-      val firstMacroCall = c.enclosingMacros.reverse.find(c => c.prefix.tree.tpe =:= c.typeOf[Derivation.type])
-      firstMacroCall.fold(false)(c => !c.openImplicits.exists(_.pre =:= c.typeOf[Derivation.type]))
+      val firstMacroCall = c.enclosingMacros.reverse.find(ctx => ctx.prefix.tree.tpe =:= ctx.typeOf[Derivation.type])
+      firstMacroCall.fold(false)(_.openImplicits.isEmpty)
     }
 
     // check the `-Xmacro-settings:materialize-derivations` scalac flag and make sure we're not in an explicit

--- a/macros/src/main/scala/pureconfig/Derivation.scala
+++ b/macros/src/main/scala/pureconfig/Derivation.scala
@@ -53,7 +53,7 @@ class DerivationMacros(val c: whitebox.Context) extends LazyContextParser with M
       // when not present, start an implicit search for `A` and place it inside a `Derivation.Successful` if the search
       // succeeds.
       val tpe = weakTypeOf[A]
-      c.inferImplicitValue(tpe) match {
+      inferImplicitValueCompat(tpe) match {
         case EmptyTree =>
           c.abort(c.enclosingPosition, s"could not derive ${prettyPrintType(tpe)}")
         case t =>

--- a/macros/src/main/scala/pureconfig/Derivation.scala
+++ b/macros/src/main/scala/pureconfig/Derivation.scala
@@ -52,11 +52,12 @@ class DerivationMacros(val c: whitebox.Context) extends LazyContextParser with M
     if (!isDerivationEnabled || !isHeadImplicitADerivation) {
       // when not present, start an implicit search for `A` and place it inside a `Derivation.Successful` if the search
       // succeeds.
-      c.inferImplicitValue(weakTypeOf[A]) match {
+      val tpe = weakTypeOf[A]
+      c.inferImplicitValue(tpe) match {
         case EmptyTree =>
-          c.abort(c.enclosingPosition, s"could not derive ${prettyPrintType(weakTypeOf[A])}")
+          c.abort(c.enclosingPosition, s"could not derive ${prettyPrintType(tpe)}")
         case t =>
-          q"_root_.pureconfig.Derivation.Successful($t)"
+          q"_root_.pureconfig.Derivation.Successful[${tpe}]($t)"
       }
 
     } else {

--- a/macros/src/main/scala/pureconfig/Derivation.scala
+++ b/macros/src/main/scala/pureconfig/Derivation.scala
@@ -46,7 +46,7 @@ class DerivationMacros(val c: whitebox.Context) extends LazyContextParser with M
 
     // check if the first implicit in the chain is a `Derivation` (if it isn't, not only we can't show custom messages
     // but we may be unable to parse `Lazy` trees)
-    val isHeadImplicitADerivation = c.openImplicits.headOption.exists(_.pre =:= typeOf[Derivation.type])
+    lazy val isHeadImplicitADerivation = c.openImplicits.lastOption.exists(_.pre =:= typeOf[Derivation.type])
 
     // check if the materialization was called explicitly, in which case we want to have the nicer compiler error
     // messages
@@ -80,10 +80,7 @@ class DerivationMacros(val c: whitebox.Context) extends LazyContextParser with M
 
     } else {
       // if `isRootDerivation` is `false`, then this is a `Derivation` triggered inside another `Derivation`
-      val isRootDerivation = if (isMaterializationExplicitCall)
-        c.enclosingMacros.count(c => c.prefix.tree.tpe =:= c.typeOf[Derivation.type]) == 1
-      else
-        c.openImplicits.count(_.pre =:= typeOf[Derivation.type]) == 1
+      val isRootDerivation = c.enclosingMacros.count(c => c.prefix.tree.tpe =:= c.typeOf[Derivation.type]) == 1
 
       if (isRootDerivation) materializeRootDerivation(weakTypeOf[A], onFailedImplicitSearch)
       else materializeInnerDerivation(weakTypeOf[A])

--- a/macros/src/main/scala/pureconfig/derivation/MacroCompat.scala
+++ b/macros/src/main/scala/pureconfig/derivation/MacroCompat.scala
@@ -27,7 +27,9 @@ trait MacroCompat {
   def inferImplicitValueCompat(typ: Type): Tree = {
     val cc = c.asInstanceOf[scala.reflect.macros.contexts.Context]
     val enclosingTree =
-      cc.openImplicits.headOption.map(_.tree).getOrElse(EmptyTree).asInstanceOf[cc.universe.analyzer.global.Tree]
+      cc.openImplicits.headOption.map(_.tree)
+        .orElse(cc.enclosingMacros.lastOption.map(_.macroApplication))
+        .getOrElse(EmptyTree).asInstanceOf[cc.universe.analyzer.global.Tree]
 
     val res: cc.Tree = cc.universe.analyzer.inferImplicit(
       enclosingTree, typ.asInstanceOf[cc.Type], false, cc.callsiteTyper.context, true, false, cc.enclosingPosition,

--- a/macros/src/main/scala/pureconfig/derivation/MacroCompat.scala
+++ b/macros/src/main/scala/pureconfig/derivation/MacroCompat.scala
@@ -26,7 +26,8 @@ trait MacroCompat {
   // reported up to Scala 2.12.2. See https://github.com/scala/bug/issues/10398 for more information.
   def inferImplicitValueCompat(typ: Type): Tree = {
     val cc = c.asInstanceOf[scala.reflect.macros.contexts.Context]
-    val enclosingTree = cc.openImplicits.head.tree.asInstanceOf[cc.universe.analyzer.global.Tree]
+    val enclosingTree =
+      cc.openImplicits.headOption.map(_.tree).getOrElse(EmptyTree).asInstanceOf[cc.universe.analyzer.global.Tree]
 
     val res: cc.Tree = cc.universe.analyzer.inferImplicit(
       enclosingTree, typ.asInstanceOf[cc.Type], false, cc.callsiteTyper.context, true, false, cc.enclosingPosition,

--- a/modules/cats/src/main/scala/pureconfig/module/cats/instances/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/cats/instances/package.scala
@@ -10,7 +10,7 @@ package object instances {
   implicit val configReaderInstance: ApplicativeError[ConfigReader, ConfigReaderFailures] =
     new ApplicativeError[ConfigReader, ConfigReaderFailures] {
       def pure[A](x: A): ConfigReader[A] =
-        ConfigReader(ConfigReader.fromFunction { _ => Right(x) })
+        ConfigReader.fromFunction { _ => Right(x) }
 
       def ap[A, B](ff: ConfigReader[A => B])(fa: ConfigReader[A]): ConfigReader[B] =
         ff.zip(fa).map { case (f, a) => f(a) }

--- a/modules/yaml/README.md
+++ b/modules/yaml/README.md
@@ -45,5 +45,5 @@ We can load the configuration to a `MyConf` instance using `loadYaml`:
 
 ```scala
 loadYaml[Person](yamlFile)
-// res1: Either[pureconfig.error.ConfigReaderFailures,Person] = Left(ConfigReaderFailures(ConvertFailure(WrongType(LIST,Set(OBJECT)),None,children),List()))
+// res1: Either[pureconfig.error.ConfigReaderFailures,Person] = Right(Person(John,42,List(Person(Sarah,7,List()), Person(Andy,10,List()))))
 ```

--- a/tests/src/test/scala/pureconfig/DerivationSuite.scala
+++ b/tests/src/test/scala/pureconfig/DerivationSuite.scala
@@ -122,7 +122,11 @@ class DerivationSuite extends BaseSuite {
 
     illTyped(
       "Derivation.materializeDerivation[ConfigReader[Conf]]",
-      "could not derive a ConfigReader instance for type Conf")
+      "could not derive a ConfigReader instance for type Conf, because:",
+      "  - missing a ConfigReader instance for type ConfC, because:",
+      "    - missing a ConfigReader instance for type Option\\[Custom\\], because:",
+      "      - missing a ConfigReader instance for type Custom",
+      "    - missing a ConfigReader instance for type Custom2")
   }
 
   it should "fallback to a regular implicit search if it's not at the root of that search" in {

--- a/tests/src/test/scala/pureconfig/DerivationSuite.scala
+++ b/tests/src/test/scala/pureconfig/DerivationSuite.scala
@@ -119,18 +119,10 @@ class DerivationSuite extends BaseSuite {
       "could not derive a ConfigConvert instance for type Option\\[Custom\\], because:",
       "  - missing a ConfigWriter instance for type Option\\[Custom\\], because:",
       "    - missing a ConfigWriter instance for type Custom")
-  }
 
-  it should "fallback to a regular implicit search if it's being materialized explicitly" in {
     illTyped(
       "Derivation.materializeDerivation[ConfigReader[Conf]]",
-      "could not find implicit value for parameter e: pureconfig.ConfigReader\\[DerivationSuite.this.Conf\\]")
-
-    {
-      implicit val cr = customReader
-      implicit val cr2 = customReader2
-      Derivation.materializeDerivation[ConfigReader[Conf]]
-    }
+      "could not derive a ConfigReader instance for type Conf")
   }
 
   it should "fallback to a regular implicit search if it's not at the root of that search" in {


### PR DESCRIPTION
This PR changes the materialization of `Derivation` instances to perform an implicit search instead of relying on `implicitly`. Additionally, this makes use of `Derivation` in the `apply` methods of `ConfigReader`, `ConfigWriter` and `ConfigConvert`.

This solves a very weird bug that made reader and writer instances for `Option` derived as coproduct readers and writers when there was a `Derivation` at the top level of the implicit search and we were using full automatic derivation. For example:

```scala
import pureconfig.generic.auto._
import pureconfig.ConfigConvert

object Main extends App {
  case class Foo(bar: Option[Map[String, Int]])
  val foo = Foo(Some(Map("a" -> 2)))

  val writer1 = implicitly[ConfigConvert[Foo]]
  val writer2 = ConfigConvert[Foo]

  println(writer1.to(foo))
  // SimpleConfigObject({"bar":{"type":"some","value":{"a":2}}})
  println(writer2.to(foo))
  // SimpleConfigObject({"bar":{"a":2}})
}
```

Unfortunately, I can't replicate this issue in the context of a spec and can't understand why this change fixes the bug. 😞 

Incidentally, this changes the error message when an implicit is not found and we're using `Derivation.materializeDerivation` explicitly.