### PR TITLE
Update example in initial page and point to naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,32 +47,51 @@ In your code, import `pureconfig.generic.auto` and define data types and a case 
 import pureconfig._
 import pureconfig.generic.auto._
 
-sealed trait MyAdt
-case class AdtA(a: String) extends MyAdt
-case class AdtB(b: Int) extends MyAdt
-final case class Port(value: Int) extends AnyVal
-case class MyClass(
-  boolean: Boolean,
+case class Port(number: Int) extends AnyVal
+
+sealed trait AuthMethod
+case class Login(username: String, password: String) extends AuthMethod
+case class Token(token: String) extends AuthMethod
+case class PrivateKey(pkFile: java.io.File) extends AuthMethod
+
+case class ServiceConf(
+  host: String,
   port: Port,
-  adt: MyAdt,
-  list: List[Double],
-  map: Map[String, String],
-  option: Option[String])
+  useHttps: Boolean,
+  authMethods: List[AuthMethod]
+)
 ```
 
-Second, define an `application.conf` file like
-[this](https://github.com/pureconfig/pureconfig/blob/master/docs/src/main/resources/application.conf) and add it as a
-resource file of your application (with SBT, they are usually placed in `src/main/resources`).
+Second, create an `application.conf` file and add it as a resource of your application (with SBT, they are usually
+placed in `src/main/resources`):
+
+```
+// src/main/resources/application.conf
+host = "example.com"
+port = 8080
+use-https = true
+auth-methods = [
+  { type = "private-key", pk-file = "/home/user/myauthkey" },
+  { type = "login", username = "pureconfig", password = "12345678" }
+]
+```
 
 Finally, load the configuration:
 
 ```scala
