### PR TITLE
 Create a ReaderResult[A] alias for Either[ConfigReaderFailures, A]

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ Finally, load the configuration:
 
 ```scala
 pureconfig.loadConfig[MyClass]
-// res0: pureconfig.ReaderResult[MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
+// res0: pureconfig.ConfigReader.Result[MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
 ```
 
-`ReaderResult[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
+`ConfigReader.Result[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
 would handle an `Either` value.
 
 The various `loadConfig` methods defer to Typesafe Config's

--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ Finally, load the configuration:
 
 ```scala
 pureconfig.loadConfig[MyClass]
-// res0: Either[pureconfig.error.ConfigReaderFailures,MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
+// res0: pureconfig.ReaderResult[MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
 ```
+
+`ReaderResult[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
+would handle an `Either` value.
 
 The various `loadConfig` methods defer to Typesafe Config's
 [`ConfigFactory`](https://lightbend.github.io/config/latest/api/com/typesafe/config/ConfigFactory.html) to

--- a/bundle/src/main/tut/README.md
+++ b/bundle/src/main/tut/README.md
@@ -71,10 +71,10 @@ Finally, load the configuration:
 
 ```scala
 pureconfig.loadConfig[MyClass]
-// res0: pureconfig.ReaderResult[MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
+// res0: pureconfig.ConfigReader.Result[MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
 ```
 
-`ReaderResult[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
+`ConfigReader.Result[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
 would handle an `Either` value.
 
 The various `loadConfig` methods defer to Typesafe Config's

--- a/bundle/src/main/tut/README.md
+++ b/bundle/src/main/tut/README.md
@@ -71,8 +71,11 @@ Finally, load the configuration:
 
 ```scala
 pureconfig.loadConfig[MyClass]
-// res0: Either[pureconfig.error.ConfigReaderFailures,MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
+// res0: pureconfig.ReaderResult[MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
 ```
+
+`ReaderResult[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
+would handle an `Either` value.
 
 The various `loadConfig` methods defer to Typesafe Config's
 [`ConfigFactory`](https://lightbend.github.io/config/latest/api/com/typesafe/config/ConfigFactory.html) to

--- a/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
+++ b/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
@@ -6,7 +6,7 @@ trait ProductReaders {
       reader: ConfigReader[A],
       key: String,
       cursor: ConfigObjectCursor): ConfigReader.Result[B] =
-    ReaderResult.zipWith(
+    ConfigReader.Result.zipWith(
       previousResult,
       if (reader.isInstanceOf[ReadsMissingKeys])
         reader.from(cursor.atKeyOrUndefined(key))

--- a/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
+++ b/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
@@ -2,10 +2,10 @@ package pureconfig
 
 trait ProductReaders {
   @inline private def combineReaderResult[B, A](
-      previousResult: ReaderResult[A => B],
+      previousResult: ConfigReader.Result[A => B],
       reader: ConfigReader[A],
       key: String,
-      cursor: ConfigObjectCursor): ReaderResult[B] =
+      cursor: ConfigObjectCursor): ConfigReader.Result[B] =
     ReaderResult.zipWith(
       previousResult,
       if (reader.isInstanceOf[ReadsMissingKeys])
@@ -25,9 +25,9 @@ trait ProductReaders {
   final def forProduct1[B, A0](keyA0: String)(f: A0 => B)(implicit
     readerA0: ConfigReader[A0]
   ): ConfigReader[B] = new ConfigReader[B] {
-    def from(cur: ConfigCursor): ReaderResult[B] =
+    def from(cur: ConfigCursor): ConfigReader.Result[B] =
       cur.asObjectCursor.right.flatMap { objCur =>
-        val a0Result: ReaderResult[A0 => B] = Right(f)
+        val a0Result: ConfigReader.Result[A0 => B] = Right(f)
         val a1Result = combineReaderResult(a0Result, readerA0, keyA0, objCur)
         a1Result
       }
@@ -44,9 +44,9 @@ trait ProductReaders {
   final def forProduct1[B, [#A0#]]([#keyA0: String#])(f: ([#A0#]) => B)(implicit
     [#readerA0: ConfigReader[A0]#]
   ): ConfigReader[B] = new ConfigReader[B] {
-    def from(cur: ConfigCursor): ReaderResult[B] =
+    def from(cur: ConfigCursor): ConfigReader.Result[B] =
       cur.asObjectCursor.right.flatMap { objCur =>
-        val a##0Result: ReaderResult[[#A0# => ] => B] = Right(f.curried)
+        val a##0Result: ConfigReader.Result[[#A0# => ] => B] = Right(f.curried)
         [#val a1Result = combineReaderResult(a0Result, readerA0, keyA0, objCur)#
         ]
         a1Result

--- a/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
+++ b/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
@@ -1,14 +1,12 @@
 package pureconfig
 
-import pureconfig.error._
-
 trait ProductReaders {
   @inline private def combineReaderResult[B, A](
-      previousResult: Either[ConfigReaderFailures, A => B],
+      previousResult: ReaderResult[A => B],
       reader: ConfigReader[A],
       key: String,
-      cursor: ConfigObjectCursor): Either[ConfigReaderFailures, B] =
-    ConvertHelpers.combineResults(
+      cursor: ConfigObjectCursor): ReaderResult[B] =
+    ReaderResult.zipWith(
       previousResult,
       if (reader.isInstanceOf[ReadsMissingKeys])
         reader.from(cursor.atKeyOrUndefined(key))
@@ -27,9 +25,9 @@ trait ProductReaders {
   final def forProduct1[B, A0](keyA0: String)(f: A0 => B)(implicit
     readerA0: ConfigReader[A0]
   ): ConfigReader[B] = new ConfigReader[B] {
-    def from(cur: ConfigCursor): Either[ConfigReaderFailures, B] =
+    def from(cur: ConfigCursor): ReaderResult[B] =
       cur.asObjectCursor.right.flatMap { objCur =>
-        val a0Result: Either[ConfigReaderFailures, A0 => B] = Right(f)
+        val a0Result: ReaderResult[A0 => B] = Right(f)
         val a1Result = combineReaderResult(a0Result, readerA0, keyA0, objCur)
         a1Result
       }
@@ -46,9 +44,9 @@ trait ProductReaders {
   final def forProduct1[B, [#A0#]]([#keyA0: String#])(f: ([#A0#]) => B)(implicit
     [#readerA0: ConfigReader[A0]#]
   ): ConfigReader[B] = new ConfigReader[B] {
-    def from(cur: ConfigCursor): Either[ConfigReaderFailures, B] =
+    def from(cur: ConfigCursor): ReaderResult[B] =
       cur.asObjectCursor.right.flatMap { objCur =>
-        val a##0Result: Either[ConfigReaderFailures, [#A0# => ] => B] = Right(f.curried)
+        val a##0Result: ReaderResult[[#A0# => ] => B] = Right(f.curried)
         [#val a1Result = combineReaderResult(a0Result, readerA0, keyA0, objCur)#
         ]
         a1Result

--- a/core/src/main/scala/pureconfig/CollectionReaders.scala
+++ b/core/src/main/scala/pureconfig/CollectionReaders.scala
@@ -36,7 +36,7 @@ trait CollectionReaders {
         // we called all the failures in the list
         listCur.list.foldLeft[ConfigReader.Result[mutable.Builder[T, F[T]]]](Right(cbf())) {
           case (acc, valueCur) =>
-            ReaderResult.zipWith(acc, configConvert.value.from(valueCur))(_ += _)
+            ConfigReader.Result.zipWith(acc, configConvert.value.from(valueCur))(_ += _)
         }.right.map(_.result())
       }
     }
@@ -47,7 +47,7 @@ trait CollectionReaders {
       cur.asMap.right.flatMap { map =>
         map.foldLeft[ConfigReader.Result[Map[String, T]]](Right(Map())) {
           case (acc, (key, valueConf)) =>
-            ReaderResult.zipWith(acc, reader.value.from(valueConf)) { (map, value) => map + (key -> value) }
+            ConfigReader.Result.zipWith(acc, reader.value.from(valueConf)) { (map, value) => map + (key -> value) }
         }
       }
     }

--- a/core/src/main/scala/pureconfig/CollectionReaders.scala
+++ b/core/src/main/scala/pureconfig/CollectionReaders.scala
@@ -4,9 +4,6 @@ import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable
 import scala.language.higherKinds
 
-import pureconfig.ConvertHelpers._
-import pureconfig.error._
-
 /**
  * A marker trait signaling that a `ConfigReader` accepts missing (undefined) values.
  *
@@ -23,7 +20,7 @@ trait CollectionReaders {
 
   implicit def optionReader[T](implicit conv: Derivation[ConfigReader[T]]): ConfigReader[Option[T]] =
     new ConfigReader[Option[T]] with ReadsMissingKeys {
-      override def from(cur: ConfigCursor): Either[ConfigReaderFailures, Option[T]] = {
+      override def from(cur: ConfigCursor): ReaderResult[Option[T]] = {
         if (cur.isUndefined || cur.isNull) Right(None)
         else conv.value.from(cur).right.map(Some(_))
       }
@@ -34,23 +31,23 @@ trait CollectionReaders {
     configConvert: Derivation[ConfigReader[T]],
     cbf: CanBuildFrom[F[T], T, F[T]]) = new ConfigReader[F[T]] {
 
-    override def from(cur: ConfigCursor): Either[ConfigReaderFailures, F[T]] = {
+    override def from(cur: ConfigCursor): ReaderResult[F[T]] = {
       cur.asListCursor.right.flatMap { listCur =>
         // we called all the failures in the list
-        listCur.list.foldLeft[Either[ConfigReaderFailures, mutable.Builder[T, F[T]]]](Right(cbf())) {
+        listCur.list.foldLeft[ReaderResult[mutable.Builder[T, F[T]]]](Right(cbf())) {
           case (acc, valueCur) =>
-            combineResults(acc, configConvert.value.from(valueCur))(_ += _)
+            ReaderResult.zipWith(acc, configConvert.value.from(valueCur))(_ += _)
         }.right.map(_.result())
       }
     }
   }
 
   implicit def mapReader[T](implicit reader: Derivation[ConfigReader[T]]) = new ConfigReader[Map[String, T]] {
-    override def from(cur: ConfigCursor): Either[ConfigReaderFailures, Map[String, T]] = {
+    override def from(cur: ConfigCursor): ReaderResult[Map[String, T]] = {
       cur.asMap.right.flatMap { map =>
-        map.foldLeft[Either[ConfigReaderFailures, Map[String, T]]](Right(Map())) {
+        map.foldLeft[ReaderResult[Map[String, T]]](Right(Map())) {
           case (acc, (key, valueConf)) =>
-            combineResults(acc, reader.value.from(valueConf)) { (map, value) => map + (key -> value) }
+            ReaderResult.zipWith(acc, reader.value.from(valueConf)) { (map, value) => map + (key -> value) }
         }
       }
     }

--- a/core/src/main/scala/pureconfig/ConfigCursor.scala
+++ b/core/src/main/scala/pureconfig/ConfigCursor.scala
@@ -56,7 +56,7 @@ sealed trait ConfigCursor {
    * @return a `Right` with the string value pointed to by this cursor if the cast can be done, `Left` with a list of
    *         failures otherwise.
    */
-  def asString: ReaderResult[String] =
+  def asString: ConfigReader.Result[String] =
     castOrFail(STRING, v => Right(v.unwrapped.asInstanceOf[String]))
 
   /**
@@ -65,7 +65,7 @@ sealed trait ConfigCursor {
    * @return a `Right` with the boolean value pointed to by this cursor if the cast can be done, `Left` with a list of
    *         failures otherwise.
    */
-  def asBoolean: ReaderResult[Boolean] =
+  def asBoolean: ConfigReader.Result[Boolean] =
     castOrFail(BOOLEAN, v => Right(v.unwrapped.asInstanceOf[Boolean]))
 
   /**
@@ -74,7 +74,7 @@ sealed trait ConfigCursor {
    * @return a `Right` with the long value pointed to by this cursor if the cast can be done, `Left` with a list of
    *         failures otherwise.
    */
-  def asLong: ReaderResult[Long] =
+  def asLong: ConfigReader.Result[Long] =
     castOrFail(NUMBER, _.unwrapped match {
       case i: java.lang.Number if i.longValue() == i => Right(i.longValue())
       case v => Left(CannotConvert(v.toString, "Long", "Unable to convert Number to Long"))
@@ -86,7 +86,7 @@ sealed trait ConfigCursor {
    * @return a `Right` with the int value pointed to by this cursor if the cast can be done, `Left` with a list of
    *         failures otherwise.
    */
-  def asInt: ReaderResult[Int] =
+  def asInt: ConfigReader.Result[Int] =
     castOrFail(NUMBER, _.unwrapped match {
       case i: java.lang.Number if i.intValue() == i => Right(i.intValue())
       case v => Left(CannotConvert(v.toString, "Int", "Unable to convert Number to Int"))
@@ -98,7 +98,7 @@ sealed trait ConfigCursor {
    * @return a `Right` with the short value pointed to by this cursor if the cast can be done, `Left` with a list of
    *         failures otherwise.
    */
-  def asShort: ReaderResult[Short] =
+  def asShort: ConfigReader.Result[Short] =
     castOrFail(NUMBER, _.unwrapped match {
       case i: java.lang.Number if i.shortValue() == i => Right(i.shortValue())
       case v => Left(CannotConvert(v.toString, "Short", "Unable to convert Number to Short"))
@@ -110,7 +110,7 @@ sealed trait ConfigCursor {
    * @return a `Right` with the double value pointed to by this cursor if the cast can be done, `Left` with a list of
    *         failures otherwise.
    */
-  def asDouble: ReaderResult[Double] =
+  def asDouble: ConfigReader.Result[Double] =
     castOrFail(NUMBER, _.unwrapped match {
       case i: java.lang.Number if i.doubleValue() == i => Right(i.doubleValue())
       case v => Left(CannotConvert(v.toString, "Double", "Unable to convert Number to Double"))
@@ -122,7 +122,7 @@ sealed trait ConfigCursor {
    * @return a `Right` with the float value pointed to by this cursor if the cast can be done, `Left` with a list of
    *         failures otherwise.
    */
-  def asFloat: ReaderResult[Float] =
+  def asFloat: ConfigReader.Result[Float] =
     castOrFail(NUMBER, _.unwrapped match {
       case i: java.lang.Number if i.floatValue() == i => Right(i.floatValue())
       case v => Left(CannotConvert(v.toString, "Float", "Unable to convert Number to Float"))
@@ -134,7 +134,7 @@ sealed trait ConfigCursor {
    * @return a `Right` with this cursor as a list cursor if the cast can be done, `Left` with a list of failures
    *         otherwise.
    */
-  def asListCursor: ReaderResult[ConfigListCursor] =
+  def asListCursor: ConfigReader.Result[ConfigListCursor] =
     castOrFail(LIST, v => Right(v.asInstanceOf[ConfigList])).right.map(ConfigListCursor(_, pathElems))
 
   /**
@@ -143,7 +143,7 @@ sealed trait ConfigCursor {
    * @return a `Right` with the list pointed to by this cursor if the cast can be done, `Left` with a list of failures
    *         otherwise.
    */
-  def asList: ReaderResult[List[ConfigCursor]] =
+  def asList: ConfigReader.Result[List[ConfigCursor]] =
     asListCursor.right.map(_.list)
 
   /**
@@ -152,7 +152,7 @@ sealed trait ConfigCursor {
    * @return a `Right` with this cursor as an object cursor if it points to an object, `Left` with a list of failures
    *         otherwise.
    */
-  def asObjectCursor: ReaderResult[ConfigObjectCursor] =
+  def asObjectCursor: ConfigReader.Result[ConfigObjectCursor] =
     castOrFail(OBJECT, v => Right(v.asInstanceOf[ConfigObject])).right.map(ConfigObjectCursor(_, pathElems))
 
   /**
@@ -161,10 +161,10 @@ sealed trait ConfigCursor {
    * @return a `Right` with the map pointed to by this cursor if the cast can be done, `Left` with a list of failures
    *         otherwise.
    */
-  def asMap: ReaderResult[Map[String, ConfigCursor]] =
+  def asMap: ConfigReader.Result[Map[String, ConfigCursor]] =
     asObjectCursor.right.map(_.map)
 
-  @inline private final def atPathSegment(pathSegment: PathSegment): ReaderResult[ConfigCursor] = {
+  @inline private final def atPathSegment(pathSegment: PathSegment): ConfigReader.Result[ConfigCursor] = {
     pathSegment match {
       case PathSegment.Key(k) => this.asObjectCursor.right.flatMap(_.atKey(k))
       case PathSegment.Index(i) => this.asListCursor.right.flatMap(_.atIndex(i))
@@ -178,8 +178,8 @@ sealed trait ConfigCursor {
    * @return a `Right` with a cursor to the config at `pathSegments` if such a config exists, a `Left` with a list of
    *         failures otherwise.
    */
-  final def atPath(pathSegments: PathSegment*): ReaderResult[ConfigCursor] = {
-    pathSegments.foldLeft(Right(this): ReaderResult[ConfigCursor]) {
+  final def atPath(pathSegments: PathSegment*): ConfigReader.Result[ConfigCursor] = {
+    pathSegments.foldLeft(Right(this): ConfigReader.Result[ConfigCursor]) {
       case (soFar, segment) => soFar.right.flatMap(_.atPathSegment(segment))
     }
   }
@@ -191,7 +191,7 @@ sealed trait ConfigCursor {
    *         failures otherwise.
    */
   @deprecated("Use `asListCursor` and/or `asObjectCursor` instead", "0.10.1")
-  def asCollectionCursor: ReaderResult[Either[ConfigListCursor, ConfigObjectCursor]] = {
+  def asCollectionCursor: ConfigReader.Result[Either[ConfigListCursor, ConfigObjectCursor]] = {
     if (isUndefined) {
       failed(KeyNotFound.forKeys(path, Set()))
     } else {
@@ -212,7 +212,7 @@ sealed trait ConfigCursor {
    * @tparam A the returning type of the `ConfigReader`
    * @return a failed `ConfigReader` result built by scoping `reason` into the context of this cursor.
    */
-  def failed[A](reason: FailureReason): ReaderResult[A] =
+  def failed[A](reason: FailureReason): ConfigReader.Result[A] =
     Left(ConfigReaderFailures(failureFor(reason)))
 
   /**
@@ -238,12 +238,12 @@ sealed trait ConfigCursor {
    * @tparam A the returning type of the `ConfigReader`
    * @return a `ConfigReader` result built by scoping `reason` into the context of this cursor.
    */
-  def scopeFailure[A](result: Either[FailureReason, A]): ReaderResult[A] =
+  def scopeFailure[A](result: Either[FailureReason, A]): ConfigReader.Result[A] =
     result.left.map { reason => ConfigReaderFailures(failureFor(reason), Nil) }
 
   private[this] def castOrFail[A](
     expectedType: ConfigValueType,
-    cast: ConfigValue => Either[FailureReason, A]): ReaderResult[A] = {
+    cast: ConfigValue => Either[FailureReason, A]): ConfigReader.Result[A] = {
 
     if (isUndefined)
       failed(KeyNotFound.forKeys(path, Set()))
@@ -348,7 +348,7 @@ case class ConfigListCursor(value: ConfigList, pathElems: List[String], offset: 
    * @return a `Right` with a cursor to the config at `idx` if such a config exists, a `Left` with a list of failures
    *         otherwise.
    */
-  def atIndex(idx: Int): ReaderResult[ConfigCursor] = {
+  def atIndex(idx: Int): ConfigReader.Result[ConfigCursor] = {
     atIndexOrUndefined(idx) match {
       case idxCur if idxCur.isUndefined => failed(KeyNotFound.forKeys(indexKey(idx), Set()))
       case idxCur => Right(idxCur)
@@ -389,7 +389,7 @@ case class ConfigListCursor(value: ConfigList, pathElems: List[String], offset: 
     value.asScala.toList.drop(offset).zipWithIndex.map { case (cv, idx) => ConfigCursor(cv, indexKey(idx) :: pathElems) }
 
   // Avoid resetting the offset when using ConfigCursor's implementation.
-  override def asListCursor: ReaderResult[ConfigListCursor] = Right(this)
+  override def asListCursor: ConfigReader.Result[ConfigListCursor] = Right(this)
 }
 
 /**
@@ -420,7 +420,7 @@ case class ConfigObjectCursor(value: ConfigObject, pathElems: List[String]) exte
    * @return a `Right` with a cursor to the config at `key` if such a config exists, a `Left` with a list of failures
    *         otherwise.
    */
-  def atKey(key: String): ReaderResult[ConfigCursor] = {
+  def atKey(key: String): ConfigReader.Result[ConfigCursor] = {
     atKeyOrUndefined(key) match {
       case keyCur if keyCur.isUndefined => failed(KeyNotFound.forKeys(key, keys))
       case keyCur => Right(keyCur)
@@ -452,5 +452,5 @@ case class ConfigObjectCursor(value: ConfigObject, pathElems: List[String]) exte
     value.asScala.toMap.map { case (key, cv) => key -> ConfigCursor(cv, key :: pathElems) }
 
   // Avoid unnecessary cast.
-  override def asObjectCursor: ReaderResult[ConfigObjectCursor] = Right(this)
+  override def asObjectCursor: ConfigReader.Result[ConfigObjectCursor] = Right(this)
 }

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -6,7 +6,7 @@ import scala.util.Try
 import com.typesafe.config.ConfigValue
 import pureconfig.ConfigReader._
 import pureconfig.ConvertHelpers._
-import pureconfig.error.FailureReason
+import pureconfig.error.{ ConfigReaderFailures, FailureReason }
 
 /**
  * Trait for objects capable of reading objects of a given type from `ConfigValues`.
@@ -21,7 +21,7 @@ trait ConfigReader[A] {
    * @param cur The cursor from which the config should be loaded
    * @return either a list of failures or an object of type `A`
    */
-  def from(cur: ConfigCursor): ReaderResult[A]
+  def from(cur: ConfigCursor): ConfigReader.Result[A]
 
   /**
    * Convert the given configuration into an instance of `A` if possible.
@@ -29,7 +29,7 @@ trait ConfigReader[A] {
    * @param config The configuration from which the config should be loaded
    * @return either a list of failures or an object of type `A`
    */
-  def from(config: ConfigValue): ReaderResult[A] =
+  def from(config: ConfigValue): ConfigReader.Result[A] =
     from(ConfigCursor(config, Nil))
 
   /**
@@ -120,6 +120,13 @@ trait ConfigReader[A] {
  */
 object ConfigReader extends BasicReaders with CollectionReaders with ProductReaders with ExportedReaders {
 
+  /**
+   * The type of most config PureConfig reading methods.
+   *
+   * @tparam A the type of the result
+   */
+  type Result[A] = Either[ConfigReaderFailures, A]
+
   def apply[A](implicit reader: Derivation[ConfigReader[A]]): ConfigReader[A] = reader.value
 
   /**
@@ -129,7 +136,7 @@ object ConfigReader extends BasicReaders with CollectionReaders with ProductRead
    * @tparam A the type of the objects readable by the returned reader
    * @return a `ConfigReader` for reading objects of type `A` using `fromF`.
    */
-  def fromCursor[A](fromF: ConfigCursor => ReaderResult[A]) = new ConfigReader[A] {
+  def fromCursor[A](fromF: ConfigCursor => ConfigReader.Result[A]) = new ConfigReader[A] {
     def from(cur: ConfigCursor) = fromF(cur)
   }
 
@@ -140,7 +147,7 @@ object ConfigReader extends BasicReaders with CollectionReaders with ProductRead
    * @tparam A the type of the objects readable by the returned reader
    * @return a `ConfigReader` for reading objects of type `A` using `fromF`.
    */
-  def fromFunction[A](fromF: ConfigValue => ReaderResult[A]) =
+  def fromFunction[A](fromF: ConfigValue => ConfigReader.Result[A]) =
     fromCursor(fromF.compose(_.value))
 
   def fromString[A](fromF: String => Either[FailureReason, A]): ConfigReader[A] =

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -128,12 +128,12 @@ object ConfigReader extends BasicReaders with CollectionReaders with ProductRead
   type Result[A] = Either[ConfigReaderFailures, A]
 
   /**
-   * Object containing useful constructors and utility methods for `ReaderResult`s.
+   * Object containing useful constructors and utility methods for `Result`s.
    */
   object Result {
 
     /**
-     * Merges two `ReaderResult`s using a given function.
+     * Merges two `Result`s using a given function.
      */
     def zipWith[A, B, C](first: ConfigReader.Result[A], second: ConfigReader.Result[B])(f: (A, B) => C): ConfigReader.Result[C] =
       (first, second) match {
@@ -144,7 +144,7 @@ object ConfigReader extends BasicReaders with CollectionReaders with ProductRead
       }
 
     /**
-     * Returns a `ReaderResult` containing a single failure.
+     * Returns a `Result` containing a single failure.
      */
     def fail[A](failure: ConfigReaderFailure): ConfigReader.Result[A] = Left(ConfigReaderFailures(failure))
   }

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -6,7 +6,7 @@ import scala.util.Try
 import com.typesafe.config.ConfigValue
 import pureconfig.ConfigReader._
 import pureconfig.ConvertHelpers._
-import pureconfig.error.{ ConfigReaderFailures, FailureReason }
+import pureconfig.error.FailureReason
 
 /**
  * Trait for objects capable of reading objects of a given type from `ConfigValues`.
@@ -21,7 +21,7 @@ trait ConfigReader[A] {
    * @param cur The cursor from which the config should be loaded
    * @return either a list of failures or an object of type `A`
    */
-  def from(cur: ConfigCursor): Either[ConfigReaderFailures, A]
+  def from(cur: ConfigCursor): ReaderResult[A]
 
   /**
    * Convert the given configuration into an instance of `A` if possible.
@@ -29,7 +29,7 @@ trait ConfigReader[A] {
    * @param config The configuration from which the config should be loaded
    * @return either a list of failures or an object of type `A`
    */
-  def from(config: ConfigValue): Either[ConfigReaderFailures, A] =
+  def from(config: ConfigValue): ReaderResult[A] =
     from(ConfigCursor(config, Nil))
 
   /**
@@ -129,7 +129,7 @@ object ConfigReader extends BasicReaders with CollectionReaders with ProductRead
    * @tparam A the type of the objects readable by the returned reader
    * @return a `ConfigReader` for reading objects of type `A` using `fromF`.
    */
-  def fromCursor[A](fromF: ConfigCursor => Either[ConfigReaderFailures, A]) = new ConfigReader[A] {
+  def fromCursor[A](fromF: ConfigCursor => ReaderResult[A]) = new ConfigReader[A] {
     def from(cur: ConfigCursor) = fromF(cur)
   }
 
@@ -140,7 +140,7 @@ object ConfigReader extends BasicReaders with CollectionReaders with ProductRead
    * @tparam A the type of the objects readable by the returned reader
    * @return a `ConfigReader` for reading objects of type `A` using `fromF`.
    */
-  def fromFunction[A](fromF: ConfigValue => Either[ConfigReaderFailures, A]) =
+  def fromFunction[A](fromF: ConfigValue => ReaderResult[A]) =
     fromCursor(fromF.compose(_.value))
 
   def fromString[A](fromF: String => Either[FailureReason, A]): ConfigReader[A] =

--- a/core/src/main/scala/pureconfig/ConvertHelpers.scala
+++ b/core/src/main/scala/pureconfig/ConvertHelpers.scala
@@ -11,15 +11,12 @@ import pureconfig.error._
  */
 trait ConvertHelpers {
 
-  def combineResults[A, B, C](first: Either[ConfigReaderFailures, A], second: Either[ConfigReaderFailures, B])(f: (A, B) => C): Either[ConfigReaderFailures, C] =
-    (first, second) match {
-      case (Right(a), Right(b)) => Right(f(a, b))
-      case (Left(aFailures), Left(bFailures)) => Left(aFailures ++ bFailures)
-      case (_, l: Left[_, _]) => l.asInstanceOf[Left[ConfigReaderFailures, Nothing]]
-      case (l: Left[_, _], _) => l.asInstanceOf[Left[ConfigReaderFailures, Nothing]]
-    }
+  @deprecated("Use `ReaderResult.zipWith` instead", "0.10.2")
+  def combineResults[A, B, C](first: ReaderResult[A], second: ReaderResult[B])(f: (A, B) => C): ReaderResult[C] =
+    ReaderResult.zipWith(first, second)(f)
 
-  def fail[A](failure: ConfigReaderFailure): Either[ConfigReaderFailures, A] = Left(ConfigReaderFailures(failure))
+  @deprecated("Use `ReaderResult.fail` instead", "0.10.2")
+  def fail[A](failure: ConfigReaderFailure): ReaderResult[A] = Left(ConfigReaderFailures(failure))
 
   private[pureconfig] def toResult[A, B](f: A => B): A => Either[FailureReason, B] =
     v => tryToEither(Try(f(v)))

--- a/core/src/main/scala/pureconfig/ConvertHelpers.scala
+++ b/core/src/main/scala/pureconfig/ConvertHelpers.scala
@@ -11,11 +11,11 @@ import pureconfig.error._
  */
 trait ConvertHelpers {
 
-  @deprecated("Use `ReaderResult.zipWith` instead", "0.10.2")
+  @deprecated("Use `ConfigReader.Result.zipWith` instead", "0.10.2")
   def combineResults[A, B, C](first: ConfigReader.Result[A], second: ConfigReader.Result[B])(f: (A, B) => C): ConfigReader.Result[C] =
-    ReaderResult.zipWith(first, second)(f)
+    ConfigReader.Result.zipWith(first, second)(f)
 
-  @deprecated("Use `ReaderResult.fail` instead", "0.10.2")
+  @deprecated("Use `ConfigReader.Result.fail` instead", "0.10.2")
   def fail[A](failure: ConfigReaderFailure): ConfigReader.Result[A] = Left(ConfigReaderFailures(failure))
 
   private[pureconfig] def toResult[A, B](f: A => B): A => Either[FailureReason, B] =

--- a/core/src/main/scala/pureconfig/ConvertHelpers.scala
+++ b/core/src/main/scala/pureconfig/ConvertHelpers.scala
@@ -12,11 +12,11 @@ import pureconfig.error._
 trait ConvertHelpers {
 
   @deprecated("Use `ReaderResult.zipWith` instead", "0.10.2")
-  def combineResults[A, B, C](first: ReaderResult[A], second: ReaderResult[B])(f: (A, B) => C): ReaderResult[C] =
+  def combineResults[A, B, C](first: ConfigReader.Result[A], second: ConfigReader.Result[B])(f: (A, B) => C): ConfigReader.Result[C] =
     ReaderResult.zipWith(first, second)(f)
 
   @deprecated("Use `ReaderResult.fail` instead", "0.10.2")
-  def fail[A](failure: ConfigReaderFailure): ReaderResult[A] = Left(ConfigReaderFailures(failure))
+  def fail[A](failure: ConfigReaderFailure): ConfigReader.Result[A] = Left(ConfigReaderFailures(failure))
 
   private[pureconfig] def toResult[A, B](f: A => B): A => Either[FailureReason, B] =
     v => tryToEither(Try(f(v)))

--- a/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
+++ b/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
@@ -17,25 +17,25 @@ object ConfigFactoryWrapper {
 
   /** @see `com.typesafe.config.ConfigFactory.invalidateCaches()` */
   def invalidateCaches(): ConfigReader.Result[Unit] =
-    unsafeToEither(ConfigFactory.invalidateCaches())
+    unsafeToReaderResult(ConfigFactory.invalidateCaches())
 
   /** @see `com.typesafe.config.ConfigFactory.load()` */
   def load(): ConfigReader.Result[Config] =
-    unsafeToEither(ConfigFactory.load())
+    unsafeToReaderResult(ConfigFactory.load())
 
   /** @see `com.typesafe.config.ConfigFactory.parseString()` */
   def parseString(s: String): ConfigReader.Result[Config] =
-    unsafeToEither(ConfigFactory.parseString(s))
+    unsafeToReaderResult(ConfigFactory.parseString(s))
 
   /** @see `com.typesafe.config.ConfigFactory.parseFile()` */
   def parseFile(path: Path): ConfigReader.Result[Config] =
-    unsafeToEither(ConfigFactory.parseFile(path.toFile, strictSettings), Some(path))
+    unsafeToReaderResult(ConfigFactory.parseFile(path.toFile, strictSettings), Some(path))
 
   /** Utility methods that parse a file and then calls `ConfigFactory.load` */
   def loadFile(path: Path): ConfigReader.Result[Config] =
-    parseFile(path).right.flatMap(rawConfig => unsafeToEither(ConfigFactory.load(rawConfig)))
+    parseFile(path).right.flatMap(rawConfig => unsafeToReaderResult(ConfigFactory.load(rawConfig)))
 
-  private def unsafeToEither[A](f: => A, path: Option[Path] = None): ConfigReader.Result[A] = {
+  private def unsafeToReaderResult[A](f: => A, path: Option[Path] = None): ConfigReader.Result[A] = {
     try Right(f) catch {
       case e: ConfigException.IO if path.nonEmpty => ReaderResult.fail(CannotReadFile(path.get, Option(e.getCause)))
       case e: ConfigException.Parse =>

--- a/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
+++ b/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
@@ -5,7 +5,7 @@ import java.nio.file.Path
 import scala.util.control.NonFatal
 
 import com.typesafe.config._
-import pureconfig.ReaderResult
+import pureconfig._
 import pureconfig.error._
 
 /**
@@ -16,26 +16,26 @@ object ConfigFactoryWrapper {
   private[this] val strictSettings = ConfigParseOptions.defaults.setAllowMissing(false)
 
   /** @see `com.typesafe.config.ConfigFactory.invalidateCaches()` */
-  def invalidateCaches(): ReaderResult[Unit] =
+  def invalidateCaches(): ConfigReader.Result[Unit] =
     unsafeToEither(ConfigFactory.invalidateCaches())
 
   /** @see `com.typesafe.config.ConfigFactory.load()` */
-  def load(): ReaderResult[Config] =
+  def load(): ConfigReader.Result[Config] =
     unsafeToEither(ConfigFactory.load())
 
   /** @see `com.typesafe.config.ConfigFactory.parseString()` */
-  def parseString(s: String): ReaderResult[Config] =
+  def parseString(s: String): ConfigReader.Result[Config] =
     unsafeToEither(ConfigFactory.parseString(s))
 
   /** @see `com.typesafe.config.ConfigFactory.parseFile()` */
-  def parseFile(path: Path): ReaderResult[Config] =
+  def parseFile(path: Path): ConfigReader.Result[Config] =
     unsafeToEither(ConfigFactory.parseFile(path.toFile, strictSettings), Some(path))
 
   /** Utility methods that parse a file and then calls `ConfigFactory.load` */
-  def loadFile(path: Path): ReaderResult[Config] =
+  def loadFile(path: Path): ConfigReader.Result[Config] =
     parseFile(path).right.flatMap(rawConfig => unsafeToEither(ConfigFactory.load(rawConfig)))
 
-  private def unsafeToEither[A](f: => A, path: Option[Path] = None): ReaderResult[A] = {
+  private def unsafeToEither[A](f: => A, path: Option[Path] = None): ConfigReader.Result[A] = {
     try Right(f) catch {
       case e: ConfigException.IO if path.nonEmpty => ReaderResult.fail(CannotReadFile(path.get, Option(e.getCause)))
       case e: ConfigException.Parse =>

--- a/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
+++ b/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
@@ -37,16 +37,16 @@ object ConfigFactoryWrapper {
 
   private def unsafeToReaderResult[A](f: => A, path: Option[Path] = None): ConfigReader.Result[A] = {
     try Right(f) catch {
-      case e: ConfigException.IO if path.nonEmpty => ReaderResult.fail(CannotReadFile(path.get, Option(e.getCause)))
+      case e: ConfigException.IO if path.nonEmpty => ConfigReader.Result.fail(CannotReadFile(path.get, Option(e.getCause)))
       case e: ConfigException.Parse =>
         val msg = (if (e.origin != null)
           // Removing the error origin from the exception message since origin is stored and used separately:
           e.getMessage.stripPrefix(s"${e.origin.description}: ")
         else
           e.getMessage).stripSuffix(".")
-        ReaderResult.fail(CannotParse(msg, ConfigValueLocation(e.origin())))
-      case e: ConfigException => ReaderResult.fail(ThrowableFailure(e, ConfigValueLocation(e.origin())))
-      case NonFatal(e) => ReaderResult.fail(ThrowableFailure(e, None))
+        ConfigReader.Result.fail(CannotParse(msg, ConfigValueLocation(e.origin())))
+      case e: ConfigException => ConfigReader.Result.fail(ThrowableFailure(e, ConfigValueLocation(e.origin())))
+      case NonFatal(e) => ConfigReader.Result.fail(ThrowableFailure(e, None))
     }
   }
 }

--- a/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
+++ b/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
@@ -5,7 +5,7 @@ import java.nio.file.Path
 import scala.util.control.NonFatal
 
 import com.typesafe.config._
-import pureconfig.ConvertHelpers._
+import pureconfig.ReaderResult
 import pureconfig.error._
 
 /**
@@ -16,37 +16,37 @@ object ConfigFactoryWrapper {
   private[this] val strictSettings = ConfigParseOptions.defaults.setAllowMissing(false)
 
   /** @see `com.typesafe.config.ConfigFactory.invalidateCaches()` */
-  def invalidateCaches(): Either[ConfigReaderFailures, Unit] =
+  def invalidateCaches(): ReaderResult[Unit] =
     unsafeToEither(ConfigFactory.invalidateCaches())
 
   /** @see `com.typesafe.config.ConfigFactory.load()` */
-  def load(): Either[ConfigReaderFailures, Config] =
+  def load(): ReaderResult[Config] =
     unsafeToEither(ConfigFactory.load())
 
   /** @see `com.typesafe.config.ConfigFactory.parseString()` */
-  def parseString(s: String): Either[ConfigReaderFailures, Config] =
+  def parseString(s: String): ReaderResult[Config] =
     unsafeToEither(ConfigFactory.parseString(s))
 
   /** @see `com.typesafe.config.ConfigFactory.parseFile()` */
-  def parseFile(path: Path): Either[ConfigReaderFailures, Config] =
+  def parseFile(path: Path): ReaderResult[Config] =
     unsafeToEither(ConfigFactory.parseFile(path.toFile, strictSettings), Some(path))
 
   /** Utility methods that parse a file and then calls `ConfigFactory.load` */
-  def loadFile(path: Path): Either[ConfigReaderFailures, Config] =
+  def loadFile(path: Path): ReaderResult[Config] =
     parseFile(path).right.flatMap(rawConfig => unsafeToEither(ConfigFactory.load(rawConfig)))
 
-  private def unsafeToEither[A](f: => A, path: Option[Path] = None): Either[ConfigReaderFailures, A] = {
+  private def unsafeToEither[A](f: => A, path: Option[Path] = None): ReaderResult[A] = {
     try Right(f) catch {
-      case e: ConfigException.IO if path.nonEmpty => fail(CannotReadFile(path.get, Option(e.getCause)))
+      case e: ConfigException.IO if path.nonEmpty => ReaderResult.fail(CannotReadFile(path.get, Option(e.getCause)))
       case e: ConfigException.Parse =>
         val msg = (if (e.origin != null)
           // Removing the error origin from the exception message since origin is stored and used separately:
           e.getMessage.stripPrefix(s"${e.origin.description}: ")
         else
           e.getMessage).stripSuffix(".")
-        fail(CannotParse(msg, ConfigValueLocation(e.origin())))
-      case e: ConfigException => fail(ThrowableFailure(e, ConfigValueLocation(e.origin())))
-      case NonFatal(e) => fail(ThrowableFailure(e, None))
+        ReaderResult.fail(CannotParse(msg, ConfigValueLocation(e.origin())))
+      case e: ConfigException => ReaderResult.fail(ThrowableFailure(e, ConfigValueLocation(e.origin())))
+      case NonFatal(e) => ReaderResult.fail(ThrowableFailure(e, None))
     }
   }
 }

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -64,7 +64,7 @@ package object configurable {
           case (acc, (key, valueCursor)) =>
             val eitherKeyOrError = cursor.scopeFailure(keyParser(key))
             val eitherValueOrError = readerV.value.from(valueCursor)
-            ReaderResult.zipWith(acc, ReaderResult.zipWith(eitherKeyOrError, eitherValueOrError)(_ -> _))(_ + _)
+            ConfigReader.Result.zipWith(acc, ConfigReader.Result.zipWith(eitherKeyOrError, eitherValueOrError)(_ -> _))(_ + _)
         }
       }
     }

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -60,7 +60,7 @@ package object configurable {
   def genericMapReader[K, V](keyParser: String => Either[FailureReason, K])(implicit readerV: Derivation[ConfigReader[V]]): ConfigReader[Map[K, V]] =
     ConfigReader.fromCursor { cursor =>
       cursor.asMap.right.flatMap { map =>
-        map.foldLeft[ReaderResult[Map[K, V]]](Right(Map.empty)) {
+        map.foldLeft[ConfigReader.Result[Map[K, V]]](Right(Map.empty)) {
           case (acc, (key, valueCursor)) =>
             val eitherKeyOrError = cursor.scopeFailure(keyParser(key))
             val eitherValueOrError = readerV.value.from(valueCursor)

--- a/core/src/main/scala/pureconfig/package.scala
+++ b/core/src/main/scala/pureconfig/package.scala
@@ -4,6 +4,7 @@
 /**
  * @author Mario Pastorelli
  */
+
 import java.io.{ OutputStream, OutputStreamWriter }
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{ Files, Path }
@@ -11,18 +12,46 @@ import java.nio.file.{ Files, Path }
 import scala.reflect.ClassTag
 
 import com.typesafe.config.{ Config => TypesafeConfig, _ }
-import pureconfig.ConvertHelpers._
 import pureconfig.backend.ConfigFactoryWrapper._
 import pureconfig.backend.PathUtil._
 import pureconfig.error._
 
 package object pureconfig {
 
+  /**
+   * The type of most config PureConfig reading methods.
+   *
+   * @tparam A the type of the result
+   */
+  type ReaderResult[A] = Either[ConfigReaderFailures, A]
+
+  /**
+   * Object containing useful constructors and utility methods for `ReaderResult`s.
+   */
+  object ReaderResult {
+
+    /**
+     * Merges two `ReaderResult`s using a given function.
+     */
+    def zipWith[A, B, C](first: ReaderResult[A], second: ReaderResult[B])(f: (A, B) => C): ReaderResult[C] =
+      (first, second) match {
+        case (Right(a), Right(b)) => Right(f(a, b))
+        case (Left(aFailures), Left(bFailures)) => Left(aFailures ++ bFailures)
+        case (_, l: Left[_, _]) => l.asInstanceOf[Left[ConfigReaderFailures, Nothing]]
+        case (l: Left[_, _], _) => l.asInstanceOf[Left[ConfigReaderFailures, Nothing]]
+      }
+
+    /**
+     * Returns a `ReaderResult` containing a single failure.
+     */
+    def fail[A](failure: ConfigReaderFailure): ReaderResult[A] = Left(ConfigReaderFailures(failure))
+  }
+
   // retrieves a value from a namespace, returning a failure if:
   //   - one of the parent keys doesn't exist or isn't an object;
   //   - `allowNullLeaf` is false and the leaf key doesn't exist.
-  private[this] def getValue(conf: TypesafeConfig, namespace: String, allowNullLeaf: Boolean): Either[ConfigReaderFailures, ConfigCursor] = {
-    def getValue(cur: ConfigCursor, path: List[String]): Either[ConfigReaderFailures, ConfigCursor] = path match {
+  private[this] def getValue(conf: TypesafeConfig, namespace: String, allowNullLeaf: Boolean): ReaderResult[ConfigCursor] = {
+    def getValue(cur: ConfigCursor, path: List[String]): ReaderResult[ConfigCursor] = path match {
       case Nil => Right(cur)
       case key :: remaining => for {
         objCur <- cur.asObjectCursor.right
@@ -33,13 +62,13 @@ package object pureconfig {
 
     // we're not expecting any exception here, this `try` is just for extra safety
     try getValue(ConfigCursor(conf.root(), Nil), splitPath(namespace)) catch {
-      case ex: ConfigException => fail(ThrowableFailure(ex, ConfigValueLocation(ex.origin())))
+      case ex: ConfigException => ReaderResult.fail(ThrowableFailure(ex, ConfigValueLocation(ex.origin())))
     }
   }
 
   // loads a value from a config in a given namespace. All `loadConfig` methods _must_ use this method to get correct
   // namespace handling, both in the values to load and in the error messages.
-  private[this] def loadValue[A](conf: TypesafeConfig, namespace: String)(implicit reader: Derivation[ConfigReader[A]]): Either[ConfigReaderFailures, A] = {
+  private[this] def loadValue[A](conf: TypesafeConfig, namespace: String)(implicit reader: Derivation[ConfigReader[A]]): ReaderResult[A] = {
     getValue(conf, namespace, reader.value.isInstanceOf[ReadsMissingKeys]).right.flatMap(reader.value.from)
   }
 
@@ -50,7 +79,7 @@ package object pureconfig {
    *         `Config` from the configuration files, else a `Failure` with details on why it
    *         isn't possible
    */
-  def loadConfig[Config](implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] =
+  def loadConfig[Config](implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] =
     loadConfig("")
 
   /**
@@ -61,7 +90,7 @@ package object pureconfig {
    *         `Config` from the configuration files, else a `Failure` with details on why it
    *         isn't possible
    */
-  def loadConfig[Config](namespace: String)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] = {
+  def loadConfig[Config](namespace: String)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
     for {
       _ <- invalidateCaches().right
       rawConfig <- load().right
@@ -77,7 +106,7 @@ package object pureconfig {
    *         `Config` from the configuration files, else a `Failure` with details on why it
    *         isn't possible
    */
-  def loadConfig[Config](path: Path)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] =
+  def loadConfig[Config](path: Path)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] =
     loadConfig(path, "")
 
   /**
@@ -89,7 +118,7 @@ package object pureconfig {
    *         `Config` from the configuration files, else a `Failure` with details on why it
    *         isn't possible
    */
-  def loadConfig[Config](path: Path, namespace: String)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] = {
+  def loadConfig[Config](path: Path, namespace: String)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
     for {
       _ <- invalidateCaches().right
       rawConfig <- loadFile(path).right
@@ -98,11 +127,11 @@ package object pureconfig {
   }
 
   /** Load a configuration of type `Config` from the given `Config` */
-  def loadConfig[Config](conf: TypesafeConfig)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] =
+  def loadConfig[Config](conf: TypesafeConfig)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] =
     loadValue(conf, "")
 
   /** Load a configuration of type `Config` from the given `Config` */
-  def loadConfig[Config](conf: TypesafeConfig, namespace: String)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] =
+  def loadConfig[Config](conf: TypesafeConfig, namespace: String)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] =
     loadValue(conf, namespace)
 
   /**
@@ -113,19 +142,19 @@ package object pureconfig {
    *         `Config` from the configuration files, else a `Failure` with details on why it
    *         isn't possible
    */
-  def loadConfigWithFallback[Config](conf: TypesafeConfig)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] =
+  def loadConfigWithFallback[Config](conf: TypesafeConfig)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] =
     loadConfigWithFallback(conf, "")
 
   /**
    * Load a configuration of type `Config` from the given `Config`, falling back to the default configuration
    *
-   * @param conf Typesafe configuration to load
+   * @param conf      Typesafe configuration to load
    * @param namespace the base namespace from which the configuration should be load
    * @return A `Success` with the configuration if it is possible to create an instance of type
    *         `Config` from the configuration files, else a `Failure` with details on why it
    *         isn't possible
    */
-  def loadConfigWithFallback[Config](conf: TypesafeConfig, namespace: String)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] = {
+  def loadConfigWithFallback[Config](conf: TypesafeConfig, namespace: String)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
     for {
       _ <- invalidateCaches().right
       rawConfig <- load().right
@@ -133,7 +162,7 @@ package object pureconfig {
     } yield config
   }
 
-  private[this] def getResultOrThrow[Config](failuresOrResult: Either[ConfigReaderFailures, Config])(implicit ct: ClassTag[Config]): Config = {
+  private[this] def getResultOrThrow[Config](failuresOrResult: ReaderResult[Config])(implicit ct: ClassTag[Config]): Config = {
     failuresOrResult match {
       case Right(config) => config
       case Left(failures) => throw new ConfigReaderException[Config](failures)
@@ -198,7 +227,7 @@ package object pureconfig {
   /**
    * Load a configuration of type `Config` from the given `Config`
    *
-   * @param conf Typesafe configuration to load
+   * @param conf      Typesafe configuration to load
    * @param namespace the base namespace from which the configuration should be load
    * @return the configuration
    */
@@ -221,7 +250,7 @@ package object pureconfig {
   /**
    * Load a configuration of type `Config` from the given `Config`, falling back to the default configuration
    *
-   * @param conf Typesafe configuration to load
+   * @param conf      Typesafe configuration to load
    * @param namespace the base namespace from which the configuration should be load
    * @return the configuration
    */
@@ -233,10 +262,10 @@ package object pureconfig {
   /**
    * Save the given configuration into a property file
    *
-   * @param conf The configuration to save
-   * @param outputPath Where to write the configuration
+   * @param conf               The configuration to save
+   * @param outputPath         Where to write the configuration
    * @param overrideOutputPath Override the path if it already exists
-   * @param options the config rendering options
+   * @param options            the config rendering options
    */
   @throws[IllegalArgumentException]
   def saveConfigAsPropertyFile[Config](
@@ -258,9 +287,9 @@ package object pureconfig {
   /**
    * Writes the configuration to the output stream and closes the stream
    *
-   * @param conf The configuration to write
+   * @param conf         The configuration to write
    * @param outputStream The stream in which the configuration should be written
-   * @param options the config rendering options
+   * @param options      the config rendering options
    */
   def saveConfigToStream[Config](
     conf: Config,
@@ -285,19 +314,19 @@ package object pureconfig {
    * defined by the `failOnReadError` flag. With `failOnReadError = false`, such files will silently be ignored while
    * otherwise they would yield a failure (a `Left` value).
    *
-   * @param files Files ordered in decreasing priority containing part or all of a `Config`
+   * @param files           Files ordered in decreasing priority containing part or all of a `Config`
    * @param failOnReadError Where to return an error if any files fail to read
-   * @param namespace the base namespace from which the configuration should be load
+   * @param namespace       the base namespace from which the configuration should be load
    */
-  def loadConfigFromFiles[Config](files: Traversable[Path], failOnReadError: Boolean = false, namespace: String = "")(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] = {
+  def loadConfigFromFiles[Config](files: Traversable[Path], failOnReadError: Boolean = false, namespace: String = "")(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
     files.map(parseFile)
       .map {
         case Left(failures) if failures.toList.exists(_.isInstanceOf[CannotReadFile]) && !failOnReadError =>
           Right(ConfigFactory.empty())
         case conf => conf
       }
-      .foldLeft[Either[ConfigReaderFailures, TypesafeConfig]](Right(ConfigFactory.empty())) {
-        case (c1, c2) => ConfigConvert.combineResults(c1, c2)(_.withFallback(_))
+      .foldLeft[ReaderResult[TypesafeConfig]](Right(ConfigFactory.empty())) {
+        case (c1, c2) => ReaderResult.zipWith(c1, c2)(_.withFallback(_))
       }
       .right.flatMap { conf => loadConfig[Config](conf.resolve, namespace) }
   }

--- a/core/src/main/scala/pureconfig/syntax/package.scala
+++ b/core/src/main/scala/pureconfig/syntax/package.scala
@@ -10,7 +10,7 @@ package object syntax {
     def toConfig(implicit writer: Derivation[ConfigWriter[T]]): ConfigValue = writer.value.to(any)
   }
 
-  private def getResultOrThrow[Config](failuresOrResult: ReaderResult[Config])(implicit ct: ClassTag[Config]): Config = {
+  private def getResultOrThrow[Config](failuresOrResult: ConfigReader.Result[Config])(implicit ct: ClassTag[Config]): Config = {
     failuresOrResult match {
       case Right(config) => config
       case Left(failures) => throw new ConfigReaderException[Config](failures)
@@ -18,17 +18,17 @@ package object syntax {
   }
 
   implicit class ConfigValueReaderOps(val conf: ConfigValue) extends AnyVal {
-    def to[T](implicit reader: Derivation[ConfigReader[T]]): ReaderResult[T] = reader.value.from(conf)
+    def to[T](implicit reader: Derivation[ConfigReader[T]]): ConfigReader.Result[T] = reader.value.from(conf)
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(reader.value.from(conf))(cl)
   }
 
   implicit class ConfigCursorReaderOps(val cur: ConfigCursor) extends AnyVal {
-    def to[T](implicit reader: Derivation[ConfigReader[T]]): ReaderResult[T] = reader.value.from(cur)
+    def to[T](implicit reader: Derivation[ConfigReader[T]]): ConfigReader.Result[T] = reader.value.from(cur)
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(reader.value.from(cur))(cl)
   }
 
   implicit class ConfigReaderOps(val conf: TypesafeConfig) extends AnyVal {
-    def to[T](implicit reader: Derivation[ConfigReader[T]]): ReaderResult[T] = conf.root().to[T]
+    def to[T](implicit reader: Derivation[ConfigReader[T]]): ConfigReader.Result[T] = conf.root().to[T]
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(conf.root().to[T])(cl)
   }
 }

--- a/core/src/main/scala/pureconfig/syntax/package.scala
+++ b/core/src/main/scala/pureconfig/syntax/package.scala
@@ -1,7 +1,7 @@
 package pureconfig
 
 import com.typesafe.config.{ ConfigValue, Config => TypesafeConfig }
-import pureconfig.error.{ ConfigReaderException, ConfigReaderFailures }
+import pureconfig.error.ConfigReaderException
 
 import scala.reflect.ClassTag
 
@@ -10,7 +10,7 @@ package object syntax {
     def toConfig(implicit writer: Derivation[ConfigWriter[T]]): ConfigValue = writer.value.to(any)
   }
 
-  private def getResultOrThrow[Config](failuresOrResult: Either[ConfigReaderFailures, Config])(implicit ct: ClassTag[Config]): Config = {
+  private def getResultOrThrow[Config](failuresOrResult: ReaderResult[Config])(implicit ct: ClassTag[Config]): Config = {
     failuresOrResult match {
       case Right(config) => config
       case Left(failures) => throw new ConfigReaderException[Config](failures)
@@ -18,17 +18,17 @@ package object syntax {
   }
 
   implicit class ConfigValueReaderOps(val conf: ConfigValue) extends AnyVal {
-    def to[T](implicit reader: Derivation[ConfigReader[T]]): Either[ConfigReaderFailures, T] = reader.value.from(conf)
+    def to[T](implicit reader: Derivation[ConfigReader[T]]): ReaderResult[T] = reader.value.from(conf)
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(reader.value.from(conf))(cl)
   }
 
   implicit class ConfigCursorReaderOps(val cur: ConfigCursor) extends AnyVal {
-    def to[T](implicit reader: Derivation[ConfigReader[T]]): Either[ConfigReaderFailures, T] = reader.value.from(cur)
+    def to[T](implicit reader: Derivation[ConfigReader[T]]): ReaderResult[T] = reader.value.from(cur)
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(reader.value.from(cur))(cl)
   }
 
   implicit class ConfigReaderOps(val conf: TypesafeConfig) extends AnyVal {
-    def to[T](implicit reader: Derivation[ConfigReader[T]]): Either[ConfigReaderFailures, T] = conf.root().to[T]
+    def to[T](implicit reader: Derivation[ConfigReader[T]]): ReaderResult[T] = conf.root().to[T]
     def toOrThrow[T](implicit reader: Derivation[ConfigReader[T]], cl: ClassTag[T]): T = getResultOrThrow(conf.root().to[T])(cl)
   }
 }

--- a/docs/src/main/tut/docs/complex-types.md
+++ b/docs/src/main/tut/docs/complex-types.md
@@ -96,12 +96,11 @@ Similarly to adding support for simple types, it is possible to manually create 
 
 ```tut:silent
 import pureconfig._
-import pureconfig.error._
 
 val class1Reader = ConfigReader.forProduct1("id")(new Class1(_))
 val class2Reader = ConfigReader.forProduct2("id", "value")(new Class2(_, _))
 
-def extractByType(typ: String, objCur: ConfigObjectCursor): Either[ConfigReaderFailures, Identifiable] = typ match {
+def extractByType(typ: String, objCur: ConfigObjectCursor): ReaderResult[Identifiable] = typ match {
   case "class1" => class1Reader.from(objCur)
   case "class2" => class2Reader.from(objCur)
   case t =>

--- a/docs/src/main/tut/docs/complex-types.md
+++ b/docs/src/main/tut/docs/complex-types.md
@@ -100,7 +100,7 @@ import pureconfig._
 val class1Reader = ConfigReader.forProduct1("id")(new Class1(_))
 val class2Reader = ConfigReader.forProduct2("id", "value")(new Class2(_, _))
 
-def extractByType(typ: String, objCur: ConfigObjectCursor): ReaderResult[Identifiable] = typ match {
+def extractByType(typ: String, objCur: ConfigObjectCursor): ConfigReader.Result[Identifiable] = typ match {
   case "class1" => class1Reader.from(objCur)
   case "class2" => class2Reader.from(objCur)
   case t =>

--- a/docs/src/main/tut/docs/config-cursors.md
+++ b/docs/src/main/tut/docs/config-cursors.md
@@ -9,7 +9,7 @@ When a `ConfigReader` needs to be created from scratch, users need to implement 
 signature:
 
 ```scala
-def from(cur: ConfigCursor): ReaderResult[A]
+def from(cur: ConfigCursor): ConfigReader.Result[A]
 ```
 
 The `ConfigCursor` class is a wrapper for the raw `ConfigValue` provided by Typesafe Config. It provides an idiomatic,
@@ -59,7 +59,7 @@ implicit val personReader = ConfigReader.fromCursor[Person] { cur =>
 ```
 
 The factory method `ConfigReader.fromCursor` allows us to create a `ConfigReader` without much boilerplate by providing
-the required `ConfigCursor => ReaderResult[A]` function. Since most methods in the cursor API return
+the required `ConfigCursor => ConfigReader.Result[A]` function. Since most methods in the cursor API return
 `Either` values with failures at their left side,
 [for comprehensions](https://docs.scala-lang.org/tour/for-comprehensions.html) are a natural fit (note that on Scala
 2.11 and below you need to add `.right` projections at the end of each `Either` result). Let's analyze the lines

--- a/docs/src/main/tut/docs/config-cursors.md
+++ b/docs/src/main/tut/docs/config-cursors.md
@@ -9,7 +9,7 @@ When a `ConfigReader` needs to be created from scratch, users need to implement 
 signature:
 
 ```scala
-def from(cur: ConfigCursor): Either[ConfigReaderFailures, A]
+def from(cur: ConfigCursor): ReaderResult[A]
 ```
 
 The `ConfigCursor` class is a wrapper for the raw `ConfigValue` provided by Typesafe Config. It provides an idiomatic,
@@ -59,7 +59,7 @@ implicit val personReader = ConfigReader.fromCursor[Person] { cur =>
 ```
 
 The factory method `ConfigReader.fromCursor` allows us to create a `ConfigReader` without much boilerplate by providing
-the required `ConfigCursor => Either[ConfigReaderFailures, A]` function. Since most methods in the cursor API return
+the required `ConfigCursor => ReaderResult[A]` function. Since most methods in the cursor API return
 `Either` values with failures at their left side,
 [for comprehensions](https://docs.scala-lang.org/tour/for-comprehensions.html) are a natural fit (note that on Scala
 2.11 and below you need to add `.right` projections at the end of each `Either` result). Let's analyze the lines

--- a/docs/src/main/tut/docs/error-handling.md
+++ b/docs/src/main/tut/docs/error-handling.md
@@ -6,8 +6,8 @@ title: Error Handling
 ## {{page.title}}
 
 PureConfig features a rich error model used on reading operations. Most PureConfig methods that read Scala types from
-configurations return an `Either[ConfigReaderFailures, A]`, with `A` being the type of a successful result and
-`ConfigReaderFailures` being a non-empty list of errors that caused the reading operation to fail.
+configurations return a `ReaderResult[A]` - an alias for `Either[ConfigReaderFailures, A]`, with `A` being the type of a
+successful result and `ConfigReaderFailures` being a non-empty list of errors that caused the reading operation to fail.
 
 From the various types of `ConfigReaderFailure`, one of them is of particular interest: a `ConvertFailure` is an error
 occurred during the conversion process itself. It features a reason (`FailureReason`), an optional location in the

--- a/docs/src/main/tut/docs/error-handling.md
+++ b/docs/src/main/tut/docs/error-handling.md
@@ -6,7 +6,7 @@ title: Error Handling
 ## {{page.title}}
 
 PureConfig features a rich error model used on reading operations. Most PureConfig methods that read Scala types from
-configurations return a `ReaderResult[A]` - an alias for `Either[ConfigReaderFailures, A]`, with `A` being the type of a
+configurations return a `ConfigReader.Result[A]` - an alias for `Either[ConfigReaderFailures, A]`, with `A` being the type of a
 successful result and `ConfigReaderFailures` being a non-empty list of errors that caused the reading operation to fail.
 
 From the various types of `ConfigReaderFailure`, one of them is of particular interest: a `ConvertFailure` is an error

--- a/docs/src/main/tut/docs/index.md
+++ b/docs/src/main/tut/docs/index.md
@@ -45,6 +45,9 @@ Finally, load the configuration:
 pureconfig.loadConfig[MyClass]
 ```
 
+`ReaderResult[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
+would handle an `Either` value.
+
 The various `loadConfig` methods defer to Typesafe Config's
 [`ConfigFactory`](https://lightbend.github.io/config/latest/api/com/typesafe/config/ConfigFactory.html) to
 select where to load the config files from. Typesafe Config has [well-documented rules for configuration

--- a/docs/src/main/tut/docs/index.md
+++ b/docs/src/main/tut/docs/index.md
@@ -45,7 +45,7 @@ Finally, load the configuration:
 pureconfig.loadConfig[MyClass]
 ```
 
-`ReaderResult[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
+`ConfigReader.Result[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
 would handle an `Either` value.
 
 The various `loadConfig` methods defer to Typesafe Config's

--- a/modules/akka/README.md
+++ b/modules/akka/README.md
@@ -34,7 +34,7 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"actor-path":"akka://my-sys/user/service-a/worker1","timeout":"5 seconds"}))
 
 loadConfig[MyConfig](conf)
-// res0: Either[pureconfig.error.ConfigReaderFailures,MyConfig] = Right(MyConfig(Timeout(5 seconds),akka://my-sys/user/service-a/worker1))
+// res0: pureconfig.ReaderResult[MyConfig] = Right(MyConfig(Timeout(5 seconds),akka://my-sys/user/service-a/worker1))
 ```
 
 

--- a/modules/akka/README.md
+++ b/modules/akka/README.md
@@ -34,7 +34,7 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"actor-path":"akka://my-sys/user/service-a/worker1","timeout":"5 seconds"}))
 
 loadConfig[MyConfig](conf)
-// res0: pureconfig.ReaderResult[MyConfig] = Right(MyConfig(Timeout(5 seconds),akka://my-sys/user/service-a/worker1))
+// res0: pureconfig.ConfigReader.Result[MyConfig] = Right(MyConfig(Timeout(5 seconds),akka://my-sys/user/service-a/worker1))
 ```
 
 

--- a/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/package.scala
+++ b/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/package.scala
@@ -10,14 +10,14 @@ import cats.data.NonEmptyList
 import cats.effect.Sync
 import cats.implicits._
 import com.typesafe.config.{ ConfigRenderOptions, Config => TypesafeConfig }
-import pureconfig.error.{ ConfigReaderException, ConfigReaderFailures }
-import pureconfig.{ ConfigReader, ConfigWriter, Derivation }
+import pureconfig._
+import pureconfig.error.ConfigReaderException
 
 package object catseffect {
 
   private val defaultNameSpace = ""
 
-  private def configToF[F[_], A](getConfig: () => Either[ConfigReaderFailures, A])(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] = {
+  private def configToF[F[_], A](getConfig: () => ReaderResult[A])(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] = {
     val delayedLoad = F.delay {
       getConfig().leftMap[Throwable](ConfigReaderException[A])
     }

--- a/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/package.scala
+++ b/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/package.scala
@@ -17,7 +17,7 @@ package object catseffect {
 
   private val defaultNameSpace = ""
 
-  private def configToF[F[_], A](getConfig: () => ReaderResult[A])(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] = {
+  private def configToF[F[_], A](getConfig: () => ConfigReader.Result[A])(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] = {
     val delayedLoad = F.delay {
       getConfig().leftMap[Throwable](ConfigReaderException[A])
     }

--- a/modules/cats/README.md
+++ b/modules/cats/README.md
@@ -54,7 +54,7 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"number-list":[1,2,3],"number-map":{"one":1,"three":3,"two":2},"number-set":[1,2,3],"number-vector":[1,2,3]}))
 
 loadConfig[MyConfig](conf)
-// res0: Either[pureconfig.error.ConfigReaderFailures,MyConfig] = Right(MyConfig(NonEmptyList(1, 2, 3),TreeSet(1, 2, 3),NonEmptyVector(1, 2, 3),Map(one -> 1, three -> 3, two -> 2)))
+// res0: pureconfig.ReaderResult[MyConfig] = Right(MyConfig(NonEmptyList(1, 2, 3),TreeSet(1, 2, 3),NonEmptyVector(1, 2, 3),Map(one -> 1, three -> 3, two -> 2)))
 ```
 
 ### Using cats type class instances for readers and writers
@@ -85,10 +85,10 @@ And we can finally put them to use:
 
 ```scala
 constIntReader.from(conf.root())
-// res4: Either[pureconfig.error.ConfigReaderFailures,Int] = Right(42)
+// res4: pureconfig.ReaderResult[Int] = Right(42)
 
 safeIntReader.from(conf.root())
-// res5: Either[pureconfig.error.ConfigReaderFailures,Int] = Right(-1)
+// res5: pureconfig.ReaderResult[Int] = Right(-1)
 
 someWriter[String].to(Some("abc"))
 // res6: com.typesafe.config.ConfigValue = Quoted("abc")

--- a/modules/cats/README.md
+++ b/modules/cats/README.md
@@ -54,7 +54,7 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"number-list":[1,2,3],"number-map":{"one":1,"three":3,"two":2},"number-set":[1,2,3],"number-vector":[1,2,3]}))
 
 loadConfig[MyConfig](conf)
-// res0: pureconfig.ReaderResult[MyConfig] = Right(MyConfig(NonEmptyList(1, 2, 3),TreeSet(1, 2, 3),NonEmptyVector(1, 2, 3),Map(one -> 1, three -> 3, two -> 2)))
+// res0: pureconfig.ConfigReader.Result[MyConfig] = Right(MyConfig(NonEmptyList(1, 2, 3),TreeSet(1, 2, 3),NonEmptyVector(1, 2, 3),Map(one -> 1, three -> 3, two -> 2)))
 ```
 
 ### Using cats type class instances for readers and writers
@@ -85,10 +85,10 @@ And we can finally put them to use:
 
 ```scala
 constIntReader.from(conf.root())
-// res4: pureconfig.ReaderResult[Int] = Right(42)
+// res4: pureconfig.ConfigReader.Result[Int] = Right(42)
 
 safeIntReader.from(conf.root())
-// res5: pureconfig.ReaderResult[Int] = Right(-1)
+// res5: pureconfig.ConfigReader.Result[Int] = Right(-1)
 
 someWriter[String].to(Some("abc"))
 // res6: com.typesafe.config.ConfigValue = Quoted("abc")

--- a/modules/cats/src/test/scala/pureconfig/module/cats/arbitrary/package.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/arbitrary/package.scala
@@ -3,7 +3,7 @@ package pureconfig.module.cats
 import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
 import org.scalacheck.{ Arbitrary, Cogen, Gen }
 import org.scalacheck.Arbitrary.{ arbitrary => arb }
-import pureconfig.{ ConfigConvert, ConfigReader, ConfigWriter, Derivation, ReaderResult }
+import pureconfig._
 import scala.collection.JavaConverters._
 
 import pureconfig.error.{ ConfigReaderFailures, ConvertFailure }
@@ -49,7 +49,7 @@ package object arbitrary {
     Cogen[String].contramap[ConfigReaderFailures](_.toString)
 
   implicit def arbConfigReader[A: Arbitrary]: Arbitrary[ConfigReader[A]] = Arbitrary {
-    arb[ConfigValue => ReaderResult[A]].map(ConfigReader.fromFunction)
+    arb[ConfigValue => ConfigReader.Result[A]].map(ConfigReader.fromFunction)
   }
 
   implicit def arbConfigWriter[A: Cogen]: Arbitrary[ConfigWriter[A]] = Arbitrary {

--- a/modules/cats/src/test/scala/pureconfig/module/cats/arbitrary/package.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/arbitrary/package.scala
@@ -3,7 +3,7 @@ package pureconfig.module.cats
 import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
 import org.scalacheck.{ Arbitrary, Cogen, Gen }
 import org.scalacheck.Arbitrary.{ arbitrary => arb }
-import pureconfig.{ ConfigConvert, ConfigReader, ConfigWriter, Derivation }
+import pureconfig.{ ConfigConvert, ConfigReader, ConfigWriter, Derivation, ReaderResult }
 import scala.collection.JavaConverters._
 
 import pureconfig.error.{ ConfigReaderFailures, ConvertFailure }
@@ -49,7 +49,7 @@ package object arbitrary {
     Cogen[String].contramap[ConfigReaderFailures](_.toString)
 
   implicit def arbConfigReader[A: Arbitrary]: Arbitrary[ConfigReader[A]] = Arbitrary {
-    arb[ConfigValue => Either[ConfigReaderFailures, A]].map(ConfigReader.fromFunction)
+    arb[ConfigValue => ReaderResult[A]].map(ConfigReader.fromFunction)
   }
 
   implicit def arbConfigWriter[A: Cogen]: Arbitrary[ConfigWriter[A]] = Arbitrary {

--- a/modules/cats/src/test/scala/pureconfig/module/cats/eq/package.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/eq/package.scala
@@ -13,7 +13,7 @@ import pureconfig.module.cats.instances._
 package object eq {
 
   implicit def configReaderEq[A: Eq]: Eq[ConfigReader[A]] =
-    Eq.by[ConfigReader[A], ConfigValue => ReaderResult[A]](_.from)
+    Eq.by[ConfigReader[A], ConfigValue => ConfigReader.Result[A]](_.from)
 
   implicit def configWriterEq[A: Arbitrary]: Eq[ConfigWriter[A]] =
     Eq.by[ConfigWriter[A], A => ConfigValue](_.to)

--- a/modules/cats/src/test/scala/pureconfig/module/cats/eq/package.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/eq/package.scala
@@ -7,14 +7,13 @@ import cats.laws.discipline.eq._
 import com.typesafe.config.ConfigValue
 import org.scalacheck.Arbitrary
 import pureconfig._
-import pureconfig.error.ConfigReaderFailures
 import pureconfig.module.cats.arbitrary._
 import pureconfig.module.cats.instances._
 
 package object eq {
 
   implicit def configReaderEq[A: Eq]: Eq[ConfigReader[A]] =
-    Eq.by[ConfigReader[A], ConfigValue => Either[ConfigReaderFailures, A]](_.from)
+    Eq.by[ConfigReader[A], ConfigValue => ReaderResult[A]](_.from)
 
   implicit def configWriterEq[A: Arbitrary]: Eq[ConfigWriter[A]] =
     Eq.by[ConfigWriter[A], A => ConfigValue](_.to)

--- a/modules/enum/README.md
+++ b/modules/enum/README.md
@@ -51,7 +51,7 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"end":"ShoutGoodBye","start":"WhisperHello"}))
 
 loadConfig[GreetingConf](conf)
-// res0: Either[pureconfig.error.ConfigReaderFailures,GreetingConf] = Right(GreetingConf(WhisperHello,ShoutGoodBye))
+// res0: pureconfig.ReaderResult[GreetingConf] = Right(GreetingConf(WhisperHello,ShoutGoodBye))
 ```
 
 ## Can I configure how the elements are read?

--- a/modules/enum/README.md
+++ b/modules/enum/README.md
@@ -51,7 +51,7 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"end":"ShoutGoodBye","start":"WhisperHello"}))
 
 loadConfig[GreetingConf](conf)
-// res0: pureconfig.ReaderResult[GreetingConf] = Right(GreetingConf(WhisperHello,ShoutGoodBye))
+// res0: pureconfig.ConfigReader.Result[GreetingConf] = Right(GreetingConf(WhisperHello,ShoutGoodBye))
 ```
 
 ## Can I configure how the elements are read?

--- a/modules/enumeratum/README.md
+++ b/modules/enumeratum/README.md
@@ -53,7 +53,7 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"end":"SHOUT_GOOD_BYE","start":"hello"}))
 
 loadConfig[GreetingConf](conf)
-// res0: pureconfig.ReaderResult[GreetingConf] = Right(GreetingConf(Hello,ShoutGoodBye))
+// res0: pureconfig.ConfigReader.Result[GreetingConf] = Right(GreetingConf(Hello,ShoutGoodBye))
 ```
 
 Note that Enumeratum has a variety of [other ways to define enums](https://github.com/lloydmeta/enumeratum#more-examples) which are [also supported by `pureconfig-enumeratum`](src/test/scala/pureconfig/module/enumeratum/EnumeratumConvertTest.scala). If you need to read integers, another numeric type, or arbitrary strings to specify your enum values, Enumeratum and Pureconfig have you covered.

--- a/modules/enumeratum/README.md
+++ b/modules/enumeratum/README.md
@@ -53,7 +53,7 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"end":"SHOUT_GOOD_BYE","start":"hello"}))
 
 loadConfig[GreetingConf](conf)
-// res0: Either[pureconfig.error.ConfigReaderFailures,GreetingConf] = Right(GreetingConf(Hello,ShoutGoodBye))
+// res0: pureconfig.ReaderResult[GreetingConf] = Right(GreetingConf(Hello,ShoutGoodBye))
 ```
 
 Note that Enumeratum has a variety of [other ways to define enums](https://github.com/lloydmeta/enumeratum#more-examples) which are [also supported by `pureconfig-enumeratum`](src/test/scala/pureconfig/module/enumeratum/EnumeratumConvertTest.scala). If you need to read integers, another numeric type, or arbitrary strings to specify your enum values, Enumeratum and Pureconfig have you covered.

--- a/modules/generic/src/main/scala/pureconfig/generic/CoproductHint.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/CoproductHint.scala
@@ -1,7 +1,7 @@
 package pureconfig.generic
 
 import com.typesafe.config.{ ConfigFactory, ConfigObject, ConfigValue, ConfigValueType }
-import pureconfig.{ ConfigCursor, ReaderResult }
+import pureconfig._
 import pureconfig.error._
 import pureconfig.syntax._
 
@@ -25,7 +25,7 @@ trait CoproductHint[T] {
    * @param name the name of the class or coproduct option to try
    * @return a `Either[ConfigReaderFailure, Option[ConfigValue]]` as defined above.
    */
-  def from(cur: ConfigCursor, name: String): ReaderResult[Option[ConfigCursor]]
+  def from(cur: ConfigCursor, name: String): ConfigReader.Result[Option[ConfigCursor]]
 
   /**
    * Given the `ConfigValue` for a specific class or coproduct option, encode disambiguation information and return a
@@ -36,7 +36,7 @@ trait CoproductHint[T] {
    * @return the config for the sealed family or coproduct wrapped in a `Right`, or a `Left` with the failure if some error
    *         occurred.
    */
-  def to(cv: ConfigValue, name: String): ReaderResult[ConfigValue]
+  def to(cv: ConfigValue, name: String): ConfigReader.Result[ConfigValue]
 
   /**
    * Defines what to do if `from` returns `Success(Some(_))` for a class or coproduct option, but its `ConfigConvert`
@@ -67,7 +67,7 @@ class FieldCoproductHint[T](key: String) extends CoproductHint[T] {
    */
   protected def fieldValue(name: String): String = name.toLowerCase
 
-  def from(cur: ConfigCursor, name: String): ReaderResult[Option[ConfigCursor]] = {
+  def from(cur: ConfigCursor, name: String): ConfigReader.Result[Option[ConfigCursor]] = {
     for {
       objCur <- cur.asObjectCursor.right
       valueCur <- objCur.atKey(key).right
@@ -76,7 +76,7 @@ class FieldCoproductHint[T](key: String) extends CoproductHint[T] {
   }
 
   // TODO: improve handling of failures on the write side
-  def to(cv: ConfigValue, name: String): ReaderResult[ConfigValue] = cv match {
+  def to(cv: ConfigValue, name: String): ConfigReader.Result[ConfigValue] = cv match {
     case co: ConfigObject =>
       if (co.containsKey(key)) {
         Left(ConfigReaderFailures(ConvertFailure(CollidingKeys(key, co.get(key)), ConfigValueLocation(co), "")))

--- a/modules/generic/src/main/scala/pureconfig/generic/DerivedConfigReader.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/DerivedConfigReader.scala
@@ -19,7 +19,7 @@ object DerivedConfigReader extends DerivedConfigReader1 {
     unwrapped: Unwrapped.Aux[T, U],
     reader: ConfigReader[U]): DerivedConfigReader[T] = new DerivedConfigReader[T] {
 
-    def from(value: ConfigCursor): ReaderResult[T] =
+    def from(value: ConfigCursor): ConfigReader.Result[T] =
       reader.from(value).right.map(unwrapped.wrap)
   }
 
@@ -47,14 +47,14 @@ object DerivedConfigReader extends DerivedConfigReader1 {
   private[pureconfig] def tupleAsListReader[F: IsTuple, Repr <: HList](cur: ConfigListCursor)(
     implicit
     gen: Generic.Aux[F, Repr],
-    cr: SeqShapedReader[Repr]): ReaderResult[F] =
+    cr: SeqShapedReader[Repr]): ConfigReader.Result[F] =
     cr.from(cur).right.map(gen.from)
 
   private[pureconfig] def tupleAsObjectReader[F: IsTuple, Repr <: HList, DefaultRepr <: HList](cur: ConfigObjectCursor)(
     implicit
     gen: LabelledGeneric.Aux[F, Repr],
     default: Default.AsOptions.Aux[F, DefaultRepr],
-    cr: MapShapedReader.WithDefaults[F, Repr, DefaultRepr]): ReaderResult[F] =
+    cr: MapShapedReader.WithDefaults[F, Repr, DefaultRepr]): ConfigReader.Result[F] =
     cr.fromWithDefault(cur, default()).right.map(gen.from)
 }
 
@@ -66,7 +66,7 @@ trait DerivedConfigReader1 {
     default: Default.AsOptions.Aux[F, DefaultRepr],
     cc: Lazy[MapShapedReader.WithDefaults[F, Repr, DefaultRepr]]): DerivedConfigReader[F] = new DerivedConfigReader[F] {
 
-    override def from(cur: ConfigCursor): ReaderResult[F] = {
+    override def from(cur: ConfigCursor): ConfigReader.Result[F] = {
       cur.asObjectCursor.right.flatMap(cc.value.fromWithDefault(_, default())).right.map(gen.from)
     }
   }
@@ -76,7 +76,7 @@ trait DerivedConfigReader1 {
     gen: LabelledGeneric.Aux[F, Repr],
     cc: Lazy[MapShapedReader[F, Repr]]): DerivedConfigReader[F] = new DerivedConfigReader[F] {
 
-    override def from(cur: ConfigCursor): ReaderResult[F] = {
+    override def from(cur: ConfigCursor): ConfigReader.Result[F] = {
       cc.value.from(cur).right.map(gen.from)
     }
   }

--- a/modules/generic/src/main/scala/pureconfig/generic/MapShapedReader.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/MapShapedReader.scala
@@ -63,7 +63,7 @@ object MapShapedReader {
       // for performance reasons only, we shouldn't clone the config object unless necessary
       val tailCur = if (hint.allowUnknownKeys) cur.withoutKey(keyStr) else cur.withoutKey(keyStr)
       val tailResult = tConfigReader.value.fromWithDefault(tailCur, default.tail)
-      ReaderResult.zipWith(headResult, tailResult)((head, tail) => field[K](head) :: tail)
+      ConfigReader.Result.zipWith(headResult, tailResult)((head, tail) => field[K](head) :: tail)
     }
   }
 

--- a/modules/generic/src/main/scala/pureconfig/generic/MapShapedReader.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/MapShapedReader.scala
@@ -1,6 +1,5 @@
 package pureconfig.generic
 
-import pureconfig.ConvertHelpers._
 import pureconfig._
 import pureconfig.error._
 import shapeless._
@@ -23,14 +22,14 @@ object MapShapedReader {
    * @tparam DefaultRepr the generic representation of the default arguments
    */
   trait WithDefaults[Wrapped, Repr, DefaultRepr] {
-    def fromWithDefault(cur: ConfigObjectCursor, default: DefaultRepr): Either[ConfigReaderFailures, Repr]
+    def fromWithDefault(cur: ConfigObjectCursor, default: DefaultRepr): ReaderResult[Repr]
   }
 
   implicit def labelledHNilReader[Wrapped](
     implicit
     hint: ProductHint[Wrapped]): WithDefaults[Wrapped, HNil, HNil] = new WithDefaults[Wrapped, HNil, HNil] {
 
-    def fromWithDefault(cur: ConfigObjectCursor, default: HNil): Either[ConfigReaderFailures, HNil] = {
+    def fromWithDefault(cur: ConfigObjectCursor, default: HNil): ReaderResult[HNil] = {
       if (!hint.allowUnknownKeys && cur.keys.nonEmpty) {
         val keys = cur.map.toList.map { case (k, keyCur) => keyCur.failureFor(UnknownKey(k)) }
         Left(new ConfigReaderFailures(keys.head, keys.tail))
@@ -47,7 +46,7 @@ object MapShapedReader {
     tConfigReader: Lazy[WithDefaults[Wrapped, T, U]],
     hint: ProductHint[Wrapped]): WithDefaults[Wrapped, FieldType[K, V] :: T, Option[V] :: U] = new WithDefaults[Wrapped, FieldType[K, V] :: T, Option[V] :: U] {
 
-    def fromWithDefault(cur: ConfigObjectCursor, default: Option[V] :: U): Either[ConfigReaderFailures, FieldType[K, V] :: T] = {
+    def fromWithDefault(cur: ConfigObjectCursor, default: Option[V] :: U): ReaderResult[FieldType[K, V] :: T] = {
       val fieldName = key.value.name
       val keyStr = hint.configKey(fieldName)
 
@@ -64,12 +63,12 @@ object MapShapedReader {
       // for performance reasons only, we shouldn't clone the config object unless necessary
       val tailCur = if (hint.allowUnknownKeys) cur.withoutKey(keyStr) else cur.withoutKey(keyStr)
       val tailResult = tConfigReader.value.fromWithDefault(tailCur, default.tail)
-      combineResults(headResult, tailResult)((head, tail) => field[K](head) :: tail)
+      ReaderResult.zipWith(headResult, tailResult)((head, tail) => field[K](head) :: tail)
     }
   }
 
   implicit def cNilReader[Wrapped]: MapShapedReader[Wrapped, CNil] = new MapShapedReader[Wrapped, CNil] {
-    override def from(cur: ConfigCursor): Either[ConfigReaderFailures, CNil] =
+    override def from(cur: ConfigCursor): ReaderResult[CNil] =
       cur.failed(NoValidCoproductChoiceFound(cur.value))
   }
 
@@ -81,7 +80,7 @@ object MapShapedReader {
     tConfigReader: Lazy[MapShapedReader[Wrapped, T]]): MapShapedReader[Wrapped, FieldType[Name, V] :+: T] =
     new MapShapedReader[Wrapped, FieldType[Name, V] :+: T] {
 
-      override def from(cur: ConfigCursor): Either[ConfigReaderFailures, FieldType[Name, V] :+: T] =
+      override def from(cur: ConfigCursor): ReaderResult[FieldType[Name, V] :+: T] =
         coproductHint.from(cur, vName.value.name) match {
           case Right(Some(optCur)) =>
             vFieldConvert.value.value.from(optCur) match {
@@ -92,7 +91,7 @@ object MapShapedReader {
             }
 
           case Right(None) => tConfigReader.value.from(cur).right.map(s => Inr(s))
-          case l: Left[_, _] => l.asInstanceOf[Either[ConfigReaderFailures, FieldType[Name, V] :+: T]]
+          case l: Left[_, _] => l.asInstanceOf[ReaderResult[FieldType[Name, V] :+: T]]
         }
     }
 }

--- a/modules/generic/src/main/scala/pureconfig/generic/SeqShapedReader.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/SeqShapedReader.scala
@@ -1,8 +1,7 @@
 package pureconfig.generic
 
-import pureconfig.ConvertHelpers._
+import pureconfig._
 import pureconfig.error._
-import pureconfig.{ ConfigCursor, ConfigReader, Derivation }
 import shapeless._
 import shapeless.ops.hlist.HKernelAux
 
@@ -16,7 +15,7 @@ trait SeqShapedReader[Repr] extends ConfigReader[Repr]
 object SeqShapedReader {
 
   implicit val hNilReader: SeqShapedReader[HNil] = new SeqShapedReader[HNil] {
-    def from(cur: ConfigCursor): Either[ConfigReaderFailures, HNil] = {
+    def from(cur: ConfigCursor): ReaderResult[HNil] = {
       cur.asList.right.flatMap {
         case Nil => Right(HNil)
         case cl => cur.failed(WrongSizeList(0, cl.size))
@@ -26,7 +25,7 @@ object SeqShapedReader {
 
   implicit def hConsReader[H, T <: HList](implicit hr: Derivation[Lazy[ConfigReader[H]]], tr: Lazy[SeqShapedReader[T]], tl: HKernelAux[T]): SeqShapedReader[H :: T] =
     new SeqShapedReader[H :: T] {
-      def from(cur: ConfigCursor): Either[ConfigReaderFailures, H :: T] = {
+      def from(cur: ConfigCursor): ReaderResult[H :: T] = {
         cur.asListCursor.right.flatMap {
           case listCur if listCur.size != tl().length + 1 =>
             cur.failed(WrongSizeList(tl().length + 1, listCur.size))
@@ -35,7 +34,7 @@ object SeqShapedReader {
             // it's guaranteed that the list cursor is non-empty at this point due to the case above
             val hv = hr.value.value.from(listCur.atIndexOrUndefined(0))
             val tv = tr.value.from(listCur.tailOption.get)
-            combineResults(hv, tv)(_ :: _)
+            ReaderResult.zipWith(hv, tv)(_ :: _)
         }
       }
     }

--- a/modules/generic/src/main/scala/pureconfig/generic/SeqShapedReader.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/SeqShapedReader.scala
@@ -34,7 +34,7 @@ object SeqShapedReader {
             // it's guaranteed that the list cursor is non-empty at this point due to the case above
             val hv = hr.value.value.from(listCur.atIndexOrUndefined(0))
             val tv = tr.value.from(listCur.tailOption.get)
-            ReaderResult.zipWith(hv, tv)(_ :: _)
+            ConfigReader.Result.zipWith(hv, tv)(_ :: _)
         }
       }
     }

--- a/modules/generic/src/main/scala/pureconfig/generic/SeqShapedReader.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/SeqShapedReader.scala
@@ -15,7 +15,7 @@ trait SeqShapedReader[Repr] extends ConfigReader[Repr]
 object SeqShapedReader {
 
   implicit val hNilReader: SeqShapedReader[HNil] = new SeqShapedReader[HNil] {
-    def from(cur: ConfigCursor): ReaderResult[HNil] = {
+    def from(cur: ConfigCursor): ConfigReader.Result[HNil] = {
       cur.asList.right.flatMap {
         case Nil => Right(HNil)
         case cl => cur.failed(WrongSizeList(0, cl.size))
@@ -25,7 +25,7 @@ object SeqShapedReader {
 
   implicit def hConsReader[H, T <: HList](implicit hr: Derivation[Lazy[ConfigReader[H]]], tr: Lazy[SeqShapedReader[T]], tl: HKernelAux[T]): SeqShapedReader[H :: T] =
     new SeqShapedReader[H :: T] {
-      def from(cur: ConfigCursor): ReaderResult[H :: T] = {
+      def from(cur: ConfigCursor): ConfigReader.Result[H :: T] = {
         cur.asListCursor.right.flatMap {
           case listCur if listCur.size != tl().length + 1 =>
             cur.failed(WrongSizeList(tl().length + 1, listCur.size))

--- a/modules/hadoop/README.md
+++ b/modules/hadoop/README.md
@@ -47,5 +47,5 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"path":"hdfs://some.domain/foo/bar.gz"}))
 
 loadConfig[MyConfig](conf)
-// res0: pureconfig.ReaderResult[MyConfig] = Right(MyConfig(hdfs://some.domain/foo/bar.gz))
+// res0: pureconfig.ConfigReader.Result[MyConfig] = Right(MyConfig(hdfs://some.domain/foo/bar.gz))
 ```

--- a/modules/hadoop/README.md
+++ b/modules/hadoop/README.md
@@ -47,5 +47,5 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"path":"hdfs://some.domain/foo/bar.gz"}))
 
 loadConfig[MyConfig](conf)
-// res0: Either[pureconfig.error.ConfigReaderFailures,MyConfig] = Right(MyConfig(hdfs://some.domain/foo/bar.gz))
+// res0: pureconfig.ReaderResult[MyConfig] = Right(MyConfig(hdfs://some.domain/foo/bar.gz))
 ```

--- a/modules/javax/README.md
+++ b/modules/javax/README.md
@@ -30,7 +30,7 @@ val conf = parseString("""{ principal: "userid@tld.REALM" }""")
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"principal":"userid@tld.REALM"}))
 
 loadConfig[MyConfig](conf)
-// res0: Either[pureconfig.error.ConfigReaderFailures,MyConfig] = Right(MyConfig(userid@tld.REALM))
+// res0: pureconfig.ReaderResult[MyConfig] = Right(MyConfig(userid@tld.REALM))
 ```
 
 

--- a/modules/javax/README.md
+++ b/modules/javax/README.md
@@ -30,7 +30,7 @@ val conf = parseString("""{ principal: "userid@tld.REALM" }""")
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"principal":"userid@tld.REALM"}))
 
 loadConfig[MyConfig](conf)
-// res0: pureconfig.ReaderResult[MyConfig] = Right(MyConfig(userid@tld.REALM))
+// res0: pureconfig.ConfigReader.Result[MyConfig] = Right(MyConfig(userid@tld.REALM))
 ```
 
 

--- a/modules/joda/README.md
+++ b/modules/joda/README.md
@@ -51,7 +51,7 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"apollo":"1969-07-20T20:18:00.000Z","pluto":"2021-01-20T06:59:59.999Z"}))
 
 loadConfig[GreatDatesConfig](conf)
-// res0: Either[pureconfig.error.ConfigReaderFailures,GreatDatesConfig] = Right(GreatDatesConfig(1969-07-20T20:18:00.000Z,2021-01-20T06:59:59.999Z))
+// res0: pureconfig.ReaderResult[GreatDatesConfig] = Right(GreatDatesConfig(1969-07-20T20:18:00.000Z,2021-01-20T06:59:59.999Z))
 ```
 
 Note that you'll need to configure a separate converter for each of the Joda Time types that you want to load from your configuration.  For example, call `localDateConfigConvert` to support `LocalDateTime`. Most of the Joda Time types are supported by methods with likewise unsurprising names in the [`joda.configurable` package](src/main/scala/pureconfig/module/joda/configurable/package.scala).

--- a/modules/joda/README.md
+++ b/modules/joda/README.md
@@ -51,7 +51,7 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"apollo":"1969-07-20T20:18:00.000Z","pluto":"2021-01-20T06:59:59.999Z"}))
 
 loadConfig[GreatDatesConfig](conf)
-// res0: pureconfig.ReaderResult[GreatDatesConfig] = Right(GreatDatesConfig(1969-07-20T20:18:00.000Z,2021-01-20T06:59:59.999Z))
+// res0: pureconfig.ConfigReader.Result[GreatDatesConfig] = Right(GreatDatesConfig(1969-07-20T20:18:00.000Z,2021-01-20T06:59:59.999Z))
 ```
 
 Note that you'll need to configure a separate converter for each of the Joda Time types that you want to load from your configuration.  For example, call `localDateConfigConvert` to support `LocalDateTime`. Most of the Joda Time types are supported by methods with likewise unsurprising names in the [`joda.configurable` package](src/main/scala/pureconfig/module/joda/configurable/package.scala).

--- a/modules/scala-xml/README.md
+++ b/modules/scala-xml/README.md
@@ -36,7 +36,7 @@ val conf = parseString(
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"people":"<people>\n      <person firstName=\"A\" lastName=\"Person\" />\n      <person firstName=\"Another\" lastName=\"Person\" />\n    </people>"}))
 
 loadConfig[Config](conf)
-// res0: pureconfig.ReaderResult[Config] =
+// res0: pureconfig.ConfigReader.Result[Config] =
 // Right(Config(<people>
 //       <person lastName="Person" firstName="A"/>
 //       <person lastName="Person" firstName="Another"/>

--- a/modules/scala-xml/README.md
+++ b/modules/scala-xml/README.md
@@ -36,7 +36,7 @@ val conf = parseString(
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"people":"<people>\n      <person firstName=\"A\" lastName=\"Person\" />\n      <person firstName=\"Another\" lastName=\"Person\" />\n    </people>"}))
 
 loadConfig[Config](conf)
-// res0: Either[pureconfig.error.ConfigReaderFailures,Config] =
+// res0: pureconfig.ReaderResult[Config] =
 // Right(Config(<people>
 //       <person lastName="Person" firstName="A"/>
 //       <person lastName="Person" firstName="Another"/>

--- a/modules/squants/README.md
+++ b/modules/squants/README.md
@@ -39,5 +39,5 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"far":"42.195 km","hot":"56.7° C"}))
 
 loadConfig[HowConfiguration](conf)
-// res0: pureconfig.ReaderResult[HowConfiguration] = Right(HowConfiguration(42.195 km,56.7°C))
+// res0: pureconfig.ConfigReader.Result[HowConfiguration] = Right(HowConfiguration(42.195 km,56.7°C))
 ```

--- a/modules/squants/README.md
+++ b/modules/squants/README.md
@@ -39,5 +39,5 @@ val conf = parseString("""{
 // conf: com.typesafe.config.Config = Config(SimpleConfigObject({"far":"42.195 km","hot":"56.7° C"}))
 
 loadConfig[HowConfiguration](conf)
-// res0: Either[pureconfig.error.ConfigReaderFailures,HowConfiguration] = Right(HowConfiguration(42.195 km,56.7°C))
+// res0: pureconfig.ReaderResult[HowConfiguration] = Right(HowConfiguration(42.195 km,56.7°C))
 ```

--- a/modules/yaml/README.md
+++ b/modules/yaml/README.md
@@ -45,5 +45,5 @@ We can load the configuration to a `MyConf` instance using `loadYaml`:
 
 ```scala
 loadYaml[Person](yamlFile)
-// res1: pureconfig.ReaderResult[Person] = Right(Person(John,42,List(Person(Sarah,7,List()), Person(Andy,10,List()))))
+// res1: pureconfig.ConfigReader.Result[Person] = Right(Person(John,42,List(Person(Sarah,7,List()), Person(Andy,10,List()))))
 ```

--- a/modules/yaml/README.md
+++ b/modules/yaml/README.md
@@ -45,5 +45,5 @@ We can load the configuration to a `MyConf` instance using `loadYaml`:
 
 ```scala
 loadYaml[Person](yamlFile)
-// res1: Either[pureconfig.error.ConfigReaderFailures,Person] = Right(Person(John,42,List(Person(Sarah,7,List()), Person(Andy,10,List()))))
+// res1: pureconfig.ReaderResult[Person] = Right(Person(John,42,List(Person(Sarah,7,List()), Person(Andy,10,List()))))
 ```

--- a/modules/yaml/src/main/scala/pureconfig/module/yaml/package.scala
+++ b/modules/yaml/src/main/scala/pureconfig/module/yaml/package.scala
@@ -21,26 +21,26 @@ package object yaml {
 
   // Converts an object created by SnakeYAML to a Typesafe `ConfigValue`.
   // (https://bitbucket.org/asomov/snakeyaml/wiki/Documentation#markdown-header-loading-yaml)
-  private[this] def yamlObjToConfigValue(obj: AnyRef): ReaderResult[ConfigValue] = {
+  private[this] def yamlObjToConfigValue(obj: AnyRef): ConfigReader.Result[ConfigValue] = {
 
-    def aux(obj: AnyRef): ReaderResult[AnyRef] = obj match {
+    def aux(obj: AnyRef): ConfigReader.Result[AnyRef] = obj match {
       case m: java.util.Map[AnyRef @unchecked, AnyRef @unchecked] =>
         val entries = m.asScala.map {
           case (k: String, v) => aux(v).right.map { v: AnyRef => k -> v }
           case (k, _) => Left(ConfigReaderFailures(NonStringKeyFound(k.toString, k.getClass.getSimpleName)))
         }
         entries
-          .foldLeft(Right(Map.empty): ReaderResult[Map[String, AnyRef]])(ReaderResult.zipWith(_, _)(_ + _))
+          .foldLeft(Right(Map.empty): ConfigReader.Result[Map[String, AnyRef]])(ReaderResult.zipWith(_, _)(_ + _))
           .right.map(_.asJava)
 
       case xs: java.util.List[AnyRef @unchecked] =>
         xs.asScala.map(aux)
-          .foldRight(Right(Nil): ReaderResult[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
+          .foldRight(Right(Nil): ConfigReader.Result[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
           .right.map(_.asJava)
 
       case s: java.util.Set[AnyRef @unchecked] =>
         s.asScala.map(aux)
-          .foldLeft(Right(Set.empty): ReaderResult[Set[AnyRef]])(ReaderResult.zipWith(_, _)(_ + _))
+          .foldLeft(Right(Set.empty): ConfigReader.Result[Set[AnyRef]])(ReaderResult.zipWith(_, _)(_ + _))
           .right.map(_.asJava)
 
       case _: java.lang.Integer | _: java.lang.Long | _: java.lang.Double | _: java.lang.String | _: java.lang.Boolean =>
@@ -73,7 +73,7 @@ package object yaml {
   }
 
   // Opens and processes a YAML file, converting all exceptions into the most appropriate PureConfig errors.
-  private[this] def handleYamlErrors[A](path: Option[Path])(block: => ReaderResult[A]): ReaderResult[A] = {
+  private[this] def handleYamlErrors[A](path: Option[Path])(block: => ConfigReader.Result[A]): ConfigReader.Result[A] = {
     try block
     catch {
       case ex: IOException if path.isDefined => Left(ConfigReaderFailures(CannotReadFile(path.get, Some(ex))))
@@ -91,7 +91,7 @@ package object yaml {
    * @return A `Success` with the configuration if it is possible to create an instance of type
    *         `Config` from the YAML file, else a `Failure` with details on why it isn't possible
    */
-  def loadYaml[Config](path: Path)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
+  def loadYaml[Config](path: Path)(implicit reader: Derivation[ConfigReader[Config]]): ConfigReader.Result[Config] = {
     handleYamlErrors(Some(path)) {
       using(Files.newBufferedReader(path)) { ioReader =>
         // we are using `SafeConstructor` in order to avoid creating custom Java instances, leaking the PureConfig
@@ -112,7 +112,7 @@ package object yaml {
    * @return A `Success` with the configuration if it is possible to create an instance of type
    *         `Config` from `content`, else a `Failure` with details on why it isn't possible
    */
-  def loadYaml[Config](content: String)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
+  def loadYaml[Config](content: String)(implicit reader: Derivation[ConfigReader[Config]]): ConfigReader.Result[Config] = {
     handleYamlErrors(None) {
       // we are using `SafeConstructor` in order to avoid creating custom Java instances, leaking the PureConfig
       // abstraction over SnakeYAML
@@ -161,7 +161,7 @@ package object yaml {
    *         `Config` from the multi-document YAML file, else a `Failure` with details on why it
    *         isn't possible
    */
-  def loadYamls[Config](path: Path)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
+  def loadYamls[Config](path: Path)(implicit reader: Derivation[ConfigReader[Config]]): ConfigReader.Result[Config] = {
     handleYamlErrors(Some(path)) {
       using(Files.newBufferedReader(path)) { ioReader =>
         // we are using `SafeConstructor` in order to avoid creating custom Java instances, leaking the PureConfig
@@ -169,7 +169,7 @@ package object yaml {
         val yamlObjs = new Yaml(new SafeConstructor()).loadAll(ioReader)
 
         yamlObjs.asScala.map(yamlObjToConfigValue)
-          .foldRight(Right(Nil): ReaderResult[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
+          .foldRight(Right(Nil): ConfigReader.Result[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
           .right.flatMap { cvs =>
             val cl = ConfigValueFactory.fromAnyRef(cvs.asJava)
             reader.value.from(ConfigCursor(cl, Nil))
@@ -187,14 +187,14 @@ package object yaml {
    *         `Config` from the multi-document string, else a `Failure` with details on why it
    *         isn't possible
    */
-  def loadYamls[Config](content: String)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
+  def loadYamls[Config](content: String)(implicit reader: Derivation[ConfigReader[Config]]): ConfigReader.Result[Config] = {
     handleYamlErrors(None) {
       // we are using `SafeConstructor` in order to avoid creating custom Java instances, leaking the PureConfig
       // abstraction over SnakeYAML
       val yamlObjs = new Yaml(new SafeConstructor()).loadAll(content)
 
       yamlObjs.asScala.map(yamlObjToConfigValue)
-        .foldRight(Right(Nil): ReaderResult[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
+        .foldRight(Right(Nil): ConfigReader.Result[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
         .right.flatMap { cvs =>
           val cl = ConfigValueFactory.fromAnyRef(cvs.asJava)
           reader.value.from(ConfigCursor(cl, Nil))

--- a/modules/yaml/src/main/scala/pureconfig/module/yaml/package.scala
+++ b/modules/yaml/src/main/scala/pureconfig/module/yaml/package.scala
@@ -30,17 +30,17 @@ package object yaml {
           case (k, _) => Left(ConfigReaderFailures(NonStringKeyFound(k.toString, k.getClass.getSimpleName)))
         }
         entries
-          .foldLeft(Right(Map.empty): ConfigReader.Result[Map[String, AnyRef]])(ReaderResult.zipWith(_, _)(_ + _))
+          .foldLeft(Right(Map.empty): ConfigReader.Result[Map[String, AnyRef]])(ConfigReader.Result.zipWith(_, _)(_ + _))
           .right.map(_.asJava)
 
       case xs: java.util.List[AnyRef @unchecked] =>
         xs.asScala.map(aux)
-          .foldRight(Right(Nil): ConfigReader.Result[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
+          .foldRight(Right(Nil): ConfigReader.Result[List[AnyRef]])(ConfigReader.Result.zipWith(_, _)(_ :: _))
           .right.map(_.asJava)
 
       case s: java.util.Set[AnyRef @unchecked] =>
         s.asScala.map(aux)
-          .foldLeft(Right(Set.empty): ConfigReader.Result[Set[AnyRef]])(ReaderResult.zipWith(_, _)(_ + _))
+          .foldLeft(Right(Set.empty): ConfigReader.Result[Set[AnyRef]])(ConfigReader.Result.zipWith(_, _)(_ + _))
           .right.map(_.asJava)
 
       case _: java.lang.Integer | _: java.lang.Long | _: java.lang.Double | _: java.lang.String | _: java.lang.Boolean =>
@@ -169,7 +169,7 @@ package object yaml {
         val yamlObjs = new Yaml(new SafeConstructor()).loadAll(ioReader)
 
         yamlObjs.asScala.map(yamlObjToConfigValue)
-          .foldRight(Right(Nil): ConfigReader.Result[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
+          .foldRight(Right(Nil): ConfigReader.Result[List[AnyRef]])(ConfigReader.Result.zipWith(_, _)(_ :: _))
           .right.flatMap { cvs =>
             val cl = ConfigValueFactory.fromAnyRef(cvs.asJava)
             reader.value.from(ConfigCursor(cl, Nil))
@@ -194,7 +194,7 @@ package object yaml {
       val yamlObjs = new Yaml(new SafeConstructor()).loadAll(content)
 
       yamlObjs.asScala.map(yamlObjToConfigValue)
-        .foldRight(Right(Nil): ConfigReader.Result[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
+        .foldRight(Right(Nil): ConfigReader.Result[List[AnyRef]])(ConfigReader.Result.zipWith(_, _)(_ :: _))
         .right.flatMap { cvs =>
           val cl = ConfigValueFactory.fromAnyRef(cvs.asJava)
           reader.value.from(ConfigCursor(cl, Nil))

--- a/modules/yaml/src/main/scala/pureconfig/module/yaml/package.scala
+++ b/modules/yaml/src/main/scala/pureconfig/module/yaml/package.scala
@@ -13,7 +13,6 @@ import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
 import org.yaml.snakeyaml.error.{ Mark, MarkedYAMLException, YAMLException }
-import pureconfig.ConvertHelpers._
 import pureconfig._
 import pureconfig.error._
 import pureconfig.module.yaml.error.{ NonStringKeyFound, UnsupportedYamlType }
@@ -22,26 +21,26 @@ package object yaml {
 
   // Converts an object created by SnakeYAML to a Typesafe `ConfigValue`.
   // (https://bitbucket.org/asomov/snakeyaml/wiki/Documentation#markdown-header-loading-yaml)
-  private[this] def yamlObjToConfigValue(obj: AnyRef): Either[ConfigReaderFailures, ConfigValue] = {
+  private[this] def yamlObjToConfigValue(obj: AnyRef): ReaderResult[ConfigValue] = {
 
-    def aux(obj: AnyRef): Either[ConfigReaderFailures, AnyRef] = obj match {
+    def aux(obj: AnyRef): ReaderResult[AnyRef] = obj match {
       case m: java.util.Map[AnyRef @unchecked, AnyRef @unchecked] =>
         val entries = m.asScala.map {
           case (k: String, v) => aux(v).right.map { v: AnyRef => k -> v }
           case (k, _) => Left(ConfigReaderFailures(NonStringKeyFound(k.toString, k.getClass.getSimpleName)))
         }
         entries
-          .foldLeft(Right(Map.empty): Either[ConfigReaderFailures, Map[String, AnyRef]])(combineResults(_, _)(_ + _))
+          .foldLeft(Right(Map.empty): ReaderResult[Map[String, AnyRef]])(ReaderResult.zipWith(_, _)(_ + _))
           .right.map(_.asJava)
 
       case xs: java.util.List[AnyRef @unchecked] =>
         xs.asScala.map(aux)
-          .foldRight(Right(Nil): Either[ConfigReaderFailures, List[AnyRef]])(combineResults(_, _)(_ :: _))
+          .foldRight(Right(Nil): ReaderResult[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
           .right.map(_.asJava)
 
       case s: java.util.Set[AnyRef @unchecked] =>
         s.asScala.map(aux)
-          .foldLeft(Right(Set.empty): Either[ConfigReaderFailures, Set[AnyRef]])(combineResults(_, _)(_ + _))
+          .foldLeft(Right(Set.empty): ReaderResult[Set[AnyRef]])(ReaderResult.zipWith(_, _)(_ + _))
           .right.map(_.asJava)
 
       case _: java.lang.Integer | _: java.lang.Long | _: java.lang.Double | _: java.lang.String | _: java.lang.Boolean =>
@@ -74,7 +73,7 @@ package object yaml {
   }
 
   // Opens and processes a YAML file, converting all exceptions into the most appropriate PureConfig errors.
-  private[this] def handleYamlErrors[A](path: Option[Path])(block: => Either[ConfigReaderFailures, A]): Either[ConfigReaderFailures, A] = {
+  private[this] def handleYamlErrors[A](path: Option[Path])(block: => ReaderResult[A]): ReaderResult[A] = {
     try block
     catch {
       case ex: IOException if path.isDefined => Left(ConfigReaderFailures(CannotReadFile(path.get, Some(ex))))
@@ -92,7 +91,7 @@ package object yaml {
    * @return A `Success` with the configuration if it is possible to create an instance of type
    *         `Config` from the YAML file, else a `Failure` with details on why it isn't possible
    */
-  def loadYaml[Config](path: Path)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] = {
+  def loadYaml[Config](path: Path)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
     handleYamlErrors(Some(path)) {
       using(Files.newBufferedReader(path)) { ioReader =>
         // we are using `SafeConstructor` in order to avoid creating custom Java instances, leaking the PureConfig
@@ -113,7 +112,7 @@ package object yaml {
    * @return A `Success` with the configuration if it is possible to create an instance of type
    *         `Config` from `content`, else a `Failure` with details on why it isn't possible
    */
-  def loadYaml[Config](content: String)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] = {
+  def loadYaml[Config](content: String)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
     handleYamlErrors(None) {
       // we are using `SafeConstructor` in order to avoid creating custom Java instances, leaking the PureConfig
       // abstraction over SnakeYAML
@@ -162,7 +161,7 @@ package object yaml {
    *         `Config` from the multi-document YAML file, else a `Failure` with details on why it
    *         isn't possible
    */
-  def loadYamls[Config](path: Path)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] = {
+  def loadYamls[Config](path: Path)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
     handleYamlErrors(Some(path)) {
       using(Files.newBufferedReader(path)) { ioReader =>
         // we are using `SafeConstructor` in order to avoid creating custom Java instances, leaking the PureConfig
@@ -170,7 +169,7 @@ package object yaml {
         val yamlObjs = new Yaml(new SafeConstructor()).loadAll(ioReader)
 
         yamlObjs.asScala.map(yamlObjToConfigValue)
-          .foldRight(Right(Nil): Either[ConfigReaderFailures, List[AnyRef]])(combineResults(_, _)(_ :: _))
+          .foldRight(Right(Nil): ReaderResult[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
           .right.flatMap { cvs =>
             val cl = ConfigValueFactory.fromAnyRef(cvs.asJava)
             reader.value.from(ConfigCursor(cl, Nil))
@@ -188,14 +187,14 @@ package object yaml {
    *         `Config` from the multi-document string, else a `Failure` with details on why it
    *         isn't possible
    */
-  def loadYamls[Config](content: String)(implicit reader: Derivation[ConfigReader[Config]]): Either[ConfigReaderFailures, Config] = {
+  def loadYamls[Config](content: String)(implicit reader: Derivation[ConfigReader[Config]]): ReaderResult[Config] = {
     handleYamlErrors(None) {
       // we are using `SafeConstructor` in order to avoid creating custom Java instances, leaking the PureConfig
       // abstraction over SnakeYAML
       val yamlObjs = new Yaml(new SafeConstructor()).loadAll(content)
 
       yamlObjs.asScala.map(yamlObjToConfigValue)
-        .foldRight(Right(Nil): Either[ConfigReaderFailures, List[AnyRef]])(combineResults(_, _)(_ :: _))
+        .foldRight(Right(Nil): ReaderResult[List[AnyRef]])(ReaderResult.zipWith(_, _)(_ :: _))
         .right.flatMap { cvs =>
           val cl = ConfigValueFactory.fromAnyRef(cvs.asJava)
           reader.value.from(ConfigCursor(cl, Nil))

--- a/tests/src/test/boilerplate/pureconfig/ForProductNSuite.scala.template
+++ b/tests/src/test/boilerplate/pureconfig/ForProductNSuite.scala.template
@@ -35,7 +35,7 @@ class ForProductNSuite extends BaseSuite {
   forAll(bitmaskGen1) { bitmask =>
     val foo = Foo1([#UUID.randomUUID().toString#])
     implicit val missingStringReader = new ConfigReader[String] with ReadsMissingKeys {
-      def from(cur: ConfigCursor): ReaderResult[String] =
+      def from(cur: ConfigCursor): ConfigReader.Result[String] =
         if (cur.isUndefined || cur.isNull) Right("missing")
         else cur.asString
     }

--- a/tests/src/test/boilerplate/pureconfig/ForProductNSuite.scala.template
+++ b/tests/src/test/boilerplate/pureconfig/ForProductNSuite.scala.template
@@ -35,7 +35,7 @@ class ForProductNSuite extends BaseSuite {
   forAll(bitmaskGen1) { bitmask =>
     val foo = Foo1([#UUID.randomUUID().toString#])
     implicit val missingStringReader = new ConfigReader[String] with ReadsMissingKeys {
-      def from(cur: ConfigCursor): Either[ConfigReaderFailures, String] =
+      def from(cur: ConfigCursor): ReaderResult[String] =
         if (cur.isUndefined || cur.isNull) Right("missing")
         else cur.asString
     }

--- a/tests/src/test/scala/pureconfig/ConfigReaderMatchers.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderMatchers.scala
@@ -8,28 +8,28 @@ import pureconfig.error._
 
 trait ConfigReaderMatchers { this: FlatSpec with Matchers =>
 
-  def failWith(reason: FailureReason): Matcher[Either[ConfigReaderFailures, Any]] =
+  def failWith(reason: FailureReason): Matcher[ReaderResult[Any]] =
     matchPattern { case Left(ConfigReaderFailures(ConvertFailure(`reason`, _, _), Nil)) => }
 
   def failWith(
     reason: FailureReason,
     path: String,
-    location: Option[ConfigValueLocation] = None): Matcher[Either[ConfigReaderFailures, Any]] =
+    location: Option[ConfigValueLocation] = None): Matcher[ReaderResult[Any]] =
     be(Left(ConfigReaderFailures(ConvertFailure(reason, location, path), Nil)))
 
-  def failWith(failure: ConfigReaderFailure): Matcher[Either[ConfigReaderFailures, Any]] =
+  def failWith(failure: ConfigReaderFailure): Matcher[ReaderResult[Any]] =
     be(Left(ConfigReaderFailures(failure, Nil)))
 
-  def failWithType[Reason <: FailureReason: ClassTag]: Matcher[Either[ConfigReaderFailures, Any]] =
+  def failWithType[Reason <: FailureReason: ClassTag]: Matcher[ReaderResult[Any]] =
     matchPattern { case Left(ConfigReaderFailures(ConvertFailure(_: Reason, _, _), Nil)) => }
 
-  def failWithType[Failure <: ConfigReaderFailure: ClassTag](implicit dummy: DummyImplicit): Matcher[Either[ConfigReaderFailures, Any]] =
+  def failWithType[Failure <: ConfigReaderFailure: ClassTag](implicit dummy: DummyImplicit): Matcher[ReaderResult[Any]] =
     matchPattern { case Left(ConfigReaderFailures(_: Failure, Nil)) => }
 
   def failLike(pf: PartialFunction[ConfigReaderFailure, MatchResult]) =
-    new Matcher[Either[ConfigReaderFailures, Any]] with Inside with PartialFunctionValues {
+    new Matcher[ReaderResult[Any]] with Inside with PartialFunctionValues {
 
-      def apply(left: Either[ConfigReaderFailures, Any]): MatchResult = {
+      def apply(left: ReaderResult[Any]): MatchResult = {
         inside(left) { case Left(ConfigReaderFailures(failure, Nil)) => pf.valueAt(failure) }
       }
     }

--- a/tests/src/test/scala/pureconfig/ConfigReaderMatchers.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderMatchers.scala
@@ -8,28 +8,28 @@ import pureconfig.error._
 
 trait ConfigReaderMatchers { this: FlatSpec with Matchers =>
 
-  def failWith(reason: FailureReason): Matcher[ReaderResult[Any]] =
+  def failWith(reason: FailureReason): Matcher[ConfigReader.Result[Any]] =
     matchPattern { case Left(ConfigReaderFailures(ConvertFailure(`reason`, _, _), Nil)) => }
 
   def failWith(
     reason: FailureReason,
     path: String,
-    location: Option[ConfigValueLocation] = None): Matcher[ReaderResult[Any]] =
+    location: Option[ConfigValueLocation] = None): Matcher[ConfigReader.Result[Any]] =
     be(Left(ConfigReaderFailures(ConvertFailure(reason, location, path), Nil)))
 
-  def failWith(failure: ConfigReaderFailure): Matcher[ReaderResult[Any]] =
+  def failWith(failure: ConfigReaderFailure): Matcher[ConfigReader.Result[Any]] =
     be(Left(ConfigReaderFailures(failure, Nil)))
 
-  def failWithType[Reason <: FailureReason: ClassTag]: Matcher[ReaderResult[Any]] =
+  def failWithType[Reason <: FailureReason: ClassTag]: Matcher[ConfigReader.Result[Any]] =
     matchPattern { case Left(ConfigReaderFailures(ConvertFailure(_: Reason, _, _), Nil)) => }
 
-  def failWithType[Failure <: ConfigReaderFailure: ClassTag](implicit dummy: DummyImplicit): Matcher[ReaderResult[Any]] =
+  def failWithType[Failure <: ConfigReaderFailure: ClassTag](implicit dummy: DummyImplicit): Matcher[ConfigReader.Result[Any]] =
     matchPattern { case Left(ConfigReaderFailures(_: Failure, Nil)) => }
 
   def failLike(pf: PartialFunction[ConfigReaderFailure, MatchResult]) =
-    new Matcher[ReaderResult[Any]] with Inside with PartialFunctionValues {
+    new Matcher[ConfigReader.Result[Any]] with Inside with PartialFunctionValues {
 
-      def apply(left: ReaderResult[Any]): MatchResult = {
+      def apply(left: ConfigReader.Result[Any]): MatchResult = {
         inside(left) { case Left(ConfigReaderFailures(failure, Nil)) => pf.valueAt(failure) }
       }
     }

--- a/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
@@ -52,7 +52,7 @@ class ConfigReaderSuite extends BaseSuite {
   }
 
   it should "have a correct zip method" in forAll { conf: ConfigValue =>
-    def zip[A, B](r1: ConfigReader[A], r2: ConfigReader[B]): ReaderResult[(A, B)] = {
+    def zip[A, B](r1: ConfigReader[A], r2: ConfigReader[B]): ConfigReader.Result[(A, B)] = {
       (r1.from(conf), r2.from(conf)) match {
         case (Right(a), Right(b)) => Right((a, b))
         case (Left(fa), Right(_)) => Left(fa)
@@ -68,7 +68,7 @@ class ConfigReaderSuite extends BaseSuite {
   }
 
   it should "have a correct orElse method" in forAll { conf: ConfigValue =>
-    def orElse[AA, A <: AA, B <: AA](r1: ConfigReader[A], r2: ConfigReader[B]): ReaderResult[AA] = {
+    def orElse[AA, A <: AA, B <: AA](r1: ConfigReader[A], r2: ConfigReader[B]): ConfigReader.Result[AA] = {
       (r1.from(conf), r2.from(conf)) match {
         case (Right(a), _) => Right(a)
         case (Left(_), Right(b)) => Right(b)

--- a/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
@@ -52,7 +52,7 @@ class ConfigReaderSuite extends BaseSuite {
   }
 
   it should "have a correct zip method" in forAll { conf: ConfigValue =>
-    def zip[A, B](r1: ConfigReader[A], r2: ConfigReader[B]): Either[ConfigReaderFailures, (A, B)] = {
+    def zip[A, B](r1: ConfigReader[A], r2: ConfigReader[B]): ReaderResult[(A, B)] = {
       (r1.from(conf), r2.from(conf)) match {
         case (Right(a), Right(b)) => Right((a, b))
         case (Left(fa), Right(_)) => Left(fa)
@@ -68,7 +68,7 @@ class ConfigReaderSuite extends BaseSuite {
   }
 
   it should "have a correct orElse method" in forAll { conf: ConfigValue =>
-    def orElse[AA, A <: AA, B <: AA](r1: ConfigReader[A], r2: ConfigReader[B]): Either[ConfigReaderFailures, AA] = {
+    def orElse[AA, A <: AA, B <: AA](r1: ConfigReader[A], r2: ConfigReader[B]): ReaderResult[AA] = {
       (r1.from(conf), r2.from(conf)) match {
         case (Right(a), _) => Right(a)
         case (Left(_), Right(b)) => Right(b)


### PR DESCRIPTION
We use `Either[ConfigReaderFailures, A]` heavily throughout our code as the default type for reading results. Writing it every time is cumbersome and forces an extra import (`pureconfig.error._`). Since we use it very heavily as a monad/applicative, we ended up creating helper methods in `ConvertHelpers`.

In my opinion, that's enough motivation to create a type alias for it, together with a companion object containing useful constructors and helpers. I updated the documentation and added two short references (one of them right in the Quick Start guide / README) so that people new to PureConfig are aware the alias is just an `Either`.
