### PR TITLE
Move `scala-compiler` and `scala-reflect` dependencies to the `provided` scope

### DIFF
--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -3,8 +3,8 @@ import Dependencies._
 name := "pureconfig-macros"
 
 libraryDependencies ++= Seq(
-  "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  "org.scala-lang" % "scala-reflect" % scalaVersion.value)
+  "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided)
 
 developers := List(
   Developer("ruippeixotog", "Rui Gonçalves", "ruippeixotog@gmail.com", url("https://github.com/ruippeixotog")))

--- a/modules/generic/build.sbt
+++ b/modules/generic/build.sbt
@@ -3,6 +3,7 @@ import Dependencies._
 name := "pureconfig-generic"
 
 libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
   shapeless)
 
 osgiSettings


### PR DESCRIPTION
This PR moves the `scala-compiler` and `scala-reflect` dependencies to the `provided` scope, which should fix #433.