### PR TITLE
Use specific `html-proofer` version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       script:
         - sbt makeMicrosite
         - htmlproofer \
-            --allow_hash_href \
+            --allow-hash-href \
             --url-swap "https\://github\.com/pureconfig/pureconfig/tree/master:file\://$(pwd)" \
             docs/target/site
       after_success: ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ jobs:
         - gem install sass jekyll:3.2.1 html-proofer:3.9.3
       script:
         - sbt makeMicrosite
-        - htmlproofer \
-            --allow-hash-href \
-            --url-swap "https\://github\.com/pureconfig/pureconfig/tree/master:file\://$(pwd)" \
+        - htmlproofer
+            --allow-hash-href
+            --url-swap "https\://github\.com/pureconfig/pureconfig/tree/master:file\://$(pwd)"
             docs/target/site
       after_success: ignore
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       install:
         - rvm use 2.4 --install --fuzzy
         - gem update --system
-        - gem install sass jekyll:3.2.1 html-proofer
+        - gem install sass jekyll:3.2.1 html-proofer:3.9.3
       script:
         - sbt makeMicrosite
         - htmlproofer \


### PR DESCRIPTION
This PR modifies the Travis pipeline to install a specific `html-proofer` version. The `--allow_hash_href` flag changed to `--allow-hash-href` in the latest version.