### PR TITLE
Http4s 0.21.0

### DIFF
--- a/modules/http4s/build.sbt
+++ b/modules/http4s/build.sbt
@@ -1,9 +1,9 @@
 name := "pureconfig-http4s"
 
-crossScalaVersions ~= { _.filterNot(_.startsWith("2.13")) }
+crossScalaVersions ~= { _.filterNot(_.startsWith("2.11")) }
 
 libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-core" % "0.20.17")
+  "org.http4s" %% "http4s-core" % "0.21.0")
 
 developers := List(
   Developer("jcranky", "Paulo Siqueira", "paulo.siqueira@gmail.com", url("https://github.com/jcranky")))


### PR DESCRIPTION
- Is Binary Breaking
- Http4s 0.21.0 only supports 2.12/2.13
