### PR TITLE
Add `forProductN` helpers to the docs

### DIFF
--- a/docs/src/main/tut/docs/complex-types.md
+++ b/docs/src/main/tut/docs/complex-types.md
@@ -98,19 +98,12 @@ Similarly to adding support for simple types, it is possible to manually create 
 import pureconfig._
 import pureconfig.error._
 
-def extractId(objCur: ConfigObjectCursor): Either[ConfigReaderFailures, String] =
-  objCur.atKey("id").flatMap(_.asString)
-
-def extractValue(objCur: ConfigObjectCursor): Either[ConfigReaderFailures, Int] =
-  objCur.atKey("value").flatMap(ConfigReader[Int].from(_))
+val class1Reader = ConfigReader.forProduct1("id")(new Class1(_))
+val class2Reader = ConfigReader.forProduct2("id", "value")(new Class2(_, _))
 
 def extractByType(typ: String, objCur: ConfigObjectCursor): Either[ConfigReaderFailures, Identifiable] = typ match {
-  case "class1" => extractId(objCur).map(new Class1(_))
-  case "class2" =>
-    for {
-      id <- extractId(objCur)
-      value <- extractValue(objCur)
-    } yield new Class2(id, value)
+  case "class1" => class1Reader.from(objCur)
+  case "class2" => class2Reader.from(objCur)
   case t =>
     objCur.failed(CannotConvert(objCur.value.toString, "Identifiable",
       s"type has value $t instead of class1 or class2"))

--- a/docs/src/main/tut/docs/non-automatic-derivation.md
+++ b/docs/src/main/tut/docs/non-automatic-derivation.md
@@ -76,7 +76,8 @@ pureconfig.loadConfig[Person](conf)
 ### Manual
 
 When case class and sealed trait derivation is not needed or wanted, we can simply not import anything and define our
-reader using any of ways explained in [Supporting New Types](supporting-new-types.html):
+reader using any of ways explained in [Supporting New Types](supporting-new-types.html). The `forProductN` helper
+methods are also convenient for creating readers and writers for case class-like types without generic derivation:
 
 ```tut:invisible:reset
 import com.typesafe.config.ConfigFactory
@@ -89,13 +90,7 @@ val conf = ConfigFactory.parseString("{ name: John, surname: Doe }")
 ```tut:silent
 import pureconfig._
 
-implicit val personReader = ConfigReader.fromCursor[Person] { cur =>
-  for {
-    objCur <- cur.asObjectCursor
-    name <- objCur.atKey("name").right.flatMap(_.asString)
-    surname <- objCur.atKey("surname").right.flatMap(_.asString)
-  } yield Person(name, surname)
-}
+implicit val personReader = ConfigReader.forProduct2("name", "surname")((name, surname) => Person(name, surname))
 ```
 
 ```tut:book

--- a/docs/src/main/tut/docs/non-automatic-derivation.md
+++ b/docs/src/main/tut/docs/non-automatic-derivation.md
@@ -90,7 +90,7 @@ val conf = ConfigFactory.parseString("{ name: John, surname: Doe }")
 ```tut:silent
 import pureconfig._
 
-implicit val personReader = ConfigReader.forProduct2("name", "surname")((name, surname) => Person(name, surname))
+implicit val personReader = ConfigReader.forProduct2("name", "surname")(Person(_, _))
 ```
 
 ```tut:book

--- a/docs/src/main/tut/docs/non-automatic-derivation.md
+++ b/docs/src/main/tut/docs/non-automatic-derivation.md
@@ -77,7 +77,7 @@ pureconfig.loadConfig[Person](conf)
 
 When case class and sealed trait derivation is not needed or wanted, we can simply not import anything and define our
 reader using any of ways explained in [Supporting New Types](supporting-new-types.html). The `forProductN` helper
-methods are also convenient for creating readers and writers for case class-like types without generic derivation:
+methods are convenient for creating readers and writers for case class-like types without generic derivation:
 
 ```tut:invisible:reset
 import com.typesafe.config.ConfigFactory


### PR DESCRIPTION
This PR adds references to the `forProductN` helpers in the docs. I used them to simplify the implementation of method 2 in the page about supporting complex types. I also mentioned them in the _Manual_ section of the _Non-Automatic Derivation_ page, as a convenient way to create readers and writers for case class-like types.