### PR TITLE
Build pureconfig-circe for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
+import Utilities._
+import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 import scalariform.formatter.preferences._
-import ReleaseTransformations._
 
 lazy val core = (project in file("core")).
   enablePlugins(BoilerplatePlugin, SbtOsgi, TutPlugin).
@@ -82,12 +83,7 @@ lazy val commonSettings = Seq(
   crossVersionSharedSources(unmanagedSourceDirectories in Compile),
   crossVersionSharedSources(unmanagedSourceDirectories in Test),
 
-  scalacOptions ++= allVersionLintFlags ++ {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some(v) => lintFlags.getOrElse(v, Nil)
-      case _ => Nil
-    }
-  },
+  scalacOptions ++= lintFlags.value,
 
   scalacOptions in Test ~= { _.filterNot(_.contains("-Ywarn-unused")) },
   scalacOptions in Test += "-Xmacro-settings:materialize-derivations",
@@ -146,28 +142,42 @@ def crossVersionSharedSources(unmanagedSrcs: SettingKey[Seq[File]]) = {
   }
 }
 
-lazy val allVersionLintFlags = List(
-  "-encoding", "UTF-8", // yes, this is 2 args
-  "-feature",
-  "-unchecked",
-  "-Ywarn-dead-code",
-  "-Ywarn-numeric-widen")
+lazy val lintFlags = {
+  lazy val allVersionLintFlags = List(
+    "-encoding", "UTF-8", // yes, this is 2 args
+    "-feature",
+    "-unchecked",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen")
 
-lazy val lintFlags = Map(
-  (2L, 11L) -> List(
-    "-deprecation",
-    "-Xlint",
-    "-Xfatal-warnings",
-    "-Yno-adapted-args",
-    "-Ywarn-unused-import"),
-  (2, 12) -> List(
-    "-deprecation",                 // Either#right is deprecated on Scala 2.13
-    "-Xlint:_,-unused",
-    "-Xfatal-warnings",
-    "-Yno-adapted-args",
-    "-Ywarn-unused:_,-implicits"),  // Some implicits are intentionally used just as evidences, triggering warnings
-  (2, 13) -> List(
-    "-Ywarn-unused:_,-implicits"))
+  def withCommon(flags: String*) =
+    allVersionLintFlags ++ flags
+
+  forScalaVersions {
+    case (2, 11) =>
+      withCommon(
+        "-deprecation",
+        "-Xlint",
+        "-Xfatal-warnings",
+        "-Yno-adapted-args",
+        "-Ywarn-unused-import")
+
+    case (2, 12) =>
+      withCommon(
+        "-deprecation",                // Either#right is deprecated on Scala 2.13
+        "-Xlint:_,-unused",
+        "-Xfatal-warnings",
+        "-Yno-adapted-args",
+        "-Ywarn-unused:_,-implicits")  // Some implicits are intentionally used just as evidences, triggering warnings
+
+    case (2, 13) =>
+      withCommon(
+        "-Ywarn-unused:_,-implicits")
+
+    case _ =>
+      withCommon()
+  }
+}
 
 // do not publish the root project
 skip in publish := true

--- a/modules/circe/build.sbt
+++ b/modules/circe/build.sbt
@@ -1,16 +1,11 @@
+import Utilities._
+
 name := "pureconfig-circe"
 
-def onScala211(onScala211: String, onOthers: String) = Def.setting {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 11)) => onScala211
-    case _ => onOthers
-  }
-}
-
 libraryDependencies ++= Seq(
-  "io.circe"      %% "circe-core"     % onScala211("0.11.1", "0.12.1").value,
-  "io.circe"      %% "circe-literal"  % onScala211("0.11.1", "0.12.1").value % Test,
-  "org.typelevel" %% "jawn-parser"    % "0.14.2" % Test
+  "io.circe"      %% "circe-core"    % forScalaVersions { case (2, 11) => "0.11.1"; case _ => "0.12.1" }.value,
+  "io.circe"      %% "circe-literal" % forScalaVersions { case (2, 11) => "0.11.1"; case _ => "0.12.1" }.value % Test,
+  "org.typelevel" %% "jawn-parser"   % "0.14.2" % Test
 )
 
 developers := List(

--- a/modules/circe/build.sbt
+++ b/modules/circe/build.sbt
@@ -1,11 +1,16 @@
 name := "pureconfig-circe"
 
-crossScalaVersions ~= { _.filterNot(_.startsWith("2.13")) }
+def onScala211(onScala211: String, onOthers: String) = Def.setting {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, 11)) => onScala211
+    case _ => onOthers
+  }
+}
 
 libraryDependencies ++= Seq(
-  "io.circe" %% "circe-core" % "0.11.1",
-  "io.circe" %% "circe-literal" % "0.11.1" % Test,
-  "org.typelevel" %% "jawn-parser" % "0.14.2" % Test
+  "io.circe"      %% "circe-core"     % onScala211("0.11.1", "0.12.1").value,
+  "io.circe"      %% "circe-literal"  % onScala211("0.11.1", "0.12.1").value % Test,
+  "org.typelevel" %% "jawn-parser"    % "0.14.2" % Test
 )
 
 developers := List(

--- a/modules/circe/src/main/scala/pureconfig/module/circe/package.scala
+++ b/modules/circe/src/main/scala/pureconfig/module/circe/package.scala
@@ -45,7 +45,7 @@ package object circe {
       },
       str => ConfigValueFactory.fromAnyRef(str),
       arr => ConfigValueFactory.fromIterable(arr.map(jsonToCv).asJava),
-      obj => ConfigValueFactory.fromMap(obj.toMap.mapValues(jsonToCv).asJava))
+      obj => ConfigValueFactory.fromMap(obj.toMap.map { case (k, v) => k -> jsonToCv(v) }.asJava))
   }
 
   implicit val circeJsonReader: ConfigReader[Json] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,14 +1,7 @@
