### PR TITLE
Add key name to the error message on UnknownKey

### DIFF
--- a/core/src/main/scala/pureconfig/error/FailureReason.scala
+++ b/core/src/main/scala/pureconfig/error/FailureReason.scala
@@ -89,7 +89,7 @@ object KeyNotFound {
  * @param key the unknown key
  */
 final case class UnknownKey(key: String) extends FailureReason {
-  def description = s"Unknown key."
+  def description = s"Unknown key: $key"
 }
 
 /**


### PR DESCRIPTION
It's nice to know for e.g. misspellings which key is unknown.