### PR TITLE
Compile against Scala 2.12.9 and build some modules for Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 
 scala:
   - 2.11.12
-  - 2.12.8
+  - 2.12.9
   - 2.13.0
 jdk:
   - openjdk8
@@ -33,7 +33,7 @@ after_success:
 jobs:
   include:
     - env: JOB=build_website
-      scala: 2.12.8
+      scala: 2.12.9
       addons:
         apt:
           packages:
@@ -55,7 +55,7 @@ jobs:
       after_success: ignore
     - env: JOB=diff_website
       if: type = pull_request AND branch = master
-      scala: 2.12.8
+      scala: 2.12.9
       install:
         - rvm use 2.4 --install --fuzzy
         - gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,18 @@ script:
   - >
     sbt coverage
     "++$TRAVIS_SCALA_VERSION test"
-    "++$TRAVIS_SCALA_VERSION tut"
     "++$TRAVIS_SCALA_VERSION doc"
     "++$TRAVIS_SCALA_VERSION publishLocal"
 
   # Compile example project
   - (cd example; sbt ++$TRAVIS_SCALA_VERSION test)
 
-  # check if there are no changes after `tut` runs
+  # Run tut and check if there are no changes in docs.
+  #
+  # We're running tut only in Scala 2.12 because it fails the compile step in
+  # the presence of comments in 2.13: https://github.com/tpolecat/tut/issues/246
   - if [[ $TRAVIS_SCALA_VERSION =~ ^2\.12.* ]]; then
+      sbt "++$TRAVIS_SCALA_VERSION tut";
       git diff --exit-code;
       fi
 

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val commonSettings = Seq(
     Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr"))),
 
   scalaVersion := crossScalaVersions.value.head,
-  crossScalaVersions := Seq("2.12.9", "2.11.12"),
+  crossScalaVersions := Seq("2.12.9", "2.13.0", "2.11.12"),
 
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val commonSettings = Seq(
     Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr"))),
 
   scalaVersion := crossScalaVersions.value.head,
-  crossScalaVersions := Seq("2.12.8", "2.11.12"),
+  crossScalaVersions := Seq("2.12.9", "2.11.12"),
 
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -2,8 +2,6 @@ import Dependencies._
 
 name := "pureconfig-core"
 
-crossScalaVersions ~= { _ :+ "2.13.0" }
-
 libraryDependencies += typesafeConfig
 
 osgiSettings

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -2,12 +2,12 @@ name := "example"
 
 version := "1.0"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.9"
 
 libraryDependencies ++= Seq(
   "com.github.pureconfig" %% "pureconfig" % "0.11.2-SNAPSHOT")
 
-crossScalaVersions := Seq("2.12.8", "2.11.12", "2.13.0")
+crossScalaVersions := Seq("2.12.9", "2.11.12", "2.13.0")
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -2,12 +2,12 @@ name := "example"
 
 version := "1.0"
 
-scalaVersion := "2.13.0"
+scalaVersion := "2.12.9"
 
 libraryDependencies ++= Seq(
   "com.github.pureconfig" %% "pureconfig" % "0.11.2-SNAPSHOT")
 
-crossScalaVersions := Seq("2.13.0", "2.12.9", "2.11.12")
+crossScalaVersions := Seq("2.12.9", "2.11.12", "2.13.0")
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -2,12 +2,12 @@ name := "example"
 
 version := "1.0"
 
-scalaVersion := "2.12.9"
+scalaVersion := "2.13.0"
 
 libraryDependencies ++= Seq(
   "com.github.pureconfig" %% "pureconfig" % "0.11.2-SNAPSHOT")
 
-crossScalaVersions := Seq("2.12.9", "2.11.12", "2.13.0")
+crossScalaVersions := Seq("2.13.0", "2.12.9", "2.11.12")
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -2,8 +2,6 @@ import Dependencies._
 
 name := "pureconfig-macros"
 
-crossScalaVersions ~= { _ :+ "2.13.0" }
-
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
   "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided)

--- a/modules/cats-effect/build.sbt
+++ b/modules/cats-effect/build.sbt
@@ -1,5 +1,7 @@
 name := "pureconfig-cats-effect"
 
+crossScalaVersions ~= { _.filterNot(_.startsWith("2.13")) }
+
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-effect" % "1.4.0")
 

--- a/modules/cats/build.sbt
+++ b/modules/cats/build.sbt
@@ -1,5 +1,7 @@
 name := "pureconfig-cats"
 
+crossScalaVersions ~= { _.filterNot(_.startsWith("2.13")) }
+
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % "1.6.1",
   "org.typelevel" %% "cats-laws" % "1.6.1" % "test")

--- a/modules/circe/build.sbt
+++ b/modules/circe/build.sbt
@@ -1,5 +1,7 @@
 name := "pureconfig-circe"
 
+crossScalaVersions ~= { _.filterNot(_.startsWith("2.13")) }
+
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % "0.11.1",
   "io.circe" %% "circe-literal" % "0.11.1" % Test,

--- a/modules/cron4s/build.sbt
+++ b/modules/cron4s/build.sbt
@@ -1,5 +1,7 @@
 name := "pureconfig-cron4s"
 
+crossScalaVersions ~= { _.filterNot(_.startsWith("2.13")) }
+
 libraryDependencies ++= Seq(
   "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.5.0")
 

--- a/modules/fs2/build.sbt
+++ b/modules/fs2/build.sbt
@@ -1,5 +1,7 @@
 name := "pureconfig-fs2"
 
+crossScalaVersions ~= { _.filterNot(_.startsWith("2.13")) }
+
 libraryDependencies ++= Seq(
   "co.fs2" %% "fs2-core" % "1.0.5",
   "co.fs2" %% "fs2-io" % "1.0.5")

--- a/modules/generic/build.sbt
+++ b/modules/generic/build.sbt
@@ -2,8 +2,6 @@ import Dependencies._
 
 name := "pureconfig-generic"
 
-crossScalaVersions ~= { _ :+ "2.13.0" }
-
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
   shapeless)

