### PR TITLE
Configure GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,116 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [8]
+        scala: [2.11.12, 2.12.10, 2.13.1]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk }}
+
+      - name: Compile
+        run: sbt coverage "++${{ matrix.scala }} compile"
+
+      - name: Run tests
+        run: sbt coverage "++${{ matrix.scala }} test"
+
+      - name: Build Scaladoc
+        run: sbt "++${{ matrix.scala }} doc"
+
+      - name: Publish artifact locally
+        run: sbt "++${{ matrix.scala }} publishLocal"
+
+      - name: Compile example project
+        run: cd example && sbt "++${{ matrix.scala }} test"
+
+      - name: Check tut output
+        run: >
+          if [[ "${{ matrix.scala }}" =~ ^2\.12.* ]]; then
+            sbt "++${{ matrix.scala }} tut" &&
+            git diff --exit-code;
+            fi
+
+# TODO: enable this once either sbt-coveralls starts supporting GitHub Actions
+# (https://github.com/scoverage/sbt-coveralls/issues/126) or coverallsapp/github-action starts
+# supporting cobertura.xml format (https://github.com/coverallsapp/github-action/issues/30)
+#
+#      - name: Compile coverage data
+#        run: sbt ++${{ matrix.scala }} coverageAggregate
+#
+#      - name: Upload coverage data to Coveralls
+#        uses: coverallsapp/github-action@master
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build_website:
+    name: Build Website
+    runs-on: ubuntu-latest
+    env:
+      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      - name: Install dependencies
+        run: >
+          sudo apt install libcurl4-openssl-dev libxslt-dev &&
+          gem install sass jekyll:4.0.0 html-proofer:3.9.3
+
+      - name: Build website
+        run: sbt makeMicrosite
+
+      - name: Verify website
+        run: >
+          htmlproofer
+          --allow-hash-href
+          --url-swap "https\://github\.com/pureconfig/pureconfig/tree/master:file\://$(pwd)"
+          --url-ignore "/search.maven.org/"
+          docs/target/site
+
+  diff_website:
+    name: Diff Website
+    runs-on: ubuntu-latest
+    if: github.ref != 'master'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      - name: Install dependencies
+        run: gem install sass jekyll:4.0.0
+
+      - name: Build and compare website
+        run: ./scripts/diff_website.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - name: Set up Scala
+        uses: olafurpg/setup-scala@v7
         with:
-          java-version: 8
+          java-version: openjdk@1.8
 
       - name: Set up Ruby
         uses: actions/setup-ruby@v1
@@ -96,12 +96,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - name: Set up Scala
+        uses: olafurpg/setup-scala@v7
         with:
-          java-version: 8
+          java-version: openjdk@1.8
 
       - name: Set up Ruby
         uses: actions/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
 
+      - name: Configure SBT
+        run: echo "-Dsbt.color=true\n-Dsbt.supershell=false" > .sbtopts
+
       - name: Compile
         run: sbt coverage "++${{ matrix.scala }} compile"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
 
-      - name: Configure SBT
-        run: echo "-Dsbt.color=true\n-Dsbt.supershell=false" > .sbtopts
-
       - name: Compile
         run: sbt coverage "++${{ matrix.scala }} compile"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [8]
+        jdk: [openjdk@1.8]
         scala: [2.11.12, 2.12.10, 2.13.1]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
 
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - name: Set up Scala
+        uses: olafurpg/setup-scala@v7
         with:
           java-version: ${{ matrix.jdk }}
 
@@ -36,11 +36,10 @@ jobs:
         run: cd example && sbt "++${{ matrix.scala }} test"
 
       - name: Check tut output
+        if: startsWith(matrix.scala, '2.12')
         run: >
-          if [[ "${{ matrix.scala }}" =~ ^2\.12.* ]]; then
-            sbt "++${{ matrix.scala }} tut" &&
-            git diff --exit-code;
-            fi
+           sbt "++${{ matrix.scala }} tut" &&
+           git diff --exit-code
 
 # TODO: enable this once either sbt-coveralls starts supporting GitHub Actions
 # (https://github.com/scoverage/sbt-coveralls/issues/126) or coverallsapp/github-action starts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set up Scala
         uses: olafurpg/setup-scala@v7


### PR DESCRIPTION
Let's try out GitHub Actions as an alternative to Travis. The advantages are that have better integration with GitHub (duh!) and they are more flexible, allowing us to automate some more workflows in the future not strictly related to CI and not necessarily triggering on pushes and PRs.

In this PR, the only things not on par with our Travis build are:
- Cache dependencies: the mechanism to cache things is a bit more complex than in Travis. However, GitHub seems to be outperforming Travis anyway ([13m8s on GitHub](https://github.com/pureconfig/pureconfig/actions) vs [13m32s on Travis](https://travis-ci.org/pureconfig/pureconfig/jobs/628148882), with GitHub builds triggering earlier), so we can start without caching and iterate later if needed;
- Upload coverage to Coveralls: see TODO on workflow definition. Since we haven't disabled Travis yet we'll continue to have coverage data;
- PR comments on website changes: this would actually be easier now as GitHub provides us a token, but since jobs are shown separately in PR checks this is not needed anymore - we can simply make diff_website not push-blocking.

Some other ideas to use GitHub Actions in the future:
- Publish a snapshot JAR to Sonatype automatically each time we push to `master`;
- Publish the website to pureconfig.github.io on every tag push (risky for now, the script is not foolproof).

We can leave both GitHub Actions and Travis running for a while to evaluate whether we are good to move definitely (and whether we want it).