### PR TITLE
Improve support for more exotic ConfigValueLocation

### DIFF
--- a/core/src/main/scala/pureconfig/error/ConfigValueLocation.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigValueLocation.scala
@@ -46,8 +46,12 @@ object ConfigValueLocation {
    */
   def apply(co: ConfigOrigin): Option[ConfigValueLocation] =
     Option(co).flatMap { origin =>
-      if (origin.url != null && origin.lineNumber != -1)
-        Some(ConfigValueLocation(origin.url, origin.lineNumber))
+      // the `description` method will append the line number by default, which
+      // we don't want here. But it won't do that for negative line numbers,
+      // hence the `withLineNumber(-1)`.
+      val description = origin.withLineNumber(-1).description
+      if (origin.lineNumber != -1)
+        Some(ConfigValueLocation(description, origin.lineNumber))
       else
         None
     }


### PR DESCRIPTION
Hey,

I've noticed that pureconfig doesn't print a useful error location when you parse a String with `ConfigFactory.parseString`. In the `ConfigParseOptions` you can use `setOriginDescription` to give the user a hint where the config is from, but that won't set a url for the `ConfigOrigin`, and hence the current implementation in pureconfig won't use it.

A better way to do it is to use `ConfigOrigin`'s `description` method because that will return something useful for all origins, whether it's from a file, a resource etc.. Since it never returns null, no null check is needed.