-ConfigSource.default.load[MyClass]
-// res0: pureconfig.ConfigReader.Result[MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
+ConfigSource.default.load[ServiceConf]
+// res4: ConfigReader.Result[ServiceConf] = Right(
+//   ServiceConf(
+//     "example.com",
+//     Port(8080),
+//     true,
+//     List(PrivateKey(/home/user/myauthkey), Login("pureconfig", "12345678"))
+//   )
+// )
 ```
 
-`ConfigReader.Result[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
-would handle an `Either` value.
+`ConfigReader.Result[ServiceConf]` is just an alias for `Either[ConfigReaderFailures, ServiceConf]`, so you can handle
+it just like you would handle an `Either` value.
 
 The various `loadConfig` methods defer to Typesafe Config's
 [`ConfigFactory`](https://lightbend.github.io/config/latest/api/com/typesafe/config/ConfigFactory.html) to

--- a/bundle/src/main/tut/README.md
+++ b/bundle/src/main/tut/README.md
@@ -47,32 +47,51 @@ In your code, import `pureconfig.generic.auto` and define data types and a case 
 import pureconfig._
 import pureconfig.generic.auto._
 
-sealed trait MyAdt
-case class AdtA(a: String) extends MyAdt
-case class AdtB(b: Int) extends MyAdt
-final case class Port(value: Int) extends AnyVal
-case class MyClass(
-  boolean: Boolean,
+case class Port(number: Int) extends AnyVal
+
+sealed trait AuthMethod
+case class Login(username: String, password: String) extends AuthMethod
+case class Token(token: String) extends AuthMethod
+case class PrivateKey(pkFile: java.io.File) extends AuthMethod
+
+case class ServiceConf(
+  host: String,
   port: Port,
-  adt: MyAdt,
-  list: List[Double],
-  map: Map[String, String],
-  option: Option[String])
+  useHttps: Boolean,
+  authMethods: List[AuthMethod]
+)
 ```
 
-Second, define an `application.conf` file like
-[this](https://github.com/pureconfig/pureconfig/blob/master/docs/src/main/resources/application.conf) and add it as a
-resource file of your application (with SBT, they are usually placed in `src/main/resources`).
+Second, create an `application.conf` file and add it as a resource of your application (with SBT, they are usually
+placed in `src/main/resources`):
+
+```
+// src/main/resources/application.conf
+host = "example.com"
+port = 8080
+use-https = true
+auth-methods = [
+  { type = "private-key", pk-file = "/home/user/myauthkey" },
+  { type = "login", username = "pureconfig", password = "12345678" }
+]
+```
 
 Finally, load the configuration:
 
 ```scala
-ConfigSource.default.load[MyClass]
-// res0: pureconfig.ConfigReader.Result[MyClass] = Right(MyClass(true,Port(8080),AdtB(1),List(1.0, 0.2),Map(key -> value),None))
+ConfigSource.default.load[ServiceConf]
+// res4: ConfigReader.Result[ServiceConf] = Right(
+//   ServiceConf(
+//     "example.com",
+//     Port(8080),
+//     true,
+//     List(PrivateKey(/home/user/myauthkey), Login("pureconfig", "12345678"))
+//   )
+// )
 ```
 
-`ConfigReader.Result[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
-would handle an `Either` value.
+`ConfigReader.Result[ServiceConf]` is just an alias for `Either[ConfigReaderFailures, ServiceConf]`, so you can handle
+it just like you would handle an `Either` value.
 
 The various `loadConfig` methods defer to Typesafe Config's
 [`ConfigFactory`](https://lightbend.github.io/config/latest/api/com/typesafe/config/ConfigFactory.html) to

--- a/docs/docs/docs/index.md
+++ b/docs/docs/docs/index.md
@@ -23,31 +23,41 @@ In your code, import `pureconfig.generic.auto` and define data types and a case 
 import pureconfig._
 import pureconfig.generic.auto._
 
-sealed trait MyAdt
-case class AdtA(a: String) extends MyAdt
-case class AdtB(b: Int) extends MyAdt
-final case class Port(value: Int) extends AnyVal
-case class MyClass(
-  boolean: Boolean,
+case class Port(number: Int) extends AnyVal
+
+sealed trait AuthMethod
+case class Login(username: String, password: String) extends AuthMethod
+case class Token(token: String) extends AuthMethod
+case class PrivateKey(pkFile: java.io.File) extends AuthMethod
+
+case class ServiceConf(
+  host: String,
   port: Port,
-  adt: MyAdt,
-  list: List[Double],
-  map: Map[String, String],
-  option: Option[String])
+  useHttps: Boolean,
+  authMethods: List[AuthMethod]
+)
 ```
 
-Second, define an `application.conf` file like
-[this](https://github.com/pureconfig/pureconfig/blob/master/docs/src/main/resources/application.conf) and add it as a
-resource file of your application (with SBT, they are usually placed in `src/main/resources`).
+Second, create an `application.conf` file and add it as a resource of your application (with SBT, they are usually
+placed in `src/main/resources`):
+
+```scala mdoc:passthrough
+println("```")
+println(scala.io.Source.fromFile("docs/src/main/resources/application.conf").mkString.trim)
+println("```")
+```
+
+Note the usage of different naming conventions for config keys and class fields, which you
+[can customize later](overriding-behavior-for-case-classes.html).
 
 Finally, load the configuration:
 
 ```scala mdoc
-ConfigSource.default.load[MyClass]
+ConfigSource.default.load[ServiceConf]
 ```
 
-`ConfigReader.Result[MyClass]` is just an alias for `Either[ConfigReaderFailures, MyClass]`, so you can handle it just like you
-would handle an `Either` value.
+`ConfigReader.Result[ServiceConf]` is just an alias for `Either[ConfigReaderFailures, ServiceConf]`, so you can handle
+it just like you would handle an `Either` value.
 
 `ConfigSource.default` defers to Typesafe Config's
 [`ConfigFactory`](https://lightbend.github.io/config/latest/api/com/typesafe/config/ConfigFactory.html) to

--- a/docs/src/main/resources/application.conf
+++ b/docs/src/main/resources/application.conf
@@ -1,10 +1,8 @@
-boolean = true
+// src/main/resources/application.conf
+host = "example.com"
 port = 8080
-adt {
-  type = "adt-b"
-  b = 1
-}
-list = ["1", "20%"]
-map {
-  key = "value"
-}
+use-https = true
+auth-methods = [
+  { type = "private-key", pk-file = "/home/user/myauthkey" },
+  { type = "login", username = "pureconfig", password = "12345678" }
+]


### PR DESCRIPTION
Depends on #687. Closes #690.

Updates the example in the initial page of the documentation to resemble more a real world config (including cases of kebab case to camel case translations) and briefly mention the (customizable) naming conventions.
