### PR TITLE
Create script to check the website build against the version in master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
 
 jobs:
   include:
-    - env: JOB=microsite
+    - env: JOB=build_website
       scala: 2.12.8
       addons:
         apt:
@@ -55,6 +55,15 @@ jobs:
             --url-ignore "/search.maven.org/"
             docs/target/site
       after_success: ignore
+    - env: JOB=diff_website
+      if: type = pull_request AND branch = master
+      scala: 2.12.8
+      install:
+        - rvm use 2.4 --install --fuzzy
+        - gem update --system
+        - gem install sass jekyll:3.2.1
+      script:
+        - ./scripts/diff_website.sh
 
 cache:
   directories:

--- a/scripts/diff_website.sh
+++ b/scripts/diff_website.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+
+# set the PureConfig root directory as working directory
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+TMP_DIR=/tmp/pureconfig_website_diff
+WEBSITE_OUTPUT_DIR=docs/target/jekyll
+
+# In order to avoid handling branch changes and non-clean working directories, we clone a new copy
+# of the PureConfig repo to have its state in master.
+#
+# Clone or update the local copy of the repo
+if [[ -d $TMP_DIR ]]; then
+  git -C "$TMP_DIR" reset --hard
+  git -C "$TMP_DIR" pull
+elif [[ ! -e $TMP_DIR ]]; then
+  git clone --depth 1 https://github.com/pureconfig/pureconfig.git "$TMP_DIR"
+else
+  echo "Error: $TMP_DIR exists but is not a directory"
+  exit 1
+fi
+
+# Build website on current working directory and on master
+(cd "$TMP_DIR"; sbt makeMicrosite)
+sbt makeMicrosite
+
+# Compare the two builds
+# Using `git diff --no-index` instead of `diff -r` because its output is prettier.
+if ! git -c color.ui=always diff --no-index "$TMP_DIR/$WEBSITE_OUTPUT_DIR" "$WEBSITE_OUTPUT_DIR"; then
+  if [[ -z $TRAVIS_PULL_REQUEST ]]; then
+    # If $TRAVIS_PULL_REQUEST isn't set, we're probably outside CI or outside a pull request. In
+    # this case the scripts exits with an error status code, which may be useful for automations
+    # or manual checks.
+    exit 1
+  else
+    # Else, comment on GitHub and exit with status 0 in order not to break the build.
+    COMMENT_CONTENT=$(echo "\
+      Warning: the content of the PureConfig website changed with this pull request. This may be \
+      intentional (as is the case when sbt-microsites is updated or some breaking change occurs) \
+      or may be an unexpected change in the library's behavior. Please check the logs of the \
+      diff_website job in the Travis build to see the diff." | \
+        sed -E 's/ +/ /g')
+
+    curl -f -H "Authorization: Token ${GITHUB_TOKEN}" -XPOST \
+      -d "{\"body\": \"$COMMENT_CONTENT\"}" \
+      "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments"
+  fi
+fi

--- a/scripts/diff_website.sh
+++ b/scripts/diff_website.sh
@@ -40,7 +40,7 @@ if ! git -c color.ui=always diff --no-index "$TMP_DIR/$WEBSITE_OUTPUT_DIR" "$WEB
       Warning: the content of the PureConfig website changed with this pull request. This may be \
       intentional (as is the case when sbt-microsites is updated or some breaking change occurs) \
       or may be an unexpected change in the library's behavior. Please check the logs of the \
-      diff_website job in the Travis build to see the diff." | \
+      [\`diff_website\` job]($TRAVIS_JOB_WEB_URL) in the Travis build to see the differences." | \
         sed -E 's/ +/ /g')
 
     curl -f -H "Authorization: Token ${GITHUB_TOKEN}" -XPOST \


### PR DESCRIPTION
Creates a new Travis job, `diff_website`, that checks whether the output of `sbt makeMicrosite` changed from the base branch (master) to this one. The goal of this is to prevent cases like #522, where we ended up generating wrong documentation (like the current state of https://pureconfig.github.io/docs) without any warning.

I wanted this to be a warning and not a build failure, as there are quite a number legitimate changes (like updating sbt-microsites or tut, as well as breaking/presentation changes) that would fail a build without any way of making it pass. Since neither GitHub nor Travis have a concept of "passed, but with warnings" in checks/builds, I ended up creating a bot user and making it comment on the PR when the check fails.

Note: the comment below is an example of a message sent by Travis. It refers to a previous version of the PR where I did a change that broke the documentation.