### PR TITLE
Fix documentation example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
   - 2.12.8
   - 2.13.0
 jdk:
-  - oraclejdk8
+  - openjdk8
 env:
   # marker environment variable to make the build matrix more readable in the UI
   - JOB=test

--- a/docs/src/main/resources/application.conf
+++ b/docs/src/main/resources/application.conf
@@ -1,7 +1,7 @@
 boolean = true
 port = 8080
 adt {
-  type = "adtb"
+  type = "adt-b"
   b = 1
 }
 list = ["1", "20%"]


### PR DESCRIPTION
Fixes #522.

GitHub's README is one of the only parts that is not compiled to ensure the examples are correct. The website has [a copy of this example](https://pureconfig.github.io/docs), but tut changed the output of this example to a failure without us noticing it :( Before we published the website we had this warning implicitly, because every change that tut made had to be committed - now we don't. I'll add a CI check to detect changes in the website later.