### PR TITLE
Upgrades sttp to latest version

### DIFF
--- a/modules/sttp/README.md
+++ b/modules/sttp/README.md
@@ -15,7 +15,7 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-sttp" % "0.12.3"
 To load an sttp `Uri` into a configuration, create a new class:
 
 ```scala
-import com.softwaremill.sttp.Uri
+import sttp.model.Uri
 import com.typesafe.config.ConfigFactory.parseString
 import pureconfig._
 import pureconfig.generic.auto._

--- a/modules/sttp/build.sbt
+++ b/modules/sttp/build.sbt
@@ -1,7 +1,8 @@
 name := "pureconfig-sttp"
 
 libraryDependencies ++= Seq(
-  "com.softwaremill.sttp" %% "core" % "1.7.2")
+  "com.softwaremill.sttp.model" %% "core" % "1.1.3"
+)
 
 developers := List(
   Developer("bszwej", "Bartlomiej Szwej", "bszwej@gmail.com", url("https://github.com/bszwej")))

--- a/modules/sttp/src/main/scala/pureconfig/module/sttp/package.scala
+++ b/modules/sttp/src/main/scala/pureconfig/module/sttp/package.scala
@@ -1,6 +1,8 @@
 package pureconfig.module
 
-import com.softwaremill.sttp.{ sttp => _, _ }
+import _root_.sttp.model._
+import _root_.sttp.model.Uri._
+
 import pureconfig.ConfigReader
 import pureconfig.error.CannotConvert
 
@@ -12,7 +14,7 @@ package object sttp {
     ConfigReader.fromNonEmptyString { str =>
       Try(uri"$str") match {
         case Success(uri) => Right(uri)
-        case Failure(ex) => Left(CannotConvert(str, "com.softwaremill.sttp.Uri", ex.getMessage))
+        case Failure(ex) => Left(CannotConvert(str, "sttp.model.Uri", ex.getMessage))
       }
     }
 

--- a/modules/sttp/src/main/tut/README.md
+++ b/modules/sttp/src/main/tut/README.md
@@ -15,7 +15,7 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-sttp" % "0.12.3"
 To load an sttp `Uri` into a configuration, create a new class:
 
 ```tut:silent
-import com.softwaremill.sttp.Uri
+import sttp.model.Uri
 import com.typesafe.config.ConfigFactory.parseString
 import pureconfig._
 import pureconfig.generic.auto._

--- a/modules/sttp/src/test/scala/pureconfig/module/sttp/SttpSuite.scala
+++ b/modules/sttp/src/test/scala/pureconfig/module/sttp/SttpSuite.scala
@@ -1,6 +1,7 @@
 package pureconfig.module.sttp
 
-import com.softwaremill.sttp._
+import sttp.model.Uri
+import sttp.model.Uri._
 import com.typesafe.config.ConfigFactory
 import pureconfig.BaseSuite
 import pureconfig.error.{ CannotConvert, ConfigReaderFailures, ConvertFailure }
@@ -20,14 +21,14 @@ class SttpSuite extends BaseSuite {
   }
 
   it should "handle error when reading uri" in {
-    val config = ConfigFactory.parseString("""{uri = "https!!://wrong.io"}""")
+    val config = ConfigFactory.parseString("""{uri = "sttp.readthedocs.io"}""")
 
     val failure =
       ConvertFailure(
         reason = CannotConvert(
-          value = "https!!://wrong.io",
-          toType = "com.softwaremill.sttp.Uri",
-          because = "requirement failed: Scheme can only contain alphanumeric characters, +, - and ."),
+          value = "sttp.readthedocs.io",
+          toType = "sttp.model.Uri",
+          because = "missing scheme"),
         location = None,
         path = "uri")
 


### PR DESCRIPTION
The latest versions of sttp use a different artifact: https://github.com/softwaremill/sttp-model

Unfortunately the package name has changed to just `sttp` instead of `com.softwaremill.sttp`, which conflicts with the pureconfig module package name. Therefore I had to prefix the imports with `_root_`.
