### PR TITLE
Skip publish of `pureconfig-generic-base`

### DIFF
--- a/modules/generic-base/build.sbt
+++ b/modules/generic-base/build.sbt
@@ -1,1 +1,3 @@
 name := "pureconfig-generic-base"
+
+skip in publish := true


### PR DESCRIPTION
This PR enables skipping the publish of `pureconfig-generic-base`.