### PR TITLE
Fix update-website.sh

### DIFF
--- a/scripts/update_website.sh
+++ b/scripts/update_website.sh
@@ -32,7 +32,7 @@ sbt "set siteDirectory in docs := file(\"$WEBSITE_DIR\")" \
     makeMicrosite
 
 # generate the website pages for this version
-rm -rf 'docs/target/streams/$global/makeSite'
+rm -rf 'docs/target/streams/_global/makeSite'
 sbt "set siteDirectory in docs := file(\"$WEBSITE_DIR/v$VERSION\")" \
     "set micrositeBaseUrl in docs := \"v$VERSION\"" \
     makeMicrosite


### PR DESCRIPTION
It seems that SBT 1.3.0 changed the names used internally in `_target`, which broke our website deploy script.
