### PR TITLE
Define project name in generic-base module

### DIFF
--- a/modules/generic-base/build.sbt
+++ b/modules/generic-base/build.sbt
@@ -1,0 +1,1 @@
+name := "pureconfig-generic-base"


### PR DESCRIPTION
I forgot to add this in #594.