### PR TITLE
simplify implementation of fs2 module

### DIFF
--- a/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
+++ b/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
@@ -23,6 +23,10 @@ object ConfigFactoryWrapper {
   def load(): Either[ConfigReaderFailures, Config] =
     unsafeToEither(ConfigFactory.load())
 
+  /** @see `com.typesafe.config.ConfigFactory.parseString()` */
+  def parseString(s: String): Either[ConfigReaderFailures, Config] =
+    unsafeToEither(ConfigFactory.parseString(s))
+
   /** @see `com.typesafe.config.ConfigFactory.parseFile()` */
   def parseFile(path: Path): Either[ConfigReaderFailures, Config] =
     unsafeToEither(ConfigFactory.parseFile(path.toFile, strictSettings), Some(path))

--- a/modules/fs2/README.md
+++ b/modules/fs2/README.md
@@ -38,7 +38,7 @@ val blockingEc: ExecutionContext = ExecutionContext.fromExecutorService(Executor
 
 val configStream = file.readAll[IO](somePath, blockingEc, chunkSize)
 
-val load: IO[MyConfig] = streamConfig[IO, MyConfig](configStream, blockingEc)
+val load: IO[MyConfig] = streamConfig[IO, MyConfig](configStream)
 ```
 
 To test that this `IO` does indeed return a `MyConfig` instance:

--- a/modules/fs2/src/main/scala/pureconfig/module/fs2/package.scala
+++ b/modules/fs2/src/main/scala/pureconfig/module/fs2/package.scala
@@ -20,8 +20,8 @@ package object fs2 {
    * @return The returned action will complete with `A` if it is possible to create an instance of type
    *         `A` from the configuration stream, or fail with a ConfigReaderException which in turn contains
    *         details on why it isn't possible
-    *         It can also raise any exception that the stream can raise, as well as any exception that
-    *         ConfigFactory.parseString might throw. 
+   *         It can also raise any exception that the stream can raise, as well as any exception that
+   *         ConfigFactory.parseString might throw.
    */
   def streamConfig[F[_], A](configStream: Stream[F, Byte])(
     implicit

--- a/modules/fs2/src/main/scala/pureconfig/module/fs2/package.scala
+++ b/modules/fs2/src/main/scala/pureconfig/module/fs2/package.scala
@@ -21,8 +21,7 @@ package object fs2 {
    * @return The returned action will complete with `A` if it is possible to create an instance of type
    *         `A` from the configuration stream, or fail with a ConfigReaderException which in turn contains
    *         details on why it isn't possible
-   *         It can also raise any exception that the stream can raise, as well as any exception that
-   *         ConfigFactory.parseString might throw.
+   *         It can also raise any exception that the stream can raise.
    */
   def streamConfig[F[_], A](configStream: Stream[F, Byte])(
     implicit

--- a/modules/fs2/src/main/scala/pureconfig/module/fs2/package.scala
+++ b/modules/fs2/src/main/scala/pureconfig/module/fs2/package.scala
@@ -30,12 +30,9 @@ package object fs2 {
       bytes <- configStream.compile.to[Array]
       string = new String(bytes, UTF_8)
       configOrError <- F.delay(ConfigFactoryWrapper.parseString(string))
-      a <- F.fromEither {
-        (for {
-          config <- configOrError
-          a <- pureconfig.loadConfig[A](config)
-        } yield a).leftMap(ConfigReaderException[A])
-      }
+      config <- F.fromEither(configOrError.leftMap(ConfigReaderException[A]))
+      aOrError <- F.delay(pureconfig.loadConfig[A](config))
+      a <- F.fromEither(aOrError.leftMap(ConfigReaderException[A]))
     } yield a
   }
 

--- a/modules/fs2/src/main/scala/pureconfig/module/fs2/package.scala
+++ b/modules/fs2/src/main/scala/pureconfig/module/fs2/package.scala
@@ -1,34 +1,17 @@
 package pureconfig.module
 
-import java.io._
+import java.nio.charset.StandardCharsets.UTF_8
 
-import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
 import scala.reflect.ClassTag
-
-import _root_.fs2.{ Stream, io, text }
-import cats.effect.{ Concurrent, Sync, ContextShift }
+import _root_.fs2.{ Stream, text }
+import cats.effect.Sync
 import cats.implicits._
 import com.typesafe.config.{ ConfigFactory, ConfigRenderOptions }
 import pureconfig.{ ConfigReader, ConfigWriter, Derivation }
 import pureconfig.error.ConfigReaderException
 
 package object fs2 {
-
-  private def parseStream[F[_], A](inputStream: InputStream)(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] = {
-    val streamReader = new InputStreamReader(inputStream)
-    val config = F.delay { ConfigFactory.parseReader(streamReader) }
-    config.flatMap { c =>
-      val loadedConfig = pureconfig.loadConfig(c).leftMap(ConfigReaderException[A])
-      F.fromEither(loadedConfig)
-    }
-  }
-
-  private def pipedStreams[F[_]](implicit F: Sync[F]): F[(InputStream, OutputStream)] = F.delay {
-    val output = new PipedOutputStream()
-    val input = new PipedInputStream(output)
-    (input, output)
-  }
 
   /**
    * Load a configuration of type `A` from the given byte stream.
@@ -37,19 +20,18 @@ package object fs2 {
    * @return The returned action will complete with `A` if it is possible to create an instance of type
    *         `A` from the configuration stream, or fail with a ConfigReaderException which in turn contains
    *         details on why it isn't possible
+    *         It can also raise any exception that the stream can raise, as well as any exception that
+    *         ConfigFactory.parseString might throw. 
    */
-  def streamConfig[F[_], A](configStream: Stream[F, Byte], blockingExecutionContext: ExecutionContext)(
+  def streamConfig[F[_], A](configStream: Stream[F, Byte])(
     implicit
-    F: Concurrent[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A], CS: ContextShift[F]): F[A] = {
-    pipedStreams.flatMap {
-      case (in, out) =>
-        val outputSink = io.writeOutputStream[F](out.pure[F], blockingExecutionContext)
-        val sunkStream = configStream.to(outputSink)
-
-        val parseConfig = parseStream(in)
-
-        Concurrent[F].start(sunkStream.compile.drain) >> parseConfig
-    }
+    F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] = {
+    for {
+      bytes <- configStream.compile.to[Array]
+      string = new String(bytes, UTF_8)
+      config <- F.delay(ConfigFactory.parseString(string))
+      a <- F.fromEither(pureconfig.loadConfig[A](config).leftMap(ConfigReaderException[A]))
+    } yield a
   }
 
   /**

--- a/modules/fs2/src/main/tut/README.md
+++ b/modules/fs2/src/main/tut/README.md
@@ -44,7 +44,7 @@ val blockingEc: ExecutionContext = ExecutionContext.fromExecutorService(Executor
 
 val configStream = file.readAll[IO](somePath, blockingEc, chunkSize)
 
-val load: IO[MyConfig] = streamConfig[IO, MyConfig](configStream, blockingEc)
+val load: IO[MyConfig] = streamConfig[IO, MyConfig](configStream)
 ```
 
 To test that this `IO` does indeed return a `MyConfig` instance:

--- a/modules/fs2/src/test/scala/pureconfig/module/fs2Suite.scala
+++ b/modules/fs2/src/test/scala/pureconfig/module/fs2Suite.scala
@@ -14,8 +14,6 @@ import scala.concurrent.ExecutionContext
 
 class fs2Suite extends FlatSpec with Matchers {
 
-  val blockingEc = ExecutionContext.global
-
   implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 

--- a/modules/fs2/src/test/scala/pureconfig/module/fs2Suite.scala
+++ b/modules/fs2/src/test/scala/pureconfig/module/fs2Suite.scala
@@ -31,7 +31,7 @@ class fs2Suite extends FlatSpec with Matchers {
     val someConfig = "somefield=1234\nanotherfield=some string"
     val configBytes = Stream.emit(someConfig).through(text.utf8Encode)
 
-    val myConfig = testee.streamConfig[IO, SomeCaseClass](configBytes, blockingEc)
+    val myConfig = testee.streamConfig[IO, SomeCaseClass](configBytes)
 
     myConfig.unsafeRunSync() shouldBe SomeCaseClass(1234, "some string")
   }
@@ -39,7 +39,7 @@ class fs2Suite extends FlatSpec with Matchers {
   it should "error when stream is blank" in {
     val blankStream = Stream.empty.covaryAll[IO, Byte]
 
-    val configLoad = testee.streamConfig[IO, SomeCaseClass](blankStream, blockingEc)
+    val configLoad = testee.streamConfig[IO, SomeCaseClass](blankStream)
 
     configLoad.attempt.unsafeRunSync().left.value shouldBe a[ConfigReaderException[_]]
 
@@ -51,7 +51,7 @@ class fs2Suite extends FlatSpec with Matchers {
     val configStream = Stream.emit(someConfig)
     val configBytes = delayEachLine(configStream, 200.milliseconds).through(text.utf8Encode)
 
-    val myConfig = testee.streamConfig[IO, SomeCaseClass](configBytes, blockingEc)
+    val myConfig = testee.streamConfig[IO, SomeCaseClass](configBytes)
 
     myConfig.unsafeRunSync() shouldBe SomeCaseClass(1234, "some string")
   }

--- a/modules/fs2/src/test/scala/pureconfig/module/fs2Suite.scala
+++ b/modules/fs2/src/test/scala/pureconfig/module/fs2Suite.scala
@@ -1,6 +1,6 @@
 package pureconfig.module
 
-import cats.effect.{ IO, Timer, ContextShift }
+import cats.effect.{ IO, Timer }
 import _root_.fs2.{ Stream, text }
 import pureconfig.generic.auto._
 import pureconfig.module.{ fs2 => testee }
@@ -15,7 +15,6 @@ import scala.concurrent.ExecutionContext
 class fs2Suite extends FlatSpec with Matchers {
 
   implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
-  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   private def delayEachLine(stream: Stream[IO, String], delay: FiniteDuration) = {
     val byLine = stream.through(text.lines)


### PR DESCRIPTION
The fs2 module looks pointlessly complicated to me. When you read a `Config` from a stream, it's going to require memory proportional to the size of the input anyway to store the `Config` object, hence there's no point in parsing it in a streaming fashion. So I wrote this implementation which is much simpler, places fewer constraints on the `F[_]` type parameter (can be used with e. g. SyncIO), doesn't require an `ExecutionContext` and doesn't mess around with threads. 