### PR TITLE
Proposal: Using blocker on the cats-effect module

### DIFF
--- a/core/src/main/scala/pureconfig/ConfigSource.scala
+++ b/core/src/main/scala/pureconfig/ConfigSource.scala
@@ -63,7 +63,7 @@ trait ConfigSource {
    * @return A `Right` with the configuration if it is possible to create an instance of type
    *         `A` from this source, a `Failure` with details on why it isn't possible otherwise
    */
-  def load[A](implicit reader: Derivation[ConfigReader[A]]): Result[A] =
+  final def load[A](implicit reader: Derivation[ConfigReader[A]]): Result[A] =
     cursor().right.flatMap(reader.value.from)
 
   /**
@@ -74,7 +74,7 @@ trait ConfigSource {
    * @return The configuration of type `A` loaded from this source.
    */
   @throws[ConfigReaderException[_]]
-  def loadOrThrow[A: ClassTag](implicit reader: Derivation[ConfigReader[A]]): A = {
+  final def loadOrThrow[A: ClassTag](implicit reader: Derivation[ConfigReader[A]]): A = {
     load[A] match {
       case Right(config) => config
       case Left(failures) => throw new ConfigReaderException[A](failures)

--- a/modules/cats-effect/README.md
+++ b/modules/cats-effect/README.md
@@ -23,11 +23,13 @@ To load a configuration file from a path using cats-effect's `IO`:
 import pureconfig._
 import pureconfig.generic.auto._
 import pureconfig.module.catseffect.syntax._
-import cats.effect.IO
+import cats.effect.{ Blocker, IO }
 
-case class MyConfig(somefield: Int, anotherfield: String)
+final case class MyConfig(somefield: Int, anotherfield: String)
 
-val load: IO[MyConfig] = ConfigSource.file(somePath).loadF[IO, MyConfig]
+val load: IO[MyConfig] = Blocker[IO].use { blocker =>
+  ConfigSource.file(somePath).loadF[IO, MyConfig](blocker)
+}
 ```
 
 To test that this `IO` does indeed return a `MyConfig` instance:
@@ -48,8 +50,11 @@ To create an IO that writes out a configuration file, do as follows:
 
 ```scala
 import pureconfig.module.catseffect._
-import cats.effect.IO
+import cats.effect.{ Blocker, IO }
 
 val someConfig = MyConfig(1234, "some string")
-val save: IO[Unit] = saveConfigAsPropertyFileF[IO, MyConfig](someConfig, somePath)
+
+val save: IO[Unit] = Blocker[IO].use { blocker =>
+  saveConfigAsPropertyFileF[IO, MyConfig](someConfig, somePath, blocker)
+}
 ```

--- a/modules/cats-effect/README.md
+++ b/modules/cats-effect/README.md
@@ -23,16 +23,20 @@ To load a configuration file from a path using cats-effect's `IO`:
 import pureconfig._
 import pureconfig.generic.auto._
 import pureconfig.module.catseffect.syntax._
-import cats.effect.{ Blocker, IO }
+import cats.effect.{ Blocker, ContextShift, IO }
 
-final case class MyConfig(somefield: Int, anotherfield: String)
+case class MyConfig(somefield: Int, anotherfield: String)
 
-val load: IO[MyConfig] = Blocker[IO].use { blocker =>
+def load(blocker: Blocker)(implicit cs: ContextShift[IO]): IO[MyConfig] = {
   ConfigSource.file(somePath).loadF[IO, MyConfig](blocker)
 }
 ```
 
 To test that this `IO` does indeed return a `MyConfig` instance:
+
+
+
+
 ```scala
 //Show the contents of the file
 new String(Files.readAllBytes(somePath), StandardCharsets.UTF_8)
@@ -40,7 +44,7 @@ new String(Files.readAllBytes(somePath), StandardCharsets.UTF_8)
 // somefield=1234
 // anotherfield=some string
 
-load.unsafeRunSync().equals(MyConfig(1234, "some string"))
+Blocker[IO].use(load).unsafeRunSync().equals(MyConfig(1234, "some string"))
 // res3: Boolean = true
 ```
 
@@ -48,13 +52,17 @@ load.unsafeRunSync().equals(MyConfig(1234, "some string"))
 
 To create an IO that writes out a configuration file, do as follows:
 
+
+
+
 ```scala
 import pureconfig.module.catseffect._
-import cats.effect.{ Blocker, IO }
+import pureconfig.generic.auto._
+import cats.effect.{ Blocker, ContextShift, IO }
 
 val someConfig = MyConfig(1234, "some string")
 
-val save: IO[Unit] = Blocker[IO].use { blocker =>
-  saveConfigAsPropertyFileF[IO, MyConfig](someConfig, somePath, blocker)
+def save(blocker: Blocker)(implicit cs: ContextShift[IO]): IO[Unit] = {
+  blockingSaveConfigAsPropertyFileF[IO, MyConfig](someConfig, somePath, blocker)
 }
 ```

--- a/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/package.scala
+++ b/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/package.scala
@@ -70,7 +70,7 @@ package object catseffect {
    *         details on why it isn't possible
    */
   def loadConfigF[F[_], A](blocker: Blocker)(implicit F: Sync[F], csf: ContextShift[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
-    loadF[F, A](ConfigSource.default, blocker)
+    F.delay(ConfigSource.default).flatMap(cs => loadF(cs, blocker))
 
   /**
    * Load a configuration of type `A` from the standard configuration files

--- a/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/package.scala
+++ b/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/package.scala
@@ -6,19 +6,24 @@ import java.nio.file.Path
 import scala.language.higherKinds
 import scala.reflect.ClassTag
 
-import cats.effect.{ Blocker, ContextShift, Sync }
+import cats.data.NonEmptyList
+import cats.effect.Sync
 import cats.implicits._
-import com.typesafe.config.ConfigRenderOptions
+import com.typesafe.config.{ ConfigRenderOptions, Config => TypesafeConfig }
 import pureconfig._
 import pureconfig.error.ConfigReaderException
 
 package object catseffect {
 
-  private[catseffect] type ConfReader[A] = Derivation[ConfigReader[A]]
-  private[catseffect] type ConfWriter[A] = Derivation[ConfigWriter[A]]
+  @deprecated("Root will be treated as the default namespace", "0.12.0")
+  val defaultNameSpace = ""
 
-  def loadF[F[_]: Sync: ContextShift, A: ConfReader: ClassTag](cs: ConfigSource, blocker: Blocker): F[A] =
-    blocker.delay(cs.load[A].leftMap[Throwable](ConfigReaderException[A])).rethrow
+  def loadF[F[_], A](cs: ConfigSource)(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] = {
+    val delayedLoad = F.delay {
+      cs.load[A].leftMap[Throwable](ConfigReaderException[A])
+    }
+    delayedLoad.rethrow
+  }
 
   /**
    * Load a configuration of type `A` from the standard configuration files
@@ -27,8 +32,67 @@ package object catseffect {
    *         `A` from the configuration files, or fail with a ConfigReaderException which in turn contains
    *         details on why it isn't possible
    */
-  def loadConfigF[F[_]: Sync: ContextShift, A: ConfReader: ClassTag](blocker: Blocker): F[A] =
-    loadF[F, A](ConfigSource.default, blocker)
+  def loadConfigF[F[_], A](implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
+    loadF[F, A](ConfigSource.default)
+
+  /**
+   * Load a configuration of type `A` from the standard configuration files
+   *
+   * @param namespace the base namespace from which the configuration should be load
+   * @return The returned action will complete with `A` if it is possible to create an instance of type
+   *         `A` from the configuration files, or fail with a ConfigReaderException which in turn contains
+   *         details on why it isn't possible
+   */
+  @deprecated("Use `ConfigSource.default.at(namespace).loadF[F, A]` instead", "0.12.0")
+  def loadConfigF[F[_], A](namespace: String)(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
+    loadF[F, A](ConfigSource.default.at(namespace))
+
+  /**
+   * Load a configuration of type `A` from the given file. Note that standard configuration
+   * files are still loaded but can be overridden from the given configuration file
+   *
+   * @param path the path of the configuration file from which to load
+   * @return The returned action will complete with `A` if it is possible to create an instance of type
+   *         `A` from the configuration file, or fail with a ConfigReaderException which in turn contains
+   *         details on why it isn't possible
+   */
+  @deprecated("Use `ConfigSource.default(ConfigSource.file(path)).loadF[F, A]` instead", "0.12.0")
+  def loadConfigF[F[_], A](path: Path)(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
+    loadF[F, A](ConfigSource.default(ConfigSource.file(path)))
+
+  /**
+   * Load a configuration of type `A` from the given file. Note that standard configuration
+   * files are still loaded but can be overridden from the given configuration file
+   *
+   * @param path the path of the configuration file from which to load
+   * @param namespace the base namespace from which the configuration should be load
+   * @return The returned action will complete with `A` if it is possible to create an instance of type
+   *         `A` from the configuration file, or fail with a ConfigReaderException which in turn contains
+   *         details on why it isn't possible
+   */
+  @deprecated("Use `ConfigSource.default(ConfigSource.file(path)).at(namespace).loadF[F, A]` instead", "0.12.0")
+  def loadConfigF[F[_], A](path: Path, namespace: String)(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
+    loadF[F, A](ConfigSource.default(ConfigSource.file(path)).at(namespace))
+
+  /**
+   * Load a configuration of type `A` from the given `Config`
+   * @return The returned action will complete with `A` if it is possible to create an instance of type
+   *         `A` from the configuration object, or fail with a ConfigReaderException which in turn contains
+   *         details on why it isn't possible
+   */
+  @deprecated("Use `ConfigSource.fromConfig(conf).loadF[F, A]` instead", "0.12.0")
+  def loadConfigF[F[_], A](conf: TypesafeConfig)(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
+    loadF[F, A](ConfigSource.fromConfig(conf))
+
+  /**
+   * Load a configuration of type `A` from the given `Config`
+   * @return The returned action will complete with `A` if it is possible to create an instance of type
+   *         `A` from the configuration object, or fail with a ConfigReaderException which in turn contains
+   *         details on why it isn't possible
+   */
+  @deprecated("Use `ConfigSource.fromConfig(conf).at(namespace).loadF[F, A]` instead", "0.12.0")
+  def loadConfigF[F[_], A](conf: TypesafeConfig, namespace: String)(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
+    loadF[F, A](ConfigSource.fromConfig(conf).at(namespace))
 
   /**
    * Save the given configuration into a property file
@@ -39,13 +103,13 @@ package object catseffect {
    * @param options the config rendering options
    * @return The return action will save out the supplied configuration upon invocation
    */
-  def saveConfigAsPropertyFileF[F[_]: Sync: ContextShift, A: ConfWriter](
+  def saveConfigAsPropertyFileF[F[_], A](
     conf: A,
     outputPath: Path,
-    blocker: Blocker,
     overrideOutputPath: Boolean = false,
-    options: ConfigRenderOptions = ConfigRenderOptions.defaults()): F[Unit] =
-    blocker.delay(pureconfig.saveConfigAsPropertyFile(conf, outputPath, overrideOutputPath, options))
+    options: ConfigRenderOptions = ConfigRenderOptions.defaults())(implicit F: Sync[F], writer: Derivation[ConfigWriter[A]]): F[Unit] = F.delay {
+    pureconfig.saveConfigAsPropertyFile(conf, outputPath, overrideOutputPath, options)
+  }
 
   /**
    * Writes the configuration to the output stream and closes the stream
@@ -55,10 +119,25 @@ package object catseffect {
    * @param options the config rendering options
    * @return The return action will save out the supplied configuration upon invocation
    */
-  def saveConfigToStreamF[F[_]: Sync: ContextShift, A: ConfWriter](
+  def saveConfigToStreamF[F[_], A](
     conf: A,
     outputStream: OutputStream,
-    blocker: Blocker,
-    options: ConfigRenderOptions = ConfigRenderOptions.defaults()): F[Unit] =
-    blocker.delay(pureconfig.saveConfigToStream(conf, outputStream, options))
+    options: ConfigRenderOptions = ConfigRenderOptions.defaults())(implicit F: Sync[F], writer: Derivation[ConfigWriter[A]]): F[Unit] = F.delay {
+    pureconfig.saveConfigToStream(conf, outputStream, options)
+  }
+
+  /**
+   * Loads `files` in order, allowing values in later files to backstop missing values from prior, and converts them into a `A`.
+   *
+   * This is a convenience method which enables having default configuration which backstops local configuration.
+   *
+   * Note: If an element of `files` references a file which doesn't exist or can't be read, it will silently be ignored.
+   *
+   * @param files Files ordered in decreasing priority containing part or all of a `A`. Must not be empty.
+   */
+  @deprecated("Construct a custom `ConfigSource` pipeline instead", "0.12.0")
+  def loadConfigFromFilesF[F[_], A](files: NonEmptyList[Path])(implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
+    loadF[F, A](ConfigSource.default(
+      files.map(ConfigSource.file(_).optional)
+        .foldLeft(ConfigSource.empty)(_.withFallback(_))))
 }

--- a/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/syntax/package.scala
+++ b/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/syntax/package.scala
@@ -12,8 +12,7 @@ package object syntax {
   implicit class CatsEffectConfigSource(private val cs: ConfigSource) extends AnyVal {
 
     @inline
-    final def loadF[F[_], A](blocker: Blocker)
-                            (implicit F: Sync[F], csf: ContextShift[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
+    final def loadF[F[_], A](blocker: Blocker)(implicit F: Sync[F], csf: ContextShift[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
       catseffect.loadF(cs, blocker)
 
     @deprecated("Use `cs.loadF[F, A](blocker)` instead", "0.12.3")

--- a/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/syntax/package.scala
+++ b/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/syntax/package.scala
@@ -3,12 +3,20 @@ package pureconfig.module.catseffect
 import scala.language.higherKinds
 import scala.reflect.ClassTag
 
-import cats.effect.Sync
+import cats.effect.{ Blocker, ContextShift, Sync }
 import pureconfig.{ ConfigReader, ConfigSource, Derivation }
 import pureconfig.module.catseffect
 
 package object syntax {
-  implicit class CatsEffectConfigSource(val cs: ConfigSource) extends AnyVal {
+
+  implicit class CatsEffectConfigSource(private val cs: ConfigSource) extends AnyVal {
+
+    @inline
+    final def loadF[F[_], A](blocker: Blocker)
+                            (implicit F: Sync[F], csf: ContextShift[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
+      catseffect.loadF(cs, blocker)
+
+    @deprecated("Use `cs.loadF[F, A](blocker)` instead", "0.12.3")
     def loadF[F[_], A](implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
       catseffect.loadF(cs)
   }

--- a/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/syntax/package.scala
+++ b/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/syntax/package.scala
@@ -3,15 +3,13 @@ package pureconfig.module.catseffect
 import scala.language.higherKinds
 import scala.reflect.ClassTag
 
-import cats.effect.{ Blocker, ContextShift, Sync }
-import pureconfig.ConfigSource
+import cats.effect.Sync
+import pureconfig.{ ConfigReader, ConfigSource, Derivation }
 import pureconfig.module.catseffect
 
 package object syntax {
-
-  implicit class CatsEffectConfigSource(private val cs: ConfigSource) extends AnyVal {
-    @inline
-    final def loadF[F[_]: Sync: ContextShift, A: ConfReader: ClassTag](blocker: Blocker): F[A] =
-      catseffect.loadF(cs, blocker)
+  implicit class CatsEffectConfigSource(val cs: ConfigSource) extends AnyVal {
+    def loadF[F[_], A](implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
+      catseffect.loadF(cs)
   }
 }

--- a/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/syntax/package.scala
+++ b/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/syntax/package.scala
@@ -3,13 +3,15 @@ package pureconfig.module.catseffect
 import scala.language.higherKinds
 import scala.reflect.ClassTag
 
-import cats.effect.Sync
-import pureconfig.{ ConfigReader, ConfigSource, Derivation }
+import cats.effect.{ Blocker, ContextShift, Sync }
+import pureconfig.ConfigSource
 import pureconfig.module.catseffect
 
 package object syntax {
-  implicit class CatsEffectConfigSource(val cs: ConfigSource) extends AnyVal {
-    def loadF[F[_], A](implicit F: Sync[F], reader: Derivation[ConfigReader[A]], ct: ClassTag[A]): F[A] =
-      catseffect.loadF(cs)
+
+  implicit class CatsEffectConfigSource(private val cs: ConfigSource) extends AnyVal {
+    @inline
+    final def loadF[F[_]: Sync: ContextShift, A: ConfReader: ClassTag](blocker: Blocker): F[A] =
+      catseffect.loadF(cs, blocker)
   }
 }

--- a/modules/cats-effect/src/test/scala/pureconfig/module/catseffect/CatsEffectSuite.scala
+++ b/modules/cats-effect/src/test/scala/pureconfig/module/catseffect/CatsEffectSuite.scala
@@ -17,12 +17,9 @@ final class CatsEffectSuite extends BaseSuite {
 
   private case class SomeCaseClass(somefield: Int, anotherfield: String)
 
-  private val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
+  private val blocker: Blocker = Blocker.liftExecutorService(Executors.newCachedThreadPool())
 
-  private val blocker: Blocker =
-    Blocker.liftExecutionContext(ec)
-
-  private implicit val ioCS = IO.contextShift(scala.concurrent.ExecutionContext.global)
+  private implicit val ioCS = IO.contextShift(ExecutionContext.global)
 
   private def getPath(classPathPath: String): Path = {
     val resource = getClass.getClassLoader.getResource(classPathPath)

--- a/modules/cats-effect/src/test/scala/pureconfig/module/catseffect/CatsEffectSuite.scala
+++ b/modules/cats-effect/src/test/scala/pureconfig/module/catseffect/CatsEffectSuite.scala
@@ -1,22 +1,26 @@
 package pureconfig.module.catseffect
 
-import java.io._
+import java.io.{ BufferedOutputStream, PipedInputStream, PipedOutputStream }
+import java.nio.file.{ Path, Paths }
+import java.util.concurrent.Executors
+
+import scala.concurrent.ExecutionContext
 
 import cats.effect.{ Blocker, ContextShift, IO }
+import com.typesafe.config.ConfigFactory
 import pureconfig.{ BaseSuite, ConfigSource }
 import pureconfig.error.{ ConfigReaderException, ConvertFailure }
 import pureconfig.generic.auto._
 import pureconfig.module.catseffect.syntax._
-import java.nio.file.{ Path, Paths }
-
-import com.typesafe.config.ConfigFactory
 
 final class CatsEffectSuite extends BaseSuite {
 
   private case class SomeCaseClass(somefield: Int, anotherfield: String)
 
+  private val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
+
   private val blocker: Blocker =
-    Blocker.liftExecutionContext(scala.concurrent.ExecutionContext.global)
+    Blocker.liftExecutionContext(ec)
 
   private implicit val ioCS = IO.contextShift(scala.concurrent.ExecutionContext.global)
 


### PR DESCRIPTION
AFAIK reading those configuration files are a blocking operation. As such, they should be done inside a _blocking context_, using [**Blocker**](https://typelevel.org/cats-effect/api/cats/effect/Blocker.html).

Since this is a binary breaking change, I took the liberty to also remove all the deprecated methods.
Obviously, that means this change can not be merged until you plan to release `0.13.0`

Let me know what do you think about this proposal.
I thought about asking in the **gitter** room before, but looking at the code I realized the change was easy to do, so I believed it was better just to start the proposal with the changes already done.