### PR TITLE
Avoid unnecessarily removing keys from `ConfigObject`s in derived readers

### DIFF
--- a/modules/generic/src/main/scala/pureconfig/generic/MapShapedReader.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/MapShapedReader.scala
@@ -61,7 +61,7 @@ object MapShapedReader {
         case keyCur => headReader.from(keyCur)
       }
       // for performance reasons only, we shouldn't clone the config object unless necessary
-      val tailCur = if (hint.allowUnknownKeys) cur.withoutKey(keyStr) else cur.withoutKey(keyStr)
+      val tailCur = if (hint.allowUnknownKeys) cur else cur.withoutKey(keyStr)
       val tailResult = tConfigReader.value.fromWithDefault(tailCur, default.tail)
       ConfigReader.Result.zipWith(headResult, tailResult)((head, tail) => field[K](head) :: tail)
     }


### PR DESCRIPTION
This PR restores a behavior we had in the past and that is consistent with what we have commented. Somehow we changed it and were left with this very unnecessary if statement.