--- a/modules/http4s/build.sbt
+++ b/modules/http4s/build.sbt
@@ -1,5 +1,7 @@
 name := "pureconfig-http4s"
 
+crossScalaVersions ~= { _.filterNot(_.startsWith("2.13")) }
+
 libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-core" % "0.20.9")
 

--- a/modules/scalaz/src/test/scala/pureconfig/module/scalaz/ScalazLawsSuite.scala
+++ b/modules/scalaz/src/test/scala/pureconfig/module/scalaz/ScalazLawsSuite.scala
@@ -38,5 +38,5 @@ class ScalazLawsSuite extends FunSuite with Checkers {
 }
 
 object ScalazLawsSuite {
-  def properties2prop(ps: Properties): Prop = Prop.all(ps.properties.map(_._2): _*)
+  def properties2prop(ps: Properties): Prop = Prop.all(ps.properties.map(_._2).toSeq: _*)
 }

--- a/modules/squants/build.sbt
+++ b/modules/squants/build.sbt
@@ -1,5 +1,7 @@
 name := "pureconfig-squants"
 
+crossScalaVersions ~= { _.filterNot(_.startsWith("2.13")) }
+
 libraryDependencies ++= Seq(
   "org.typelevel" %% "squants" % "1.3.0")  // blocked by https://github.com/typelevel/squants/issues/321
 

--- a/modules/sttp/src/main/scala/pureconfig/module/sttp/package.scala
+++ b/modules/sttp/src/main/scala/pureconfig/module/sttp/package.scala
@@ -1,6 +1,6 @@
 package pureconfig.module
 
-import com.softwaremill.sttp._
+import com.softwaremill.sttp.{ sttp => _, _ }
 import pureconfig.ConfigReader
 import pureconfig.error.CannotConvert
 


### PR DESCRIPTION
This PR enables compilation against Scala 2.12.9 and builds some modules for Scala 2.13. 

There's a bug in tut (tpolecat/tut#246) that makes comments fail the compilation step in Scala 2.13. As such, I've enabled tut only for 2.12 in the CI. This is also preventing us from building the microsite in Scala 2.13. 😢 