### PR TITLE
Correct version in deprecation warnings

### DIFF
--- a/core/src/main/scala/pureconfig/error/FailureReason.scala
+++ b/core/src/main/scala/pureconfig/error/FailureReason.scala
@@ -126,7 +126,7 @@ final case class EmptyStringFound(typ: String) extends FailureReason {
  *
  * @param typ the type for which a non-empty object was attempted to be written
  */
-@deprecated("`EnumCoproductHint` is deprecated in favor of the `pureconfig.generic.semiauto.deriveEnumeration(Reader|Writer|Convert)[T]` methods", "0.10.3")
+@deprecated("`EnumCoproductHint` is deprecated in favor of the `pureconfig.generic.semiauto.deriveEnumeration(Reader|Writer|Convert)[T]` methods", "0.11.0")
 final case class NonEmptyObjectFound(typ: String) extends FailureReason {
   def description = s"Non-empty object found when using EnumCoproductHint to write a $typ."
 }

--- a/modules/generic/src/main/scala/pureconfig/generic/CoproductHint.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/CoproductHint.scala
@@ -118,7 +118,7 @@ object FieldCoproductHint {
  *
  * @tparam T the type of the coproduct or sealed family for which this hint applies
  */
-@deprecated("Use `pureconfig.generic.semiauto.deriveEnumerationReader[T]`, `pureconfig.generic.semiauto.deriveEnumerationWriter[T]` and `pureconfig.generic.semiauto.deriveEnumerationConvert[T]` instead", "0.10.3")
+@deprecated("Use `pureconfig.generic.semiauto.deriveEnumerationReader[T]`, `pureconfig.generic.semiauto.deriveEnumerationWriter[T]` and `pureconfig.generic.semiauto.deriveEnumerationConvert[T]` instead", "0.11.0")
 class EnumCoproductHint[T] extends CoproductHint[T] {
 
   /**

--- a/modules/generic/src/main/scala/pureconfig/generic/error/UnexpectedValueForFieldCoproductHint.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/error/UnexpectedValueForFieldCoproductHint.scala
@@ -13,7 +13,7 @@ final case class UnexpectedValueForFieldCoproductHint(value: ConfigValue) extend
   def description =
     s"Unexpected value ${value.render(ConfigRenderOptions.concise())} found. Note that the default transformation " +
       "for representing class names in config values changed from converting to lower case to converting to kebab " +
-      "case in version 0.10.3 of PureConfig. See " +
+      "case in version 0.11.0 of PureConfig. See " +
       "https://pureconfig.github.io/docs/overriding-behavior-for-sealed-families.html for more details on how to use " +
       "a different transformation."
 }

--- a/tests/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
@@ -132,7 +132,7 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
     exception.getMessage shouldBe
       s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$EnclosingA. Failures are:
           |  at 'values.v1.type':
-          |    - Unexpected value "unexpected" found. Note that the default transformation for representing class names in config values changed from converting to lower case to converting to kebab case in version 0.10.3 of PureConfig. See https://pureconfig.github.io/docs/overriding-behavior-for-sealed-families.html for more details on how to use a different transformation.
+          |    - Unexpected value "unexpected" found. Note that the default transformation for representing class names in config values changed from converting to lower case to converting to kebab case in version 0.11.0 of PureConfig. See https://pureconfig.github.io/docs/overriding-behavior-for-sealed-families.html for more details on how to use a different transformation.
           |  at 'values.v3':
           |    - Key not found: 'type'.
           |""".stripMargin


### PR DESCRIPTION
This PR corrects the version pointed to by deprecation warnings regarding `EnumCoproductHint` and the default transformation of `FieldCoproductHint`.