### PR TITLE
Enable coverage checking again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,9 @@ env:
   # marker environment variable to make the build matrix more readable in the UI
   - JOB=test
 
-    # sbt coverage TODO: Enable coverage again after scoverage is published for 2.13 https://github.com/scoverage/scalac-scoverage-plugin/pull/260
 script:
   - >
-    sbt
+    sbt coverage
     "++$TRAVIS_SCALA_VERSION test"
     "++$TRAVIS_SCALA_VERSION tut"
     "++$TRAVIS_SCALA_VERSION doc"
@@ -28,9 +27,8 @@ script:
       git diff --exit-code;
       fi
 
-# TODO: Enable coverage again after scoverage is published for 2.13 https://github.com/scoverage/scalac-scoverage-plugin/pull/260
-# after_success:
-#   - sbt ++$TRAVIS_SCALA_VERSION "++$TRAVIS_SCALA_VERSION coverageReport" coverageAggregate coveralls
+after_success:
+  - sbt ++$TRAVIS_SCALA_VERSION "++$TRAVIS_SCALA_VERSION coverageReport" coverageAggregate coveralls
 
 jobs:
   include:


### PR DESCRIPTION
Now that sbt-scoverage 1.6.0 was released we can enable coverage data again. See https://coveralls.io/builds/24860067 for a run on this PR.