### PR TITLE
Add circe module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ project/plugins/project/
 # ENSIME specific
 .ensime
 .ensime_cache
+
+# Bloop specific
+.bloop

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ def module(proj: Project) = proj.
 lazy val akka = module(project) in file("modules/akka")
 lazy val cats = module(project) in file("modules/cats")
 lazy val `cats-effect` = module(project) in file("modules/cats-effect")
+lazy val circe = module(project) in file("modules/circe")
 lazy val cron4s = module(project) in file("modules/cron4s")
 lazy val enum = module(project) in file("modules/enum")
 lazy val enumeratum = module(project) in file("modules/enumeratum")

--- a/docs/src/main/tut/docs/library-integrations.md
+++ b/docs/src/main/tut/docs/library-integrations.md
@@ -25,6 +25,7 @@ The core of PureConfig eschews unnecessary dependencies. Separate modules exist 
 - [`pureconfig-squants`](https://github.com/pureconfig/pureconfig/tree/master/modules/squants) provides converters for [Squants](http://www.squants.com/)'s beautiful types representing units of measure;
 - [`pureconfig-sttp`](https://github.com/pureconfig/pureconfig/tree/master/modules/sttp) provides converters for [sttp](https://github.com/softwaremill/sttp) types;
 - [`pureconfig-yaml`](https://github.com/pureconfig/pureconfig/tree/master/modules/yaml) provides support for reading YAML files as configurations.
+- [`pureconfig-circe`](https://github.com/pureconfig/pureconfig/tree/master/modules/circe) provides converters for Circe's Json AST
 
 ### External Integrations
 

--- a/modules/circe/README.md
+++ b/modules/circe/README.md
@@ -1,0 +1,52 @@
+# Circe module for PureConfig
+
+Adds support for [Circe](https://circe.github.io/circe/) `Json` to PureConfig.
+
+## Add pureconfig-circe to your project
+
+In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
+
+```scala
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-circe" % "0.11.0"
+```
+
+## Example
+
+Imports to be used below:
+
+```scala
+import io.circe._
+import com.typesafe.config.ConfigFactory
+import pureconfig._
+import pureconfig.generic.auto._
+import pureconfig.module.circe._
+import pureconfig.error.CannotConvert
+```
+
+### Reading Json  values directly
+
+Imagine a class, `UserConfig`, that has a `Json` field:
+
+```scala
+case class UserConfig(username: String, age: Int, custom: Json)
+```
+
+A `UserConfig` can be read like this:
+
+```scala
+val conf = ConfigFactory.parseString("""{
+  username = nathan
+  age = 31
+  custom = {
+    favoriteFood = pizza
+  }
+}""")
+// conf: com.typesafe.config.Config = Config(SimpleConfigObject({"age":31,"custom":{"favoriteFood":"pizza"},"username":"nathan"}))
+
+loadConfig[UserConfig](conf)
+// res0: pureconfig.ConfigReader.Result[UserConfig] =
+// Right(UserConfig(nathan,31,{
+//   "favoriteFood" : "pizza"
+// }))
+```
+

--- a/modules/circe/README.md
+++ b/modules/circe/README.md
@@ -20,10 +20,9 @@ import com.typesafe.config.ConfigFactory
 import pureconfig._
 import pureconfig.generic.auto._
 import pureconfig.module.circe._
-import pureconfig.error.CannotConvert
 ```
 
-### Reading Json  values directly
+### Reading Json values directly
 
 Imagine a class, `UserConfig`, that has a `Json` field:
 

--- a/modules/circe/build.sbt
+++ b/modules/circe/build.sbt
@@ -1,0 +1,16 @@
+name := "pureconfig-circe"
+
+libraryDependencies ++= Seq(
+  "io.circe" %% "circe-core" % "0.11.1",
+  "io.circe" %% "circe-literal" % "0.11.1" % Test,
+  "org.typelevel" %% "jawn-parser" % "0.14.2" % Test
+)
+
+developers := List(
+  Developer("moradology", "Nathan Zimmerman", "npzimmerman@gmail.com", url("https://github.com/moradology")))
+
+osgiSettings
+
+OsgiKeys.exportPackage := Seq("pureconfig.module.circe.*")
+OsgiKeys.privatePackage := Seq()
+OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")

--- a/modules/circe/src/main/scala/pureconfig/module/circe/package.scala
+++ b/modules/circe/src/main/scala/pureconfig/module/circe/package.scala
@@ -1,0 +1,55 @@
+package pureconfig.module
+
+import pureconfig.{ ConfigWriter, ConfigReader }
+import com.typesafe.config._
+import io.circe._
+import com.typesafe.config._
+
+import scala.collection.JavaConverters._
+
+package object circe {
+  private def cvToJson(cv: ConfigValue): Json = {
+    cv.valueType match {
+      case ConfigValueType.NULL =>
+        Json.Null
+      case ConfigValueType.BOOLEAN =>
+        Json.fromBoolean(cv.unwrapped.asInstanceOf[Boolean])
+      case ConfigValueType.NUMBER =>
+        cv.unwrapped match {
+          case i: java.lang.Number if i.longValue() == i =>
+            Json.fromLong(i.longValue())
+          case d: java.lang.Number =>
+            Json.fromDoubleOrNull(d.doubleValue())
+        }
+      case ConfigValueType.STRING =>
+        Json.fromString(cv.unwrapped.asInstanceOf[String])
+      case ConfigValueType.LIST => {
+        val iter = cv.asInstanceOf[ConfigList].asScala.map(cvToJson _)
+        Json.fromValues(iter)
+      }
+      case ConfigValueType.OBJECT => {
+        val jsonMap = cv.asInstanceOf[ConfigObject].asScala.mapValues(cvToJson _).toMap
+        val jsonObj = JsonObject.fromMap(jsonMap)
+        Json.fromJsonObject(jsonObj)
+      }
+    }
+  }
+
+  private def jsonToCv(json: Json): ConfigValue = {
+    json.fold(
+      ConfigValueFactory.fromAnyRef(null),
+      bool => ConfigValueFactory.fromAnyRef(bool),
+      jnum => jnum.toLong match {
+        case Some(long) => ConfigValueFactory.fromAnyRef(long)
+        case None => ConfigValueFactory.fromAnyRef(jnum.toDouble)
+      },
+      str => ConfigValueFactory.fromAnyRef(str),
+      arr => ConfigValueFactory.fromIterable(arr.map(jsonToCv).asJava),
+      obj => ConfigValueFactory.fromMap(obj.toMap.mapValues(jsonToCv).asJava))
+  }
+
+  implicit val circeJsonReader: ConfigReader[Json] =
+    ConfigReader[ConfigValue].map(cvToJson)
+  implicit val circeJsonWriter: ConfigWriter[Json] =
+    ConfigWriter[ConfigValue].contramap(jsonToCv)
+}

--- a/modules/circe/src/main/tut/README.md
+++ b/modules/circe/src/main/tut/README.md
@@ -20,10 +20,9 @@ import com.typesafe.config.ConfigFactory
 import pureconfig._
 import pureconfig.generic.auto._
 import pureconfig.module.circe._
-import pureconfig.error.CannotConvert
 ```
 
-### Reading Json  values directly
+### Reading Json values directly
 
 Imagine a class, `UserConfig`, that has a `Json` field:
 

--- a/modules/circe/src/main/tut/README.md
+++ b/modules/circe/src/main/tut/README.md
@@ -1,0 +1,47 @@
+# Circe module for PureConfig
+
+Adds support for [Circe](https://circe.github.io/circe/) `Json` to PureConfig.
+
+## Add pureconfig-circe to your project
+
+In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
+
+```scala
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-circe" % "0.11.0"
+```
+
+## Example
+
+Imports to be used below:
+
+```tut:silent
+import io.circe._
+import com.typesafe.config.ConfigFactory
+import pureconfig._
+import pureconfig.generic.auto._
+import pureconfig.module.circe._
+import pureconfig.error.CannotConvert
+```
+
+### Reading Json  values directly
+
+Imagine a class, `UserConfig`, that has a `Json` field:
+
+```tut:silent
+case class UserConfig(username: String, age: Int, custom: Json)
+```
+
+A `UserConfig` can be read like this:
+
+```tut:book
+val conf = ConfigFactory.parseString("""{
+  username = nathan
+  age = 31
+  custom = {
+    favoriteFood = pizza
+  }
+}""")
+
+loadConfig[UserConfig](conf)
+```
+

--- a/modules/circe/src/test/scala/pureconfig/module/circe/CirceSuite.scala
+++ b/modules/circe/src/test/scala/pureconfig/module/circe/CirceSuite.scala
@@ -1,0 +1,36 @@
+package pureconfig.module.circe
+
+import io.circe._
+import io.circe.literal._
+import org.scalatest._
+import com.typesafe.config.{ ConfigFactory, ConfigValue }
+import pureconfig._
+import pureconfig.syntax._
+import pureconfig.generic.auto._
+
+class CirceSuite extends FlatSpec with Matchers with EitherValues {
+
+  case class JsonConf(json: Json)
+  val confJson = json"""{ "long": 123, "double": 123.123, "alpha": "test", "arr": [1, 2, 3], "map": { "key1": "value1", "key2": "value2" } }"""
+  val confString = """
+    json = {
+      long = 123
+      double = 123.123
+      alpha = test
+      arr = [1, 2, 3]
+      map = {
+        key1 = value1
+        key2 = value2
+      }
+    }
+  """
+  val config = ConfigFactory.parseString(confString)
+
+  it should "be able to read a config as circe json" in {
+    config.to[JsonConf].right.value shouldEqual JsonConf(confJson)
+  }
+
+  it should "be able to write a config as circe json" in {
+    ConfigWriter[JsonConf].to(JsonConf(confJson)) shouldEqual config.root()
+  }
+}


### PR DESCRIPTION
This PR adds a very simple circe module which allows reading/writing of `io.circe.Json` instances as segments of a configuration.

Note: The implicit search in `tut` didn't seem to like my `Decoder` without wrapping things up in an object (I assume as a result of REPL limitations). As a result, the second example's code looks a bit strange