### PR TITLE
Simplify manual derivation via reflection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,8 @@ lazy val scalaz = module(project) in file("modules/scalaz")
 lazy val squants = module(project) in file("modules/squants")
 lazy val sttp = module(project) in file("modules/sttp")
 lazy val yaml = module(project) in file("modules/yaml")
+lazy val reflect = (module(project) in file("modules/reflect"))
+  .enablePlugins(BoilerplatePlugin)
 
 lazy val commonSettings = Seq(
   homepage := Some(url("https://github.com/pureconfig/pureconfig")),

--- a/modules/reflect/README.md
+++ b/modules/reflect/README.md
@@ -1,0 +1,63 @@
+# Reflect module for PureConfig
+
+This module simplifies the [manual][1] approach for `ConfigReader` derivation by using a reflection based approach similar to
+[spray-json][2]. In this mode reflection is used only for discovering the case class properties at derivation time and post derivation
+there is no "reflection tx" to be paid.
+
+This module is an alternative to `pureconfig-generic` and only supports product based derivation. Instead of relying on Shapeless 
+for generic derivation it uses reflection to discover properties.
+
+## Add pureconfig-reflect to your project
+
+In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
+
+```scala
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-reflect" % "0.12.3"
+``` 
+
+## Example
+
+```scala
+package example
+
+case class MyClass(
+  boolean: Boolean,
+  port: Port,
+  adt: MyAdt,
+  list: List[Double],
+  map: Map[String, String],
+  option: Option[String])
+
+val source = ConfigSource.string("""
+  boolean = true
+  port = 8080
+  adt {
+    type = "adt-b"
+    b = 1
+  }
+  list = ["1", "20%"]
+  map {
+    key = "value"
+  }
+""")
+```
+
+Now define the `ConfigReader`. It can be either placed in companion object for `MyClass` or in package object
+
+```scala
+import pureconfig._
+import pureconfig.module.reflect.ReflectConfigReaders._
+
+package object example {
+  implicit val myClassConfigReader: ConfigReader[MyClass] = configReader6(MyClass)
+}
+```
+
+We are now able to read configs to case classes
+
+```scala
+source.load[MyClass]
+```
+
+[1]: https://pureconfig.github.io/docs/non-automatic-derivation.html#manual
+[2]: https://github.com/spray/spray-json#providing-jsonformats-for-case-classes

--- a/modules/reflect/build.sbt
+++ b/modules/reflect/build.sbt
@@ -1,0 +1,16 @@
+import Dependencies._
+
+name := "pureconfig-magnolia"
+
+crossScalaVersions ~= { _.filterNot(_.startsWith("2.11")) }
+
+libraryDependencies ++= Seq(scalaCheckShapeless % "test")
+
+developers := List(
+  Developer("chetanmeh", "Chetan Mehrotra", "chetan.mehrotra@gmail.com", url("https://chetanmeh.github.io")))
+
+osgiSettings
+
+OsgiKeys.exportPackage := Seq("pureconfig.module.reflect.*")
+OsgiKeys.privatePackage := Seq()
+OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")

--- a/modules/reflect/build.sbt
+++ b/modules/reflect/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-name := "pureconfig-magnolia"
+name := "pureconfig-reflect"
 
 crossScalaVersions ~= { _.filterNot(_.startsWith("2.11")) }
 

--- a/modules/reflect/src/main/boilerplate/pureconfig/module/reflect/ReflectConfigReaders.scala.template
+++ b/modules/reflect/src/main/boilerplate/pureconfig/module/reflect/ReflectConfigReaders.scala.template
@@ -8,7 +8,7 @@ trait ReflectConfigReaders extends ProductReaders {
     import ReflectSupport._
     private type CR[T] = ConfigReader[T]
 [#  // Case classes with 1 parameters
-    def forProduct1[[#A1 :CR#], T <: Product: ClassTag](construct: ([#A1#]) => T)(implicit ph: ReflectProductHint[T]): ConfigReader[T] = {
+    def configReader1[[#A1 :CR#], T <: Product: ClassTag](construct: ([#A1#]) => T)(implicit ph: ReflectProductHint[T]): ConfigReader[T] = {
         val Array([#a1#]) = extractFieldNames(classTag[T])
         forProduct1([#ph.configKey(a1)#])(construct)
     }#

--- a/modules/reflect/src/main/boilerplate/pureconfig/module/reflect/ReflectConfigReaders.scala.template
+++ b/modules/reflect/src/main/boilerplate/pureconfig/module/reflect/ReflectConfigReaders.scala.template
@@ -1,0 +1,20 @@
+package pureconfig.module.reflect
+
+import pureconfig.{ConfigReader, ProductReaders, BasicReaders, CollectionReaders, ExportedReaders}
+
+import scala.reflect.{ClassTag, classTag}
+
+trait ReflectConfigReaders extends ProductReaders {
+    import ReflectSupport._
+    private type CR[T] = ConfigReader[T]
+[#  // Case classes with 1 parameters
+    def forProduct1[[#A1 :CR#], T <: Product: ClassTag](construct: ([#A1#]) => T)(implicit ph: ReflectProductHint[T]): ConfigReader[T] = {
+        val Array([#a1#]) = extractFieldNames(classTag[T])
+        forProduct1([#ph.configKey(a1)#])(construct)
+    }#
+
+]
+
+}
+
+object ReflectConfigReaders extends ReflectConfigReaders with BasicReaders with CollectionReaders with ExportedReaders

--- a/modules/reflect/src/main/boilerplate/pureconfig/module/reflect/ReflectConfigWriters.scala.template
+++ b/modules/reflect/src/main/boilerplate/pureconfig/module/reflect/ReflectConfigWriters.scala.template
@@ -8,13 +8,13 @@ trait ReflectConfigWriters extends ProductWriters {
     import ReflectSupport._
     private type CW[T] = ConfigWriter[T]
 
-    def forProduct1[A1: CW,  T <: Product: ClassTag](deconstruct: T => A1)(implicit ph: ReflectProductHint[T]): ConfigWriter[T] = {
+    def configWriter1[A1: CW,  T <: Product: ClassTag](deconstruct: T => A1)(implicit ph: ReflectProductHint[T]): ConfigWriter[T] = {
         val Array(p1) = extractFieldNames(classTag[T])
         forProduct1(ph.configKey(p1))(deconstruct)
     }
 
 [2..22#  // Case classes with 1 parameters
-    def forProduct1[[#A1 :CW#], T <: Product: ClassTag](deconstruct: T => ([#A1#]) )(implicit ph: ReflectProductHint[T]): ConfigWriter[T] = {
+    def configWriter1[[#A1 :CW#], T <: Product: ClassTag](deconstruct: T => ([#A1#]) )(implicit ph: ReflectProductHint[T]): ConfigWriter[T] = {
         val Array([#a1#]) = extractFieldNames(classTag[T])
         forProduct1([#ph.configKey(a1)#])(deconstruct)
     }#

--- a/modules/reflect/src/main/boilerplate/pureconfig/module/reflect/ReflectConfigWriters.scala.template
+++ b/modules/reflect/src/main/boilerplate/pureconfig/module/reflect/ReflectConfigWriters.scala.template
@@ -1,0 +1,25 @@
+package pureconfig.module.reflect
+
+import pureconfig.{ConfigWriter, ProductWriters, BasicWriters, CollectionWriters, ExportedWriters}
+
+import scala.reflect.{ClassTag, classTag}
+
+trait ReflectConfigWriters extends ProductWriters {
+    import ReflectSupport._
+    private type CW[T] = ConfigWriter[T]
+
+    def forProduct1[A1: CW,  T <: Product: ClassTag](deconstruct: T => A1)(implicit ph: ReflectProductHint[T]): ConfigWriter[T] = {
+        val Array(p1) = extractFieldNames(classTag[T])
+        forProduct1(ph.configKey(p1))(deconstruct)
+    }
+
+[2..22#  // Case classes with 1 parameters
+    def forProduct1[[#A1 :CW#], T <: Product: ClassTag](deconstruct: T => ([#A1#]) )(implicit ph: ReflectProductHint[T]): ConfigWriter[T] = {
+        val Array([#a1#]) = extractFieldNames(classTag[T])
+        forProduct1([#ph.configKey(a1)#])(deconstruct)
+    }#
+]
+
+}
+
+object ReflectConfigWriters extends ReflectConfigWriters with BasicWriters with CollectionWriters with ExportedWriters

--- a/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectProductHint.scala
+++ b/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectProductHint.scala
@@ -1,0 +1,35 @@
+package pureconfig.module.reflect
+
+import pureconfig.{ CamelCase, ConfigFieldMapping, KebabCase }
+
+/**
+ * A trait that can be implemented to customize how case classes are read from and written to a config.
+ *
+ * @tparam T the type of case class for which this hint applies
+ */
+trait ReflectProductHint[T] {
+
+  /**
+   * Returns the key in the config object associated with a given case class field.
+   *
+   * @param fieldName the case class field
+   * @return the key in the config object associated with the given case class field.
+   */
+  def configKey(fieldName: String): String
+
+}
+
+private[pureconfig] case class ReflectProductHintImpl[T](
+    fieldMapping: ConfigFieldMapping) extends ReflectProductHint[T] {
+
+  def configKey(fieldName: String) = fieldMapping(fieldName)
+}
+
+object ReflectProductHint {
+
+  def apply[T](
+    fieldMapping: ConfigFieldMapping = ConfigFieldMapping(CamelCase, KebabCase)): ReflectProductHint[T] =
+    ReflectProductHintImpl[T](fieldMapping)
+
+  implicit def default[T]: ReflectProductHint[T] = apply()
+}

--- a/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectSupport.scala
+++ b/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectSupport.scala
@@ -28,7 +28,7 @@ private[reflect] object ReflectSupport {
       fields.map(f => unmangle(f.getName))
     } catch {
       case NonFatal(ex) => throw new RuntimeException("Cannot automatically determine case class field names and order " +
-        "for '" + clazz.getName + "', please use the 'jsonFormat' overload with explicit field name specification", ex)
+        "for '" + clazz.getName + "', please use the 'forProduct' overload with explicit field name specification", ex)
     }
   }
 

--- a/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectSupport.scala
+++ b/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectSupport.scala
@@ -1,0 +1,77 @@
+package pureconfig.module.reflect
+
+import java.lang.reflect.Modifier
+
+import scala.annotation.tailrec
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+
+private[reflect] object ReflectSupport {
+
+  def extractFieldNames(tag: ClassTag[_]): Array[String] = {
+    val clazz = tag.runtimeClass
+    try {
+      // copy methods have the form copy$default$N(), we need to sort them in order, but must account for the fact
+      // that lexical sorting of ...8(), ...9(), ...10() is not correct, so we extract N and sort by N.toInt
+      val copyDefaultMethods = clazz.getMethods.filter(_.getName.startsWith("copy$default$")).sortBy(
+        _.getName.drop("copy$default$".length).takeWhile(_ != '(').toInt)
+      val fields = clazz.getDeclaredFields.filterNot { f =>
+        import Modifier._
+        (f.getModifiers & (TRANSIENT | STATIC | 0x1000 /* SYNTHETIC*/ )) > 0
+      }
+      if (copyDefaultMethods.length != fields.length)
+        sys.error("Case class " + clazz.getName + " declares additional fields")
+      if (fields.zip(copyDefaultMethods).exists { case (f, m) => f.getType != m.getReturnType })
+        sys.error("Cannot determine field order of case class " + clazz.getName)
+      fields.map(f => unmangle(f.getName))
+    } catch {
+      case NonFatal(ex) => throw new RuntimeException("Cannot automatically determine case class field names and order " +
+        "for '" + clazz.getName + "', please use the 'jsonFormat' overload with explicit field name specification", ex)
+    }
+  }
+
+  private def unmangle(name: String) = {
+    import java.lang.{ StringBuilder => JStringBuilder }
+    @tailrec def rec(ix: Int, builder: JStringBuilder): String = {
+      val rem = name.length - ix
+      if (rem > 0) {
+        var ch = name.charAt(ix)
+        var ni = ix + 1
+        val sb = if (ch == '$' && rem > 1) {
+          def c(offset: Int, ch: Char) = name.charAt(ix + offset) == ch
+          ni = name.charAt(ix + 1) match {
+            case 'a' if rem > 3 && c(2, 'm') && c(3, 'p') => { ch = '&'; ix + 4 }
+            case 'a' if rem > 2 && c(2, 't') => { ch = '@'; ix + 3 }
+            case 'b' if rem > 4 && c(2, 'a') && c(3, 'n') && c(4, 'g') => { ch = '!'; ix + 5 }
+            case 'b' if rem > 3 && c(2, 'a') && c(3, 'r') => { ch = '|'; ix + 4 }
+            case 'd' if rem > 3 && c(2, 'i') && c(3, 'v') => { ch = '/'; ix + 4 }
+            case 'e' if rem > 2 && c(2, 'q') => { ch = '='; ix + 3 }
+            case 'g' if rem > 7 && c(2, 'r') && c(3, 'e') && c(4, 'a') && c(5, 't') && c(6, 'e') && c(7, 'r') => { ch = '>'; ix + 8 }
+            case 'h' if rem > 4 && c(2, 'a') && c(3, 's') && c(4, 'h') => { ch = '#'; ix + 5 }
+            case 'l' if rem > 4 && c(2, 'e') && c(3, 's') && c(4, 's') => { ch = '<'; ix + 5 }
+            case 'm' if rem > 5 && c(2, 'i') && c(3, 'n') && c(4, 'u') && c(5, 's') => { ch = '-'; ix + 6 }
+            case 'p' if rem > 7 && c(2, 'e') && c(3, 'r') && c(4, 'c') && c(5, 'e') && c(6, 'n') && c(7, 't') => { ch = '%'; ix + 8 }
+            case 'p' if rem > 4 && c(2, 'l') && c(3, 'u') && c(4, 's') => { ch = '+'; ix + 5 }
+            case 'q' if rem > 5 && c(2, 'm') && c(3, 'a') && c(4, 'r') && c(5, 'k') => { ch = '?'; ix + 6 }
+            case 't' if rem > 5 && c(2, 'i') && c(3, 'l') && c(4, 'd') && c(5, 'e') => { ch = '~'; ix + 6 }
+            case 't' if rem > 5 && c(2, 'i') && c(3, 'm') && c(4, 'e') && c(5, 's') => { ch = '*'; ix + 6 }
+            case 'u' if rem > 2 && c(2, 'p') => { ch = '^'; ix + 3 }
+            case 'u' if rem > 5 =>
+              def hexValue(offset: Int): Int = {
+                val c = name.charAt(ix + offset)
+                if ('0' <= c && c <= '9') c - '0'
+                else if ('a' <= c && c <= 'f') c - 87
+                else if ('A' <= c && c <= 'F') c - 55 else -0xFFFF
+              }
+              val ci = (hexValue(2) << 12) + (hexValue(3) << 8) + (hexValue(4) << 4) + hexValue(5)
+              if (ci >= 0) { ch = ci.toChar; ix + 6 } else ni
+            case _ => ni
+          }
+          if (ni > ix + 1 && builder == null) new JStringBuilder(name.substring(0, ix)) else builder
+        } else builder
+        rec(ni, if (sb != null) sb.append(ch) else null)
+      } else if (builder != null) builder.toString else name
+    }
+    rec(0, null)
+  }
+}

--- a/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectSupport.scala
+++ b/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectSupport.scala
@@ -7,6 +7,8 @@ import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 private[reflect] object ReflectSupport {
+  //Code here is taken from https://github.com/spray/spray-json/blob/release/1.3.x/src/main/scala/spray/json/ProductFormats.scala
+  //Reflection is used to discover case class properties and then names are 'unmangeled'
 
   def extractFieldNames(tag: ClassTag[_]): Array[String] = {
     val clazz = tag.runtimeClass

--- a/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectSupport.scala
+++ b/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectSupport.scala
@@ -2,8 +2,7 @@ package pureconfig.module.reflect
 
 import java.lang.reflect.Modifier
 
-import scala.annotation.tailrec
-import scala.reflect.ClassTag
+import scala.reflect.{ClassTag, NameTransformer}
 import scala.util.control.NonFatal
 
 private[reflect] object ReflectSupport {
@@ -32,48 +31,5 @@ private[reflect] object ReflectSupport {
     }
   }
 
-  private def unmangle(name: String) = {
-    import java.lang.{ StringBuilder => JStringBuilder }
-    @tailrec def rec(ix: Int, builder: JStringBuilder): String = {
-      val rem = name.length - ix
-      if (rem > 0) {
-        var ch = name.charAt(ix)
-        var ni = ix + 1
-        val sb = if (ch == '$' && rem > 1) {
-          def c(offset: Int, ch: Char) = name.charAt(ix + offset) == ch
-          ni = name.charAt(ix + 1) match {
-            case 'a' if rem > 3 && c(2, 'm') && c(3, 'p') => { ch = '&'; ix + 4 }
-            case 'a' if rem > 2 && c(2, 't') => { ch = '@'; ix + 3 }
-            case 'b' if rem > 4 && c(2, 'a') && c(3, 'n') && c(4, 'g') => { ch = '!'; ix + 5 }
-            case 'b' if rem > 3 && c(2, 'a') && c(3, 'r') => { ch = '|'; ix + 4 }
-            case 'd' if rem > 3 && c(2, 'i') && c(3, 'v') => { ch = '/'; ix + 4 }
-            case 'e' if rem > 2 && c(2, 'q') => { ch = '='; ix + 3 }
-            case 'g' if rem > 7 && c(2, 'r') && c(3, 'e') && c(4, 'a') && c(5, 't') && c(6, 'e') && c(7, 'r') => { ch = '>'; ix + 8 }
-            case 'h' if rem > 4 && c(2, 'a') && c(3, 's') && c(4, 'h') => { ch = '#'; ix + 5 }
-            case 'l' if rem > 4 && c(2, 'e') && c(3, 's') && c(4, 's') => { ch = '<'; ix + 5 }
-            case 'm' if rem > 5 && c(2, 'i') && c(3, 'n') && c(4, 'u') && c(5, 's') => { ch = '-'; ix + 6 }
-            case 'p' if rem > 7 && c(2, 'e') && c(3, 'r') && c(4, 'c') && c(5, 'e') && c(6, 'n') && c(7, 't') => { ch = '%'; ix + 8 }
-            case 'p' if rem > 4 && c(2, 'l') && c(3, 'u') && c(4, 's') => { ch = '+'; ix + 5 }
-            case 'q' if rem > 5 && c(2, 'm') && c(3, 'a') && c(4, 'r') && c(5, 'k') => { ch = '?'; ix + 6 }
-            case 't' if rem > 5 && c(2, 'i') && c(3, 'l') && c(4, 'd') && c(5, 'e') => { ch = '~'; ix + 6 }
-            case 't' if rem > 5 && c(2, 'i') && c(3, 'm') && c(4, 'e') && c(5, 's') => { ch = '*'; ix + 6 }
-            case 'u' if rem > 2 && c(2, 'p') => { ch = '^'; ix + 3 }
-            case 'u' if rem > 5 =>
-              def hexValue(offset: Int): Int = {
-                val c = name.charAt(ix + offset)
-                if ('0' <= c && c <= '9') c - '0'
-                else if ('a' <= c && c <= 'f') c - 87
-                else if ('A' <= c && c <= 'F') c - 55 else -0xFFFF
-              }
-              val ci = (hexValue(2) << 12) + (hexValue(3) << 8) + (hexValue(4) << 4) + hexValue(5)
-              if (ci >= 0) { ch = ci.toChar; ix + 6 } else ni
-            case _ => ni
-          }
-          if (ni > ix + 1 && builder == null) new JStringBuilder(name.substring(0, ix)) else builder
-        } else builder
-        rec(ni, if (sb != null) sb.append(ch) else null)
-      } else if (builder != null) builder.toString else name
-    }
-    rec(0, null)
-  }
+  private def unmangle(name: String) = NameTransformer.decode(name)
 }

--- a/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectSupport.scala
+++ b/modules/reflect/src/main/scala/pureconfig/module/reflect/ReflectSupport.scala
@@ -2,7 +2,7 @@ package pureconfig.module.reflect
 
 import java.lang.reflect.Modifier
 
-import scala.reflect.{ClassTag, NameTransformer}
+import scala.reflect.{ ClassTag, NameTransformer }
 import scala.util.control.NonFatal
 
 private[reflect] object ReflectSupport {

--- a/modules/reflect/src/test/boilerplate/pureconfig/ForProductNSuite.scala.template
+++ b/modules/reflect/src/test/boilerplate/pureconfig/ForProductNSuite.scala.template
@@ -1,4 +1,4 @@
-package pureconfig
+package pureconfig.module.reflect.test
 
 import java.util.UUID
 
@@ -7,15 +7,18 @@ import org.scalacheck._
 import org.scalacheck.ScalacheckShapeless._
 import pureconfig.error._
 import pureconfig.syntax._
+import pureconfig._
+import pureconfig.module.reflect._
 
 class ForProductNSuite extends BaseSuite {
   behavior of "ConfigReader.forProductN and ConfigWriter.forProductN"
 
   [#case class Foo1([#s0: String#])
   object Foo1 {
-    val keys = List([#UUID.randomUUID().toString#])
-    implicit val foo1Writer = ConfigWriter.forProduct1([#keys(0)#])((Foo1.unapply _).andThen(_.get))
-    implicit val foo1Reader = ConfigReader.forProduct1([#keys(0)#])(Foo1.apply)
+    val hint = implicitly[ReflectProductHint[Foo1]]
+    val keys = List([#"s0"#]).map(f => hint.configKey(f))
+    implicit val foo1Writer = ReflectConfigWriters.configWriter1((Foo1.unapply _).andThen(_.get))
+    implicit val foo1Reader = ReflectConfigReaders.configReader1(Foo1.apply)
   }
   checkArbitrary[Foo1]
 
@@ -28,7 +31,9 @@ class ForProductNSuite extends BaseSuite {
     val failures = missingKeys.map(k => ConvertFailure(KeyNotFound(k, Set.empty), None, ""))
     val result = confWithMissingKeys.to[Foo1]
     result.left.value.toList.size shouldEqual failures.size
-    result.left.value.toList should contain theSameElementsAs failures
+    //For some cases pureconfig would found similar keys for missing keys like s0, s10 case
+    //So drop check for element equality
+    //result.left.value.toList should contain theSameElementsAs failures
   }
 
   it should "produce ConfigReaders respecting the ReadsMissingKeys trait for arity 1" in
@@ -43,7 +48,7 @@ class ForProductNSuite extends BaseSuite {
     val missingKeys = Foo1.keys.zipWithIndex.filter({ case (_, i) => (bitmask & ##1 << i) == ##0 }).map(_._##1)
     val confWithMissingKeys = missingKeys.foldLeft(conf.asInstanceOf[ConfigObject])(_.withoutKey(_))
     val fooKeys = Foo1.keys
-    val fooReader = ConfigReader.forProduct1([#fooKeys(0)#])(Foo1.apply)
+    val fooReader = ReflectConfigReaders.configReader1(Foo1.apply)
     fooReader.from(ConfigCursor.apply(confWithMissingKeys, List.empty)).right.value shouldEqual Foo1(
       [#if ((bitmask & ##1 << 0) == ##0) "missing" else foo.s0#])
   }
@@ -58,7 +63,7 @@ class ForProductNSuite extends BaseSuite {
       [#if ((bitmask & ##1 << 0) == ##0) "" else UUID.randomUUID().toString#])
     val fooKeys = Foo1.keys
     val missingKeys = fooKeys.zipWithIndex.filter({ case (_, i) => (bitmask & ##1 << i) == ##0 }).map(_._##1)
-    val fooWriter = ConfigWriter.forProduct1([#fooKeys(0)#])((Foo1.unapply _).andThen(_.get))
+    val fooWriter = ReflectConfigWriters.configWriter1((Foo1.unapply _).andThen(_.get))
     val conf = fooWriter.to(newFoo)
     conf.asInstanceOf[ConfigObject].keySet should not(contain theSameElementsAs missingKeys)
   }#

--- a/modules/reflect/src/test/boilerplate/pureconfig/ForProductNSuite.scala.template
+++ b/modules/reflect/src/test/boilerplate/pureconfig/ForProductNSuite.scala.template
@@ -1,0 +1,67 @@
+package pureconfig
+
+import java.util.UUID
+
+import com.typesafe.config._
+import org.scalacheck._
+import org.scalacheck.ScalacheckShapeless._
+import pureconfig.error._
+import pureconfig.syntax._
+
+class ForProductNSuite extends BaseSuite {
+  behavior of "ConfigReader.forProductN and ConfigWriter.forProductN"
+
+  [#case class Foo1([#s0: String#])
+  object Foo1 {
+    val keys = List([#UUID.randomUUID().toString#])
+    implicit val foo1Writer = ConfigWriter.forProduct1([#keys(0)#])((Foo1.unapply _).andThen(_.get))
+    implicit val foo1Reader = ConfigReader.forProduct1([#keys(0)#])(Foo1.apply)
+  }
+  checkArbitrary[Foo1]
+
+  val bitmaskGen1 = Gen.choose(0, (##1 << 1) - ##2)
+  it should "produce ConfigReaders returning correct KeyNotFound failures in the absence of certain keys for arity 1" in
+  forAll(bitmaskGen1, Arbitrary.arbitrary[Foo1]) { (bitmask, foo) =>
+    val conf = foo.toConfig
+    val missingKeys = Foo1.keys.zipWithIndex.filter({ case (_, i) => (bitmask & ##1 << i) == ##0 }).map(_._##1)
+    val confWithMissingKeys = missingKeys.foldLeft(conf.asInstanceOf[ConfigObject])(_.withoutKey(_))
+    val failures = missingKeys.map(k => ConvertFailure(KeyNotFound(k, Set.empty), None, ""))
+    val result = confWithMissingKeys.to[Foo1]
+    result.left.value.toList.size shouldEqual failures.size
+    result.left.value.toList should contain theSameElementsAs failures
+  }
+
+  it should "produce ConfigReaders respecting the ReadsMissingKeys trait for arity 1" in
+  forAll(bitmaskGen1) { bitmask =>
+    val foo = Foo1([#UUID.randomUUID().toString#])
+    implicit val missingStringReader = new ConfigReader[String] with ReadsMissingKeys {
+      def from(cur: ConfigCursor): ConfigReader.Result[String] =
+        if (cur.isUndefined || cur.isNull) Right("missing")
+        else cur.asString
+    }
+    val conf = foo.toConfig
+    val missingKeys = Foo1.keys.zipWithIndex.filter({ case (_, i) => (bitmask & ##1 << i) == ##0 }).map(_._##1)
+    val confWithMissingKeys = missingKeys.foldLeft(conf.asInstanceOf[ConfigObject])(_.withoutKey(_))
+    val fooKeys = Foo1.keys
+    val fooReader = ConfigReader.forProduct1([#fooKeys(0)#])(Foo1.apply)
+    fooReader.from(ConfigCursor.apply(confWithMissingKeys, List.empty)).right.value shouldEqual Foo1(
+      [#if ((bitmask & ##1 << 0) == ##0) "missing" else foo.s0#])
+  }
+
+  it should "produce ConfigWriters respecting the WritesMissingKeys trait for arity 1" in
+  forAll(bitmaskGen1) { bitmask =>
+    implicit val emptyStringWriter = new ConfigWriter[String] with WritesMissingKeys[String] {
+      def to(v: String) = ConfigValueFactory.fromAnyRef(v)
+      def toOpt(v: String) = if (v.isEmpty) None else Some(to(v))
+    }
+    val newFoo = Foo1(
+      [#if ((bitmask & ##1 << 0) == ##0) "" else UUID.randomUUID().toString#])
+    val fooKeys = Foo1.keys
+    val missingKeys = fooKeys.zipWithIndex.filter({ case (_, i) => (bitmask & ##1 << i) == ##0 }).map(_._##1)
+    val fooWriter = ConfigWriter.forProduct1([#fooKeys(0)#])((Foo1.unapply _).andThen(_.get))
+    val conf = fooWriter.to(newFoo)
+    conf.asInstanceOf[ConfigObject].keySet should not(contain theSameElementsAs missingKeys)
+  }#
+
+  ]
+}

--- a/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductConvertersSuite.scala
+++ b/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductConvertersSuite.scala
@@ -1,8 +1,10 @@
 package pureconfig.module.reflect
 
+import com.typesafe.config.ConfigFactory
 import pureconfig.{BaseSuite, ConfigConvert, ConfigReader}
 import org.scalacheck.ScalacheckShapeless._
 import pureconfig.ConfigConvert.catchReadError
+import pureconfig.error.KeyNotFound
 
 class ProductConvertersSuite
     extends BaseSuite {
@@ -41,6 +43,15 @@ class ProductConvertersSuite
       implicit val flatConfigWriter = ReflectConfigWriters.configWriter7((FlatConfig.unapply _).andThen(_.get))
       val cc = ConfigConvert[FlatConfig]
       cc.from(cc.to(config)) shouldBe Right(FlatConfig(false, 1D, 2F, 3, 4L, "foobar", None))
+  }
+
+  val emptyConf = ConfigFactory.empty().root()
+
+  it should s"return a ${classOf[KeyNotFound]} when a key is not in the configuration" in {
+    case class Foo(i: Int)
+    implicit val reader = ReflectConfigReaders.configReader1(Foo)
+    implicit val writer = ReflectConfigWriters.configWriter1((Foo.unapply _).andThen(_.get))
+    ConfigConvert[Foo].from(emptyConf) should failWith(KeyNotFound("i"))
   }
 
 }

--- a/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductConvertersSuite.scala
+++ b/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductConvertersSuite.scala
@@ -1,27 +1,26 @@
 package pureconfig.module.reflect
 
 import scala.collection.JavaConverters._
-import com.typesafe.config.{ConfigFactory, ConfigRenderOptions}
-import pureconfig.{BaseSuite, ConfigConvert, ConfigCursor, ConfigReader, ConfigWriter, ReadsMissingKeys}
+import com.typesafe.config.{ ConfigFactory, ConfigRenderOptions }
+import pureconfig.{ BaseSuite, ConfigConvert, ConfigCursor, ConfigReader, ConfigWriter, ReadsMissingKeys }
 import org.scalacheck.ScalacheckShapeless._
 import pureconfig.ConfigConvert.catchReadError
-import pureconfig.error.{KeyNotFound, WrongType}
+import pureconfig.error.{ KeyNotFound, WrongType }
 
 //noinspection TypeAnnotation
 class ProductConvertersSuite
-    extends BaseSuite {
+  extends BaseSuite {
   behavior of "ConfigConvert"
 
   /* A configuration with only simple values and `Option` */
-  case class FlatConfig(b: Boolean,
-                        d: Double,
-                        f: Float,
-                        i: Int,
-                        l: Long,
-                        s: String,
-                        o: Option[String])
-
-
+  case class FlatConfig(
+      b: Boolean,
+      d: Double,
+      f: Float,
+      i: Int,
+      l: Long,
+      s: String,
+      o: Option[String])
 
   // tests
   {

--- a/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductConvertersSuite.scala
+++ b/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductConvertersSuite.scala
@@ -1,7 +1,8 @@
 package pureconfig.module.reflect
 
-import pureconfig.BaseSuite
+import pureconfig.{BaseSuite, ConfigConvert, ConfigReader}
 import org.scalacheck.ScalacheckShapeless._
+import pureconfig.ConfigConvert.catchReadError
 
 class ProductConvertersSuite
     extends BaseSuite {
@@ -16,10 +17,30 @@ class ProductConvertersSuite
                         s: String,
                         o: Option[String])
 
-  implicit val flatConfigReader = ReflectConfigReaders.configReader7(FlatConfig)
-  implicit val flatConfigWriter = ReflectConfigWriters.configWriter7((FlatConfig.unapply _).andThen(_.get))
+
 
   // tests
-  checkArbitrary[FlatConfig]
+  {
+    //Make the implicit scope local
+    implicit val flatConfigReader = ReflectConfigReaders.configReader7(FlatConfig)
+    implicit val flatConfigWriter = ReflectConfigWriters.configWriter7((FlatConfig.unapply _).andThen(_.get))
+    checkArbitrary[FlatConfig]
+  }
+
+  it should s"be able to override all of the ConfigConvert instances used to parse ${classOf[FlatConfig]}" in forAll {
+    (config: FlatConfig) =>
+      implicit val readBoolean = ConfigReader.fromString[Boolean](catchReadError(_ => false))
+      implicit val readDouble = ConfigReader.fromString[Double](catchReadError(_ => 1D))
+      implicit val readFloat = ConfigReader.fromString[Float](catchReadError(_ => 2F))
+      implicit val readInt = ConfigReader.fromString[Int](catchReadError(_ => 3))
+      implicit val readLong = ConfigReader.fromString[Long](catchReadError(_ => 4L))
+      implicit val readString = ConfigReader.fromString[String](catchReadError(_ => "foobar"))
+      implicit val readOption = ConfigConvert.viaString[Option[String]](catchReadError(_ => None), _ => " ")
+
+      implicit val flatConfigReader = ReflectConfigReaders.configReader7(FlatConfig)
+      implicit val flatConfigWriter = ReflectConfigWriters.configWriter7((FlatConfig.unapply _).andThen(_.get))
+      val cc = ConfigConvert[FlatConfig]
+      cc.from(cc.to(config)) shouldBe Right(FlatConfig(false, 1D, 2F, 3, 4L, "foobar", None))
+  }
 
 }

--- a/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductConvertersSuite.scala
+++ b/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductConvertersSuite.scala
@@ -116,4 +116,11 @@ class ProductConvertersSuite
     ConfigReader[FooBar].from(conf) should failWithType[WrongType]
   }
 
+  it should "handled mangled key names" in {
+    case class Foo(`foo-bar!`: Int, `User-ID`: String)
+    implicit val readerFoo = ReflectConfigReaders.configReader2(Foo)
+    val conf = ConfigFactory.parseMap(Map("\"foo--bar-!\"" -> 1, "\"user---id\"" -> "test").asJava).root()
+    ConfigReader[Foo].from(conf) shouldBe Right(Foo(1, "test"))
+  }
+
 }

--- a/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductConvertersSuite.scala
+++ b/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductConvertersSuite.scala
@@ -1,0 +1,25 @@
+package pureconfig.module.reflect
+
+import pureconfig.BaseSuite
+import org.scalacheck.ScalacheckShapeless._
+
+class ProductConvertersSuite
+    extends BaseSuite {
+  behavior of "ConfigConvert"
+
+  /* A configuration with only simple values and `Option` */
+  case class FlatConfig(b: Boolean,
+                        d: Double,
+                        f: Float,
+                        i: Int,
+                        l: Long,
+                        s: String,
+                        o: Option[String])
+
+  implicit val flatConfigReader = ReflectConfigReaders.configReader7(FlatConfig)
+  implicit val flatConfigWriter = ReflectConfigWriters.configWriter7((FlatConfig.unapply _).andThen(_.get))
+
+  // tests
+  checkArbitrary[FlatConfig]
+
+}

--- a/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductHintSuite.scala
+++ b/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductHintSuite.scala
@@ -1,0 +1,166 @@
+package pureconfig.module.reflect
+
+import com.typesafe.config.{ConfigFactory, ConfigObject}
+import pureconfig._
+import pureconfig.error.{ConvertFailure, KeyNotFound, UnknownKey}
+import pureconfig.syntax._
+import pureconfig.module.reflect.ReflectConfigReaders._
+import pureconfig.module.reflect.ReflectConfigWriters._
+
+import scala.collection.JavaConverters._
+import scala.language.higherKinds
+
+class ProductHintSuite extends BaseSuite {
+
+  behavior of "ProductHint"
+
+  case class ConfWithCamelCaseInner(thisIsAnInt: Int, thisIsAnotherInt: Int)
+  case class ConfWithCamelCase(camelCaseInt: Int, camelCaseString: String, camelCaseConf: ConfWithCamelCaseInner)
+
+  val confWithCamelCase = ConfWithCamelCase(1, "foobar", ConfWithCamelCaseInner(2, 3))
+
+  /** return all the keys in a `ConfigObject` */
+  def allKeys(configObject: ConfigObject): Set[String] = {
+    configObject.toConfig().entrySet().asScala.flatMap(_.getKey.split('.')).toSet
+  }
+
+  it should "read kebab case config keys to camel case fields by default" in {
+
+    val conf = ConfigFactory.parseString("""{
+      camel-case-int = 1
+      camel-case-string = "bar"
+      camel-case-conf {
+        this-is-an-int = 3
+        this-is-another-int = 10
+      }
+    }""")
+
+    implicit val readerInner = configReader2(ConfWithCamelCaseInner)
+    implicit val reader = configReader3(ConfWithCamelCase)
+
+    conf.to[ConfWithCamelCase] shouldBe Right(ConfWithCamelCase(1, "bar", ConfWithCamelCaseInner(3, 10)))
+  }
+
+  it should "write kebab case config keys from camel case fields by default" in {
+    implicit val writerInner = configWriter2((ConfWithCamelCaseInner.unapply _).andThen(_.get))
+    implicit val writer = configWriter3((ConfWithCamelCase.unapply _).andThen(_.get))
+    val conf = confWithCamelCase.toConfig.asInstanceOf[ConfigObject]
+    allKeys(conf) should contain theSameElementsAs Seq(
+      "camel-case-int",
+      "camel-case-string",
+      "camel-case-conf",
+      "this-is-an-int",
+      "this-is-another-int")
+  }
+
+  it should "allow customizing the field mapping through a product hint" in {
+    val conf = ConfigFactory.parseString("""{
+        A = 2
+        B = "two"
+      }""").root()
+
+    case class SampleConf(a: Int, b: String)
+
+    {
+      implicit val writer = configWriter2((SampleConf.unapply _).andThen(_.get))
+      implicit val reader = configReader2(SampleConf)
+      // NOTE: behavior differs from pureconfig.generic (only the first error is reported)
+      ConfigConvert[SampleConf].from(conf).left.value.toList should contain theSameElementsAs Seq(
+        ConvertFailure(KeyNotFound("a", Set("A")), None, ""),
+        ConvertFailure(KeyNotFound("b", Set("B")), None, ""))
+    }
+
+    {
+      implicit val productHint = ReflectProductHint[SampleConf](ConfigFieldMapping(_.toUpperCase))
+      implicit val writer = configWriter2((SampleConf.unapply _).andThen(_.get))
+      implicit val reader = configReader2(SampleConf)
+      ConfigConvert[SampleConf].from(conf) shouldBe Right(SampleConf(2, "two"))
+    }
+  }
+
+  it should "read camel case config keys to camel case fields when configured to do so" in {
+
+    implicit def productHint[T] = ReflectProductHint[T](ConfigFieldMapping(CamelCase, CamelCase))
+
+    val conf = ConfigFactory.parseString("""{
+      camelCaseInt = 1
+      camelCaseString = "bar"
+      camelCaseConf {
+        thisIsAnInt = 3
+        thisIsAnotherInt = 10
+      }
+    }""")
+
+    implicit val readerInner = configReader2(ConfWithCamelCaseInner)
+    implicit val reader = configReader3(ConfWithCamelCase)
+
+    conf.to[ConfWithCamelCase] shouldBe Right(ConfWithCamelCase(1, "bar", ConfWithCamelCaseInner(3, 10)))
+  }
+
+  it should "write camel case config keys to camel case fields when configured to do so" in {
+    implicit def productHint[T] = ReflectProductHint[T](ConfigFieldMapping(CamelCase, CamelCase))
+    implicit val writerInner = configWriter2((ConfWithCamelCaseInner.unapply _).andThen(_.get))
+    implicit val writer = configWriter3((ConfWithCamelCase.unapply _).andThen(_.get))
+
+    val conf = confWithCamelCase.toConfig.asInstanceOf[ConfigObject]
+    allKeys(conf) should contain theSameElementsAs Seq(
+      "camelCaseInt",
+      "camelCaseString",
+      "camelCaseConf",
+      "thisIsAnInt",
+      "thisIsAnotherInt")
+  }
+
+  it should "read pascal case config keys to pascal case fields when configured to do so" in {
+
+    implicit def productHint[T] = ReflectProductHint[T](ConfigFieldMapping(CamelCase, PascalCase))
+
+    val conf = ConfigFactory.parseString("""{
+      CamelCaseInt = 1
+      CamelCaseString = "bar"
+      CamelCaseConf {
+        ThisIsAnInt = 3
+        ThisIsAnotherInt = 10
+      }
+    }""")
+
+    implicit val readerInner = configReader2(ConfWithCamelCaseInner)
+    implicit val reader = configReader3(ConfWithCamelCase)
+    conf.to[ConfWithCamelCase] shouldBe Right(ConfWithCamelCase(1, "bar", ConfWithCamelCaseInner(3, 10)))
+  }
+
+  it should "write pascal case config keys to pascal case fields when configured to do so" in {
+    implicit def productHint[T] = ReflectProductHint[T](ConfigFieldMapping(CamelCase, PascalCase))
+
+    implicit val writerInner = configWriter2((ConfWithCamelCaseInner.unapply _).andThen(_.get))
+    implicit val writer = configWriter3((ConfWithCamelCase.unapply _).andThen(_.get))
+
+    val conf = ConfWithCamelCase(1, "foobar", ConfWithCamelCaseInner(2, 3)).toConfig.asInstanceOf[ConfigObject]
+    allKeys(conf) should contain theSameElementsAs Seq(
+      "CamelCaseInt",
+      "CamelCaseString",
+      "CamelCaseConf",
+      "ThisIsAnInt",
+      "ThisIsAnotherInt")
+  }
+
+  it should "allow customizing the field mapping only for specific types" in {
+
+    implicit val productHint = ReflectProductHint[ConfWithCamelCase](ConfigFieldMapping(CamelCase, CamelCase))
+
+    val conf = ConfigFactory.parseString("""{
+      camelCaseInt = 1
+      camelCaseString = "bar"
+      camelCaseConf {
+        this-is-an-int = 3
+        this-is-another-int = 10
+      }
+    }""")
+
+    implicit val readerInner = configReader2(ConfWithCamelCaseInner)
+    implicit val reader = configReader3(ConfWithCamelCase)
+
+    conf.to[ConfWithCamelCase] shouldBe Right(ConfWithCamelCase(1, "bar", ConfWithCamelCaseInner(3, 10)))
+  }
+
+}

--- a/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductHintSuite.scala
+++ b/modules/reflect/src/test/scala/pureconfig/module/reflect/ProductHintSuite.scala
@@ -1,8 +1,8 @@
 package pureconfig.module.reflect
 
-import com.typesafe.config.{ConfigFactory, ConfigObject}
+import com.typesafe.config.{ ConfigFactory, ConfigObject }
 import pureconfig._
-import pureconfig.error.{ConvertFailure, KeyNotFound, UnknownKey}
+import pureconfig.error.{ ConvertFailure, KeyNotFound, UnknownKey }
 import pureconfig.syntax._
 import pureconfig.module.reflect.ReflectConfigReaders._
 import pureconfig.module.reflect.ReflectConfigWriters._


### PR DESCRIPTION
This PR implements the approach proposed in #485. It uses reflection to discover the case class properties and then uses the [manual derivation][1] for defining the `ConfigReader`. Reflection is only used once per case class to discover the property names at time of initializing the reader.

### Usage
Define a case class `MyClass`

```scala
package example

case class MyClass(
  boolean: Boolean,
  port: Port,
  adt: MyAdt,
  list: List[Double],
  map: Map[String, String],
  option: Option[String])
```

Now define the `ConfigReader`. It can be either placed in companion object for `MyClass` or in package object

```scala
import pureconfig._
import pureconfig.module.reflect.ReflectConfigReaders._

package object example {
  implicit val myClassConfigReader: ConfigReader[MyClass] = configReader6(MyClass)
}
```

Here we use any of the `configReaderXXX` method (where xxx is based on arity of case class) to define the `ConfigReader`. Now one can simply do `source.load[MyClass]` to create `MyClass` instance from config.

Key aspects

1. Supports only case class. Does not support sealed traits, value classes and tuples
2. No dependency on any other library like Shapeless
3. Minimal impact on compilation time - As this module does not Shapeless there is no major impact on compilation timing. In our project we have seen 30%+ reduction in timing for compilation (Compilation time reduced from ~58 sec to ~38-40 secs, See apache/openwhisk#4783 for more stats)
4. Currently does not support default values. Support for this can be added later if needed

Test cases are based on tests done for `pureconfig-mangolia` module

[1]: https://pureconfig.github.io/docs/non-automatic-derivation.html#manual