### PR TITLE
Remove JDK version requirement

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,12 +100,6 @@ lazy val commonSettings = Seq(
     .setPreference(DoubleIndentConstructorArguments, true)
     .setPreference(SpacesAroundMultiImports, true),
 
-  initialize := {
-    val required = "1.8"
-    val current = sys.props("java.specification.version")
-    assert(current == required, s"Unsupported JDK: java.specification.version $current != $required")
-  },
-
   autoAPIMappings := true,
 
   publishMavenStyle := true,


### PR DESCRIPTION
This is old code that had the goal of preventing usage of JDK 7. There's no need to have such a requirement and it's a [problem for the community build](https://github.com/scala/community-builds/pull/906#issuecomment-492482343).