### PR TITLE
Upgrade ConfigReader to ConfigConvert for http4s Uri

### DIFF
--- a/modules/http4s/src/main/scala/pureconfig/module/http4s/package.scala
+++ b/modules/http4s/src/main/scala/pureconfig/module/http4s/package.scala
@@ -1,8 +1,8 @@
 package pureconfig.module
 
 import org.http4s.Uri
-import pureconfig.ConfigReader
 import pureconfig.error.CannotConvert
+import pureconfig.{ ConfigReader, ConfigWriter }
 
 package object http4s {
 
@@ -11,4 +11,6 @@ package object http4s {
       Uri.fromString(str).fold(
         err => Left(CannotConvert(str, "Uri", err.sanitized)),
         uri => Right(uri)))
+
+  implicit val uriWriter: ConfigWriter[Uri] = ConfigWriter[String].contramap(_.renderString)
 }

--- a/modules/http4s/src/test/scala/pureconfig/module/http4s/Http4sTest.scala
+++ b/modules/http4s/src/test/scala/pureconfig/module/http4s/Http4sTest.scala
@@ -2,7 +2,7 @@ package pureconfig.module.http4s
 
 import com.typesafe.config.ConfigFactory
 import org.http4s.Uri
-import pureconfig.BaseSuite
+import pureconfig.{ BaseSuite, ConfigReader, ConfigWriter }
 import pureconfig.error.{ CannotConvert, ConfigReaderFailures, ConvertFailure }
 import pureconfig.generic.auto._
 import pureconfig.syntax._
@@ -23,5 +23,15 @@ class Http4sTest extends BaseSuite {
     val errors = ConfigReaderFailures(ConvertFailure(CannotConvert("\\", "Uri", "Invalid URI"), None, "uri"))
 
     conf.to[ServerConfig].left.value shouldEqual errors
+  }
+
+  "Uri ConfigReader and ConfigWriter" should "be able to round-trip reading/writing of Uri" in {
+    val expectedComplexUri =
+      Uri.unsafeFromString("http://www.google.ps/search?hl=en&client=firefox-a&hs=42F&rls=org.mozilla%3Aen-US%3Aofficial&q=The+type+%27Microsoft.Practices.ObjectBuilder.Locator%27+is+defined+in+an+assembly+that+is+not+referenced.+You+must+add+a+reference+to+assembly+&aq=f&aqi=&aql=&oq=")
+
+    val configValue = ConfigWriter[Uri].to(expectedComplexUri)
+    val Right(actualUri) = ConfigReader[Uri].from(configValue)
+
+    actualUri shouldEqual expectedComplexUri
   }
 }


### PR DESCRIPTION
Minor improvement: upgraded `ConfigReader` to `ConfigConvert` for http4s `Uri`.