### PR TITLE
adding a friendly message when the implicit for Derivation is not found

### DIFF
--- a/macros/src/main/scala/pureconfig/Derivation.scala
+++ b/macros/src/main/scala/pureconfig/Derivation.scala
@@ -1,11 +1,17 @@
 package pureconfig
 
+import scala.annotation.implicitNotFound
 import scala.collection.mutable
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 
 import pureconfig.derivation._
 
+@implicitNotFound("""Cannot find an implicit Derivation for ${A}.
+If your application does not define a Derivation elsewhere,
+consider using PureConfig's auto derivation by defining the following:
+
+import pureconfig.generic.auto._""")
 sealed trait Derivation[A] {
   def value: A
 }

--- a/macros/src/main/scala/pureconfig/Derivation.scala
+++ b/macros/src/main/scala/pureconfig/Derivation.scala
@@ -7,11 +7,8 @@ import scala.reflect.macros.whitebox
 
 import pureconfig.derivation._
 
-@implicitNotFound("""Cannot find an implicit Derivation for ${A}.
-If your application does not define a Derivation elsewhere,
-consider using PureConfig's auto derivation by defining the following:
-
-import pureconfig.generic.auto._""")
+@implicitNotFound("""Cannot find an implicit instance of ${A}.
+If you are trying to read or write a case class or sealed trait consider using PureConfig's auto derivation by adding `import pureconfig.generic.auto._`""")
 sealed trait Derivation[A] {
   def value: A
 }


### PR DESCRIPTION
Adding a friendly message when the implicit for Derivation is not found.
See #455 