### PR TITLE
Fix home page title

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,8 @@ jobs:
         - gem install sass jekyll:3.2.1 html-proofer
       script:
         - sbt makeMicrosite
-          # we're ignoring www.47deg.com due to SSL errors; we should check this again later
         - htmlproofer \
             --allow_hash_href \
-            --url-ignore '/www.47deg.com/' \
             --url-swap "https\://github\.com/pureconfig/pureconfig/tree/master:file\://$(pwd)" \
             docs/target/site
       after_success: ignore

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -1,9 +1,8 @@
 ---
 layout: home
-title: PureConfig
 ---
 
-# {{page.title}}
+# PureConfig
 
 <img src="img/pureconfig-logo-1040x1200.png" width="130px" height="150px" align="right" alt="PureConfig">
 


### PR DESCRIPTION
Due to recent sbt-microsite updates, our [home page](https://pureconfig.github.io/) has the browser title "PureConfig: PureConfig". This PR fixes that.