### PR TITLE
Avoid unnecessary casts when creating a cursor from a `ConfigObjectSource`

### DIFF
--- a/core/src/main/scala/pureconfig/ConfigSource.scala
+++ b/core/src/main/scala/pureconfig/ConfigSource.scala
@@ -93,6 +93,10 @@ final class ConfigObjectSource private (getConf: () => Result[Config]) extends C
   def value(): Result[ConfigObject] =
     config().right.flatMap(_.resolveSafe()).right.map(_.root)
 
+  // Avoids unnecessary cast on `ConfigCursor#asObjectCursor`.
+  override def cursor(): Result[ConfigCursor] =
+    value().right.map(ConfigObjectCursor(_, Nil))
+
   /**
    * Reads a `Config` from this config source. The returned config is usually unresolved, unless
    * the source forces it otherwise.


### PR DESCRIPTION
This PR proposes a small performance improvement when creating a cursor from a `ConfigObjectSource` by creating a specialized cursor, which avoids some unnecessary casts in its `asObjectCursor` method.