### PR TITLE
Support for Scala 2.13 in cron4s

### DIFF
--- a/modules/cron4s/build.sbt
+++ b/modules/cron4s/build.sbt
@@ -1,13 +1,8 @@
 name := "pureconfig-cron4s"
 
-libraryDependencies += {
-  val cron4sVersion = CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, n)) if n < 12 => "0.5.0"
-    case _                      => "0.6.0"
-  }
-  
-  "com.github.alonsodomin.cron4s" %% "cron4s-core" % cron4sVersion
-}
+crossScalaVersions := List("2.13.1", "2.12.9")
+
+libraryDependencies += "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.6.0"
 
 developers := List(
   Developer("bardurdam", "Bárður Viberg Dam", "bardurdam@gmail.com", url("https://github.com/bardurdam")))

--- a/modules/cron4s/build.sbt
+++ b/modules/cron4s/build.sbt
@@ -1,9 +1,13 @@
 name := "pureconfig-cron4s"
 
-crossScalaVersions ~= { _.filterNot(_.startsWith("2.13")) }
-
-libraryDependencies ++= Seq(
-  "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.5.0")
+libraryDependencies += {
+  val cron4sVersion = CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n < 12 => "0.5.0"
+    case _                      => "0.6.0-M2"
+  }
+  
+  "com.github.alonsodomin.cron4s" %% "cron4s-core" % cron4sVersion
+}
 
 developers := List(
   Developer("bardurdam", "Bárður Viberg Dam", "bardurdam@gmail.com", url("https://github.com/bardurdam")))

--- a/modules/cron4s/build.sbt
+++ b/modules/cron4s/build.sbt
@@ -1,6 +1,6 @@
 name := "pureconfig-cron4s"
 
-crossScalaVersions := List("2.13.1", "2.12.9")
+crossScalaVersions ~= { _.filterNot(_.startsWith("2.11")) }
 
 libraryDependencies += "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.6.0"
 

--- a/modules/cron4s/build.sbt
+++ b/modules/cron4s/build.sbt
@@ -3,7 +3,7 @@ name := "pureconfig-cron4s"
 libraryDependencies += {
   val cron4sVersion = CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, n)) if n < 12 => "0.5.0"
-    case _                      => "0.6.0-M2"
+    case _                      => "0.6.0"
   }
   
   "com.github.alonsodomin.cron4s" %% "cron4s-core" % cron4sVersion

--- a/modules/cron4s/src/test/scala/pureconfig/module/cron4s/Cron4sSuite.scala
+++ b/modules/cron4s/src/test/scala/pureconfig/module/cron4s/Cron4sSuite.scala
@@ -24,7 +24,7 @@ class Cron4sSuite extends BaseSuite {
 
     val errors = ConfigReaderFailures(
       ConvertFailure(
-        CannotConvert("10-65 * * * * *", "CronExpr", "Expected '\" \" | 0-59' at position 2 but found '\"-65 * * * * *\"'"),
+        CannotConvert("10-65 * * * * *", "CronExpr", "blank expected at position 3 but found '-'"),
         None,
         "schedule"))
 


### PR DESCRIPTION
`cron4s` supports Scala 2.13 in the 0.6 version series, but at the same time drops support for Scala 2.11. This change makes this module available for all the cross Scala versions at the cost of choosing a different version of the dependency.

Other option would be dropping 2.11 support in this module.

ps: `cron4s` 0.6 will be source compatible with 0.5.