### PR TITLE
Extract `ConfigReaderException` pretty printing logic to `ConfigReaderFailures`

### DIFF
--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
@@ -18,8 +18,8 @@ case class ConfigReaderFailures(head: ConfigReaderFailure, tail: List[ConfigRead
   def ++(that: ConfigReaderFailures): ConfigReaderFailures =
     new ConfigReaderFailures(head, tail ++ that.toList)
 
-  def prettyPrint(identLevel: Int = 0, tabSize: Int = 2): String = {
-    def tabs(n: Int): String = " " * ((identLevel + n) * tabSize)
+  def prettyPrint(identLevel: Int = 0, identSize: Int = 2): String = {
+    def tabs(n: Int): String = " " * ((identLevel + n) * identSize)
     def descriptionWithLocation(failure: ConfigReaderFailure, ident: Int): String = {
       val failureLines = failure.description.split("\n")
       (failure.location.fold(s"${tabs(ident)}- ${failureLines.head}")(f => s"${tabs(ident)}- ${f.description} ${failureLines.head}") ::

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package pureconfig.error
 
+import scala.collection.mutable
+
 /**
  * A non-empty list of ConfigReader failures
  */
@@ -15,6 +17,37 @@ case class ConfigReaderFailures(head: ConfigReaderFailure, tail: List[ConfigRead
 
   def ++(that: ConfigReaderFailures): ConfigReaderFailures =
     new ConfigReaderFailures(head, tail ++ that.toList)
+
+  def prettyPrint(identLevel: Int = 0, tabSize: Int = 2): String = {
+    def tabs(n: Int): String = " " * ((identLevel + n) * tabSize)
+    def descriptionWithLocation(failure: ConfigReaderFailure, ident: Int): String = {
+      val failureLines = failure.description.split("\n")
+      (failure.location.fold(s"${tabs(ident)}- ${failureLines.head}")(f => s"${tabs(ident)}- ${f.description} ${failureLines.head}") ::
+        failureLines.tail.map(l => s"${tabs(ident + 1)}$l").toList).mkString("\n")
+    }
+
+    val linesBuffer = mutable.Buffer.empty[String]
+    val (convertFailures, otherFailures) = this.toList.partition(_.isInstanceOf[ConvertFailure])
+
+    val failuresByPath = convertFailures.asInstanceOf[List[ConvertFailure]].groupBy(_.path).toList.sortBy(_._1)
+
+    otherFailures.foreach { failure =>
+      linesBuffer += descriptionWithLocation(failure, 0)
+    }
+
+    if (otherFailures.nonEmpty && convertFailures.nonEmpty) {
+      linesBuffer += ""
+    }
+
+    failuresByPath.foreach {
+      case (p, failures) =>
+        linesBuffer += (tabs(0) + (if (p.isEmpty) s"at the root:" else s"at '$p':"))
+        failures.foreach { failure =>
+          linesBuffer += descriptionWithLocation(failure, 1)
+        }
+    }
+    linesBuffer.mkString(System.lineSeparator())
+  }
 }
 
 object ConfigReaderFailures {

--- a/tests/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderExceptionSuite.scala
@@ -4,12 +4,14 @@
 package pureconfig
 
 import com.typesafe.config._
+import java.net.URL
 import java.nio.file.Paths
 import org.scalatest._
 import shapeless._
 
 import pureconfig.error._
 import pureconfig.generic.auto._
+import pureconfig.generic.error._
 import pureconfig.generic.hlist._
 import pureconfig.syntax._
 
@@ -29,6 +31,11 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
       conf.toOrThrow[Conf]
     }
 
+    exception.failures.toList.toSet shouldBe Set(
+      ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), None, "a"),
+      ConvertFailure(KeyNotFound("b", Set()), None, ""),
+      ConvertFailure(KeyNotFound("c", Set()), None, ""))
+
     exception.getMessage shouldBe
       s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$Conf. Failures are:
           |  at the root:
@@ -41,7 +48,7 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
 
   case class ParentConf(conf: Conf)
 
-  it should "have a message displaying errors that occur at the root of the configuration" in {
+  it should "include failures that occur at the root of the configuration" in {
     val conf = ConfigFactory.parseString("""
       {
         conf = 2
@@ -52,26 +59,20 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
       conf.root().get("conf").toOrThrow[Conf]
     }
 
-    exception1.getMessage shouldBe
-      s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$Conf. Failures are:
-          |  at the root:
-          |    - Expected type OBJECT. Found NUMBER instead.
-          |""".stripMargin
+    exception1.failures.toList.toSet shouldBe Set(
+      ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, ""))
 
     val exception2 = intercept[ConfigReaderException[_]] {
       conf.root().toOrThrow[ParentConf]
     }
 
-    exception2.getMessage shouldBe
-      s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$ParentConf. Failures are:
-          |  at 'conf':
-          |    - Expected type OBJECT. Found NUMBER instead.
-          |""".stripMargin
+    exception2.failures.toList.toSet shouldBe Set(
+      ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, "conf"))
   }
 
   case class MapConf(values: Map[String, MapConf])
 
-  it should "have a message showing the full path to errors" in {
+  it should "include failures with the full error path" in {
     val conf = ConfigFactory.parseString("""
       {
         values {
@@ -92,13 +93,9 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
       conf.root().toOrThrow[MapConf]
     }
 
-    exception.getMessage shouldBe
-      s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$MapConf. Failures are:
-          |  at 'values.a.values.c':
-          |    - Expected type OBJECT. Found NUMBER instead.
-          |  at 'values.b':
-          |    - Expected type OBJECT. Found STRING instead.
-          |""".stripMargin
+    exception.failures.toList.toSet shouldBe Set(
+      ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT)), None, "values.b"),
+      ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, "values.a.values.c"))
   }
 
   sealed trait A
@@ -106,7 +103,7 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
   case class A2(a: String) extends A
   case class EnclosingA(values: Map[String, A])
 
-  it should "have a message displaying relevant errors for coproduct derivation" in {
+  it should "include failures relevant for coproduct derivation" in {
     val conf = ConfigFactory.parseString("""
       {
         values {
@@ -129,13 +126,9 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
       conf.root().toOrThrow[EnclosingA]
     }
 
-    exception.getMessage shouldBe
-      s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$EnclosingA. Failures are:
-          |  at 'values.v1.type':
-          |    - Unexpected value "unexpected" found. Note that the default transformation for representing class names in config values changed from converting to lower case to converting to kebab case in version 0.11.0 of PureConfig. See https://pureconfig.github.io/docs/overriding-behavior-for-sealed-families.html for more details on how to use a different transformation.
-          |  at 'values.v3':
-          |    - Key not found: 'type'.
-          |""".stripMargin
+    exception.failures.toList.toSet shouldBe Set(
+      ConvertFailure(UnexpectedValueForFieldCoproductHint(ConfigValueFactory.fromAnyRef("unexpected")), None, "values.v1.type"),
+      ConvertFailure(KeyNotFound("type", Set()), None, "values.v3"))
   }
 
   case class CamelCaseConf(camelCaseInt: Int, camelCaseString: String)
@@ -146,7 +139,7 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
       kebabCaseConf: KebabCaseConf,
       snakeCaseConf: SnakeCaseConf)
 
-  it should "have a message displaying candidate keys in case of a suspected misconfigured ProductHint" in {
+  it should "include candidate keys in case of a suspected misconfigured ProductHint" in {
     val conf = ConfigFactory.parseString("""{
       camel-case-conf {
         camelCaseInt = 2
@@ -166,54 +159,42 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
       conf.root().toOrThrow[EnclosingConf]
     }
 
-    exception.getMessage shouldBe
-      s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$EnclosingConf. Failures are:
-          |  at 'camel-case-conf':
-          |    - Key not found: 'camel-case-int'. You might have a misconfigured ProductHint, since the following similar keys were found:
-          |       - 'camelCaseInt'
-          |    - Key not found: 'camel-case-string'. You might have a misconfigured ProductHint, since the following similar keys were found:
-          |       - 'camelCaseString'
-          |  at 'snake-case-conf':
-          |    - Key not found: 'snake-case-int'. You might have a misconfigured ProductHint, since the following similar keys were found:
-          |       - 'snake_case_int'
-          |    - Key not found: 'snake-case-string'. You might have a misconfigured ProductHint, since the following similar keys were found:
-          |       - 'snake_case_string'
-          |""".stripMargin
+    exception.failures.toList.toSet shouldBe Set(
+      ConvertFailure(KeyNotFound("camel-case-int", Set("camelCaseInt")), None, "camel-case-conf"),
+      ConvertFailure(KeyNotFound("camel-case-string", Set("camelCaseString")), None, "camel-case-conf"),
+      ConvertFailure(KeyNotFound("snake-case-int", Set("snake_case_int")), None, "snake-case-conf"),
+      ConvertFailure(KeyNotFound("snake-case-string", Set("snake_case_string")), None, "snake-case-conf"))
   }
 
-  it should "have a message displaying the proper file system location of the values that raised errors, if available" in {
+  it should "have failures with the proper file system location of the values that raised errors, if available" in {
     val workingDir = getClass.getResource("/").getFile
     val file = "conf/configFailureLocation/single/a.conf"
+    val url = new URL("file://" + workingDir + file)
     val conf = ConfigFactory.load(file).root()
 
     val exception = intercept[ConfigReaderException[_]] {
       conf.get("conf").toOrThrow[Conf]
     }
 
-    exception.getMessage shouldBe
-      s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$Conf. Failures are:
-          |  at the root:
-          |    - (file:${workingDir}${file}:1) Key not found: 'a'.
-          |  at 'c':
-          |    - (file:${workingDir}${file}:3) Expected type NUMBER. Found STRING instead.
-          |""".stripMargin
+    exception.failures.toList.toSet shouldBe Set(
+      ConvertFailure(KeyNotFound("a", Set()), Some(ConfigValueLocation(url, 1)), ""),
+      ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), Some(ConfigValueLocation(url, 3)), "c"))
   }
 
-  it should "have a message displaying the inability to parse a given configuration" in {
+  it should "include failures regarding the inability to parse a given configuration" in {
     val workingDir = getClass.getResource("/").getFile
     val file = "conf/malformed/a.conf"
+    val url = new URL("file://" + workingDir + file)
 
     val exception = intercept[ConfigReaderException[_]] {
       ConfigSource.file(Paths.get(workingDir, file)).loadOrThrow[Conf]
     }
 
-    exception.getMessage shouldBe
-      s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$Conf. Failures are:
-          |  - (file:${workingDir}${file}:2) Unable to parse the configuration: Expecting close brace } or a comma, got end of file.
-          |""".stripMargin
+    exception.failures.toList.toSet shouldBe Set(
+      CannotParse("Expecting close brace } or a comma, got end of file", Some(ConfigValueLocation(url, 2))))
   }
 
-  it should "have a message indicating that a given file does not exist" in {
+  it should "include failures indicating that a given file does not exist" in {
     val workingDir = getClass.getResource("/").getFile
     val file = "conf/nonexisting"
 
@@ -221,15 +202,14 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
       ConfigSource.file(Paths.get(workingDir, file)).loadOrThrow[Conf]
     }
 
-    exception.getMessage shouldBe
-      s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$Conf. Failures are:
-          |  - Unable to read file ${workingDir}${file} (No such file or directory).
-          |""".stripMargin
+    // Note: exceptions can't be compared for equality
+    exception.failures.toList.toString shouldBe
+      s"List(CannotReadFile(${workingDir}${file},Some(java.io.FileNotFoundException: ${workingDir}${file} (No such file or directory))))"
   }
 
   case class HListAndTupleConf(hlist: Int :: Int :: String :: HNil, tuple: (Int, Int, String))
 
-  it should "have a message showing lists of wrong size" in {
+  it should "include failures showing lists of wrong size" in {
     val conf = ConfigFactory.parseString("""
       {
         hlist = [1, 2, "three", 4]
@@ -241,12 +221,8 @@ class ConfigReaderExceptionSuite extends FlatSpec with Matchers {
       conf.root().toOrThrow[HListAndTupleConf]
     }
 
-    exception.getMessage shouldBe
-      s"""|Cannot convert configuration to a pureconfig.ConfigReaderExceptionSuite$$HListAndTupleConf. Failures are:
-          |  at 'hlist':
-          |    - List of wrong size found. Expected 3 elements. Found 4 elements instead.
-          |  at 'tuple':
-          |    - List of wrong size found. Expected 3 elements. Found 6 elements instead.
-          |""".stripMargin
+    exception.failures.toList.toSet shouldBe Set(
+      ConvertFailure(WrongSizeList(3, 4), None, "hlist"),
+      ConvertFailure(WrongSizeList(3, 6), None, "tuple"))
   }
 }

--- a/tests/src/test/scala/pureconfig/ConfigReaderFailuresPrettyPrintSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderFailuresPrettyPrintSuite.scala
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package pureconfig
+
+import java.net.URL
+
+import org.scalatest._
+import pureconfig.error._
+
+/**
+ * Suite of tests related to the pretty printing of config reader failures.
+ */
+class ConfigReaderFailuresPrettyPrintSuite extends FlatSpec with Matchers {
+  "A list of failures" should "be printable with a configurable identation" in {
+
+    def location(line: Int) = ConfigValueLocation(new URL("file:///tmp/config"), line)
+
+    val failures = ConfigReaderFailures(
+      ThrowableFailure(new Exception("Throwable error"), Some(location(12))),
+      List(
+        ConvertFailure(KeyNotFound("unknown_key"), None, "path"),
+        CannotReadResource("resourceName", None)))
+
+    failures.prettyPrint(0, 2) shouldBe
+      s"""|- (file:/tmp/config:12) Throwable error.
+          |- Unable to read resource resourceName.
+          |
+          |at 'path':
+          |  - Key not found: 'unknown_key'.""".stripMargin
+
+    failures.prettyPrint(1, 2) shouldBe
+      s"""|  - (file:/tmp/config:12) Throwable error.
+          |  - Unable to read resource resourceName.
+          |
+          |  at 'path':
+          |    - Key not found: 'unknown_key'.""".stripMargin
+
+    failures.prettyPrint(1, 4) shouldBe
+      s"""|    - (file:/tmp/config:12) Throwable error.
+          |    - Unable to read resource resourceName.
+          |
+          |    at 'path':
+          |        - Key not found: 'unknown_key'.""".stripMargin
+  }
+}

--- a/tests/src/test/scala/pureconfig/ConfigReaderFailuresPrettyPrintSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderFailuresPrettyPrintSuite.scala
@@ -3,16 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package pureconfig
 
+import com.typesafe.config._
 import java.net.URL
-
 import org.scalatest._
+
 import pureconfig.error._
+import pureconfig.generic.error._
+import java.nio.file.Path
 
 /**
  * Suite of tests related to the pretty printing of config reader failures.
  */
 class ConfigReaderFailuresPrettyPrintSuite extends FlatSpec with Matchers {
-  "A list of failures" should "be printable with a configurable identation" in {
+  "A ConfigReaderFailures prettyPrint method" should "print errors with a configurable identation" in {
 
     def location(line: Int) = ConfigValueLocation(new URL("file:///tmp/config"), line)
 
@@ -42,5 +45,136 @@ class ConfigReaderFailuresPrettyPrintSuite extends FlatSpec with Matchers {
           |
           |    at 'path':
           |        - Key not found: 'unknown_key'.""".stripMargin
+  }
+
+  it should "be printable with failures organized by path" in {
+    val failures = ConfigReaderFailures(
+      ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), None, "a"),
+      List(
+        ConvertFailure(KeyNotFound("b", Set()), None, ""),
+        ConvertFailure(KeyNotFound("c", Set()), None, "")))
+
+    failures.prettyPrint() shouldBe
+      s"""|at the root:
+          |  - Key not found: 'b'.
+          |  - Key not found: 'c'.
+          |at 'a':
+          |  - Expected type NUMBER. Found STRING instead.""".stripMargin
+  }
+
+  it should "print errors that occur at the root of the config" in {
+    val failures1 = ConfigReaderFailures(
+      ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, ""),
+      List())
+
+    failures1.prettyPrint() shouldBe
+      s"""|at the root:
+          |  - Expected type OBJECT. Found NUMBER instead.""".stripMargin
+
+    val failures2 = ConfigReaderFailures(
+      ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, "conf"),
+      List())
+
+    failures2.prettyPrint() shouldBe
+      s"""|at 'conf':
+          |  - Expected type OBJECT. Found NUMBER instead.""".stripMargin
+  }
+
+  it should "print the full error path" in {
+    val failures = ConfigReaderFailures(
+      ConvertFailure(
+        WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT)), None, "values.b"),
+      List(ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, "values.a.values.c")))
+
+    failures.prettyPrint() shouldBe
+      s"""|at 'values.a.values.c':
+          |  - Expected type OBJECT. Found NUMBER instead.
+          |at 'values.b':
+          |  - Expected type OBJECT. Found STRING instead.""".stripMargin
+  }
+
+  it should "print a message displaying relevant errors for coproduct derivation" in {
+    val failures = ConfigReaderFailures(
+      ConvertFailure(UnexpectedValueForFieldCoproductHint(ConfigValueFactory.fromAnyRef("unexpected")), None, "values.v1.type"),
+      List(ConvertFailure(KeyNotFound("type", Set()), None, "values.v3")))
+
+    failures.prettyPrint() shouldBe
+      s"""|at 'values.v1.type':
+          |  - Unexpected value "unexpected" found. Note that the default transformation for representing class names in config values changed from converting to lower case to converting to kebab case in version 0.11.0 of PureConfig. See https://pureconfig.github.io/docs/overriding-behavior-for-sealed-families.html for more details on how to use a different transformation.
+          |at 'values.v3':
+          |  - Key not found: 'type'.""".stripMargin
+  }
+
+  it should "print a message displaying candidate keys in case of a suspected misconfigured ProductHint" in {
+    val failures = ConfigReaderFailures(
+      ConvertFailure(KeyNotFound("camel-case-int", Set("camelCaseInt")), None, "camel-case-conf"),
+      List(
+        ConvertFailure(KeyNotFound("camel-case-string", Set("camelCaseString")), None, "camel-case-conf"),
+        ConvertFailure(KeyNotFound("snake-case-int", Set("snake_case_int")), None, "snake-case-conf"),
+        ConvertFailure(KeyNotFound("snake-case-string", Set("snake_case_string")), None, "snake-case-conf")))
+
+    failures.prettyPrint() shouldBe
+      s"""|at 'camel-case-conf':
+          |  - Key not found: 'camel-case-int'. You might have a misconfigured ProductHint, since the following similar keys were found:
+          |     - 'camelCaseInt'
+          |  - Key not found: 'camel-case-string'. You might have a misconfigured ProductHint, since the following similar keys were found:
+          |     - 'camelCaseString'
+          |at 'snake-case-conf':
+          |  - Key not found: 'snake-case-int'. You might have a misconfigured ProductHint, since the following similar keys were found:
+          |     - 'snake_case_int'
+          |  - Key not found: 'snake-case-string'. You might have a misconfigured ProductHint, since the following similar keys were found:
+          |     - 'snake_case_string'""".stripMargin
+  }
+
+  it should "print a message displaying the proper file system location of the values that raised errors, if available" in {
+    val workingDir = getClass.getResource("/").getFile
+    val file = "conf/configFailureLocation/single/a.conf"
+    val url = new URL("file://" + workingDir + file)
+
+    val failures = ConfigReaderFailures(
+      ConvertFailure(KeyNotFound("a", Set()), Some(ConfigValueLocation(url, 1)), ""),
+      List(ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), Some(ConfigValueLocation(url, 3)), "c")))
+
+    failures.prettyPrint() shouldBe
+      s"""|at the root:
+          |  - (file:${workingDir}${file}:1) Key not found: 'a'.
+          |at 'c':
+          |  - (file:${workingDir}${file}:3) Expected type NUMBER. Found STRING instead.""".stripMargin
+  }
+
+  it should "print a message displaying the inability to parse a given configuration" in {
+    val workingDir = getClass.getResource("/").getFile
+    val file = "conf/malformed/a.conf"
+    val url = new URL("file://" + workingDir + file)
+
+    val failures = ConfigReaderFailures(
+      CannotParse("Expecting close brace } or a comma, got end of file", Some(ConfigValueLocation(url, 2))), List())
+
+    failures.prettyPrint() shouldBe
+      s"""|- (file:${workingDir}${file}:2) Unable to parse the configuration: Expecting close brace } or a comma, got end of file.""".stripMargin
+  }
+
+  it should "print a message indicating that a given file does not exist" in {
+    val workingDir = getClass.getResource("/").getFile
+    val file = "conf/nonexisting"
+    val path = java.nio.file.Paths.get(workingDir + file)
+
+    val failures = ConfigReaderFailures(
+      CannotReadFile(path, Some(new java.io.FileNotFoundException(workingDir + file + " (No such file or directory)"))), List())
+
+    failures.prettyPrint() shouldBe
+      s"""|- Unable to read file ${workingDir}${file} (No such file or directory).""".stripMargin
+  }
+
+  it should "print a message showing lists of wrong size" in {
+    val failures = ConfigReaderFailures(
+      ConvertFailure(WrongSizeList(3, 4), None, "hlist"),
+      List(ConvertFailure(WrongSizeList(3, 6), None, "tuple")))
+
+    failures.prettyPrint() shouldBe
+      s"""|at 'hlist':
+          |  - List of wrong size found. Expected 3 elements. Found 4 elements instead.
+          |at 'tuple':
+          |  - List of wrong size found. Expected 3 elements. Found 6 elements instead.""".stripMargin
   }
 }


### PR DESCRIPTION
Extracts the bulk of the `ConfigReaderException` pretty printing logic to a `prettyPrint` method on `ConfigReaderFailures` (with configurable spacing).

Closes #385 