### PR TITLE
Apply some minor fixes to example about semi-automatic derivation of families

### DIFF
--- a/docs/docs/docs/non-automatic-derivation.md
+++ b/docs/docs/docs/non-automatic-derivation.md
@@ -96,7 +96,7 @@ object Occupation {
   implicit val reader = deriveReader[Occupation]
 }
 
-case class WorkingPerson(name: String, surname: String, occuation: Occupation)
+case class WorkingPerson(name: String, surname: String, occupation: Occupation)
 
 object WorkingPerson {
   implicit val reader = deriveReader[WorkingPerson]
@@ -104,8 +104,8 @@ object WorkingPerson {
 ```
 
 ```scala mdoc
-ConfigSource.string("{ name: Isaac, surname: Newton, occuation.type: student }").load[WorkingPerson]
-ConfigSource.string("""{ name: David, surname: Shingy, occuation: { type: employed, job: Digital Prophet } }""").load[WorkingPerson]
+ConfigSource.string("{ name: Isaac, surname: Newton, occupation.type: student }").load[WorkingPerson]
+ConfigSource.string("""{ name: David, surname: Shingy, occupation: { type: employed, job: Digital Prophet } }""").load[WorkingPerson]
 ```
 
 ### Manual

--- a/docs/docs/docs/non-automatic-derivation.md
+++ b/docs/docs/docs/non-automatic-derivation.md
@@ -85,21 +85,21 @@ sealed trait Occupation extends Product with Serializable
 object Occupation {
   case class Employed(job: String) extends Occupation
   object Employed {
-    implicit val reader = deriveReader[Employed]
+    implicit val employedReader = deriveReader[Employed]
   }
   case object Unemployed extends Occupation {
-    implicit val reader = deriveReader[Unemployed.type]
+    implicit val unemployedReader = deriveReader[Unemployed.type]
   }
   case object Student extends Occupation {
-    implicit val reader = deriveReader[Student.type]
+    implicit val studentReader = deriveReader[Student.type]
   }
-  implicit val reader = deriveReader[Occupation]
+  implicit val occupationReader = deriveReader[Occupation]
 }
 
 case class WorkingPerson(name: String, surname: String, occupation: Occupation)
 
 object WorkingPerson {
-  implicit val reader = deriveReader[WorkingPerson]
+  implicit val workingPersonReader = deriveReader[WorkingPerson]
 }
 ```
 

--- a/docs/docs/docs/non-automatic-derivation.md
+++ b/docs/docs/docs/non-automatic-derivation.md
@@ -77,7 +77,8 @@ ConfigSource.fromConfig(conf).load[Person]
 
 #### Semi-Automatic for Sealed Families
 
-To support a sealed family with semi-automatic derivation, you'll need to provide a derivation for every concrete member of the family and the base of the family.
+To support a sealed family with semi-automatic derivation, you'll need to provide a derivation for every concrete member
+of the family and the base of the family.
 
 ```scala mdoc:silent
 sealed trait Occupation extends Product with Serializable


### PR DESCRIPTION
This fixes a typo in occupation, starts using different names for implicits to avoid shadowing and fills a paragraph at 120 chars, to be consistent with the rest of the document.