### PR TITLE
Use a different test suite for collection converters

### DIFF
--- a/tests/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/tests/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -135,46 +135,6 @@ class BasicConvertersSuite extends BaseSuite {
     ConfigValueFactory.fromAnyRef("thursday"), // lowercase string vs upper case enum
     ConfigValueFactory.fromAnyRef("this is not a day")) // no such value
 
-  checkArbitrary[immutable.HashSet[String]]
-
-  checkArbitrary[immutable.List[Float]]
-  checkRead[immutable.List[Int]](
-    // order of keys maintained
-    ConfigValueFactory.fromMap(Map("2" -> 1, "0" -> 2, "1" -> 3).asJava) -> List(2, 3, 1),
-    ConfigValueFactory.fromMap(Map("3" -> 2, "1" -> 4).asJava) -> List(4, 2),
-    ConfigValueFactory.fromMap(Map("1" -> 1, "a" -> 2).asJava) -> List(1))
-
-  checkFailures[immutable.List[Int]](
-    ConfigValueFactory.fromMap(Map("b" -> 1, "a" -> 2).asJava) -> ConfigReaderFailures(
-      ConvertFailure(WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.LIST)), emptyConfigOrigin, "")),
-    ConfigValueFactory.fromMap(Map().asJava) -> ConfigReaderFailures(
-      ConvertFailure(WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.LIST)), emptyConfigOrigin, "")))
-
-  checkArbitrary[immutable.ListSet[Int]]
-
-  checkArbitrary[immutable.Map[String, Int]]
-  checkFailures[immutable.Map[String, Int]](
-    // nested map should fail
-    ConfigFactory.parseString("conf.a=1").root() -> ConfigReaderFailures(
-      ConvertFailure(WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.NUMBER)), stringConfigOrigin(1), "conf")),
-    // wrong value type should fail
-    ConfigFactory.parseString("{ a=b }").root() -> ConfigReaderFailures(
-      ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), stringConfigOrigin(1), "a")))
-
-  checkArbitrary[immutable.Queue[Boolean]]
-
-  checkArbitrary[immutable.Set[Double]]
-  checkRead[immutable.Set[Int]](
-    ConfigValueFactory.fromMap(Map("1" -> 4, "2" -> 5, "3" -> 6).asJava) -> Set(4, 5, 6))
-
-  checkArbitrary[immutable.Stream[String]]
-
-  checkArbitrary[immutable.TreeSet[Int]]
-
-  checkArbitrary[immutable.Vector[Short]]
-
-  checkArbitrary[Option[Int]]
-
   checkReadWriteString[Pattern]("(a|b)" -> Pattern.compile("(a|b)"))
   checkFailure[Pattern, CannotConvert](ConfigValueFactory.fromAnyRef("(a|b")) // missing closing ')'
 

--- a/tests/src/test/scala/pureconfig/CollectionConvertersSuite.scala
+++ b/tests/src/test/scala/pureconfig/CollectionConvertersSuite.scala
@@ -1,0 +1,53 @@
+package pureconfig
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.{ HashSet, ListSet, Queue, TreeSet }
+
+import com.typesafe.config.{ ConfigFactory, ConfigValueFactory, ConfigValueType }
+import pureconfig.error.{ ConfigReaderFailures, ConvertFailure, WrongType }
+
+class CollectionConvertersSuite extends BaseSuite {
+  implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
+
+  behavior of "ConfigConvert"
+
+  checkArbitrary[HashSet[String]]
+
+  checkArbitrary[List[Float]]
+  checkRead[List[Int]](
+    // order of keys maintained
+    ConfigValueFactory.fromMap(Map("2" -> 1, "0" -> 2, "1" -> 3).asJava) -> List(2, 3, 1),
+    ConfigValueFactory.fromMap(Map("3" -> 2, "1" -> 4).asJava) -> List(4, 2),
+    ConfigValueFactory.fromMap(Map("1" -> 1, "a" -> 2).asJava) -> List(1))
+
+  checkFailures[List[Int]](
+    ConfigValueFactory.fromMap(Map("b" -> 1, "a" -> 2).asJava) -> ConfigReaderFailures(
+      ConvertFailure(WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.LIST)), emptyConfigOrigin, "")),
+    ConfigValueFactory.fromMap(Map().asJava) -> ConfigReaderFailures(
+      ConvertFailure(WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.LIST)), emptyConfigOrigin, "")))
+
+  checkArbitrary[ListSet[Int]]
+
+  checkArbitrary[Map[String, Int]]
+  checkFailures[Map[String, Int]](
+    // nested map should fail
+    ConfigFactory.parseString("conf.a=1").root() -> ConfigReaderFailures(
+      ConvertFailure(WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.NUMBER)), stringConfigOrigin(1), "conf")),
+    // wrong value type should fail
+    ConfigFactory.parseString("{ a=b }").root() -> ConfigReaderFailures(
+      ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), stringConfigOrigin(1), "a")))
+
+  checkArbitrary[Queue[Boolean]]
+
+  checkArbitrary[Set[Double]]
+  checkRead[Set[Int]](
+    ConfigValueFactory.fromMap(Map("1" -> 4, "2" -> 5, "3" -> 6).asJava) -> Set(4, 5, 6))
+
+  checkArbitrary[Stream[String]]
+
+  checkArbitrary[TreeSet[Int]]
+
+  checkArbitrary[Vector[Short]]
+
+  checkArbitrary[Option[Int]]
+}


### PR DESCRIPTION
Since we provide `ConfigReader`s and `ConfigWriter`s for collections in a different trait, it helps to locate their tests by using a similarly named suite.