+import Utilities._
 import sbt._
-import sbt.Keys._
 
 object Dependencies {
-
-  private[this] def onScala213(onScala213: String, onOthers: String) = Def.setting {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 13)) => onScala213
-      case _ => onOthers
-    }
-  }
 
   object Version {
     val shapeless           = "2.3.3"
@@ -17,8 +10,8 @@ object Dependencies {
     val scalaTest           = "3.0.8"
 
     // cats will only be compatible with scalacheck 1.14 on 2.x
-    val scalaCheck          = onScala213("1.14.0", "1.13.5")
-    val scalaCheckShapeless = onScala213("1.2.3", "1.1.8")
+    val scalaCheck          = forScalaVersions { case (2, 13) => "1.14.0"; case _ => "1.13.5" }
+    val scalaCheckShapeless = forScalaVersions { case (2, 13) => "1.2.3"; case _ => "1.1.8" }
   }
 
   val shapeless = "com.chuusai" %% "shapeless" % Version.shapeless
@@ -29,6 +22,7 @@ object Dependencies {
   val scalaCheck = Def.setting { "org.scalacheck" %% "scalacheck" % Version.scalaCheck.value % "test" }
   val scalaCheckShapeless = Def.setting {
     "com.github.alexarchambault" %%
-      s"scalacheck-shapeless_${onScala213("1.14", "1.13").value}" % Version.scalaCheckShapeless.value % "test"
+      s"scalacheck-shapeless_${forScalaVersions { case (2, 13) => "1.14"; case _ => "1.13" }.value}" %
+      Version.scalaCheckShapeless.value % "test"
   }
 }

--- a/project/Utilities.scala
+++ b/project/Utilities.scala
@@ -1,0 +1,9 @@
+import sbt.Keys.scalaVersion
+import sbt.{CrossVersion, Def}
+
+object Utilities {
+
+  def forScalaVersions[A](f: ((Long, Long)) => A) = Def.setting {
+    f(CrossVersion.partialVersion(scalaVersion.value).getOrElse(sys.error("Improperly formatted Scala version.")))
+  }
+}


### PR DESCRIPTION
This PR starts building `pureconfig-circe` for Scala 2.13.

Circe is no longer available for Scala 2.11 since 0.11.1, so we have to stay there for that Scala version.