### PR TITLE
be Scala 2.13.3 compatible: don't rely on Symbol#toString to make key names

### DIFF
--- a/modules/generic/src/main/scala/pureconfig/generic/MapShapedWriter.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/MapShapedWriter.scala
@@ -30,7 +30,7 @@ object MapShapedWriter {
     hint: ProductHint[Wrapped]): MapShapedWriter[Wrapped, FieldType[K, V] :: T] = new MapShapedWriter[Wrapped, FieldType[K, V] :: T] {
 
     override def to(t: FieldType[K, V] :: T): ConfigValue = {
-      val keyStr = hint.configKey(key.value.toString().tail)
+      val keyStr = hint.configKey(key.value.name)
       val rem = tConfigWriter.value.to(t.tail)
       // TODO check that all keys are unique
       vFieldConvert.value.value match {


### PR DESCRIPTION
because `Symbol#toString` will change in Scala 2.13.3 to be `Symbol(foo)`
instead of `'foo`: https://github.com/scala/scala/pull/8933

using `.name` instead works as expected in any Scala version