### PR TITLE
Stop using `TRAVIS_REPO_SLUG` in `diff_website.sh`

### DIFF
--- a/scripts/diff_website.sh
+++ b/scripts/diff_website.sh
@@ -45,6 +45,6 @@ if ! git -c color.ui=always diff --no-index "$TMP_DIR/$WEBSITE_OUTPUT_DIR" "$WEB
 
     curl -f -H "Authorization: Token ${GITHUB_TOKEN}" -XPOST \
       -d "{\"body\": \"$COMMENT_CONTENT\"}" \
-      "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments"
+      "https://api.github.com/repos/pureconfig/pureconfig/issues/${TRAVIS_PULL_REQUEST}/comments"
   fi
 fi


### PR DESCRIPTION
This pull request hardcodes the repo slug in `diff_website.sh` to `pureconfig/pureconfig`. I think it's OK to do it, since the script is already very specific to this repository.

This might fix the issue with the failed build in #558.