### PR TITLE
Have a more convenient apply method for `ConfigReaderFailures`

### DIFF
--- a/core/src/main/scala/pureconfig/ConfigCursor.scala
+++ b/core/src/main/scala/pureconfig/ConfigCursor.scala
@@ -257,7 +257,7 @@ sealed trait ConfigCursor {
    * @return a `ConfigReader` result built by scoping `reason` into the context of this cursor.
    */
   def scopeFailure[A](result: Either[FailureReason, A]): ConfigReader.Result[A] =
-    result.left.map { reason => ConfigReaderFailures(failureFor(reason), Nil) }
+    result.left.map { reason => ConfigReaderFailures(failureFor(reason)) }
 
   private[this] def castOrFail[A](
     expectedType: ConfigValueType,

--- a/core/src/main/scala/pureconfig/ConfigSource.scala
+++ b/core/src/main/scala/pureconfig/ConfigSource.scala
@@ -127,7 +127,7 @@ final class ConfigObjectSource private (getConf: () => Result[Config]) extends C
    *         to an empty config if it cannot be read.
    */
   def optional: ConfigObjectSource =
-    recoverWith { case ConfigReaderFailures(_: CannotRead, Nil) => ConfigSource.empty }
+    recoverWith { case ConfigReaderFailures(_: CannotRead) => ConfigSource.empty }
 
   /**
    * Applies a function `f` if this source returns a failure, returning an alternative config

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable
  */
 case class ConfigReaderFailures(head: ConfigReaderFailure, tail: ConfigReaderFailure*) {
 
-  lazy val toList: List[ConfigReaderFailure] = head :: tail.toList
+  def toList: List[ConfigReaderFailure] = head :: tail.toList
 
   def +:(failure: ConfigReaderFailure): ConfigReaderFailures =
     ConfigReaderFailures(failure, this.toList: _*)

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
@@ -52,6 +52,6 @@ case class ConfigReaderFailures(head: ConfigReaderFailure, tail: List[ConfigRead
 
 object ConfigReaderFailures {
 
-  def apply(configReaderFailure: ConfigReaderFailure): ConfigReaderFailures =
-    new ConfigReaderFailures(configReaderFailure, List.empty[ConfigReaderFailure])
+  def apply(first: ConfigReaderFailure, rest: ConfigReaderFailure*): ConfigReaderFailures =
+    new ConfigReaderFailures(first, rest.toList)
 }

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
@@ -8,15 +8,15 @@ import scala.collection.mutable
 /**
  * A non-empty list of ConfigReader failures
  */
-case class ConfigReaderFailures(head: ConfigReaderFailure, tail: List[ConfigReaderFailure]) {
+case class ConfigReaderFailures(head: ConfigReaderFailure, tail: ConfigReaderFailure*) {
 
-  def toList: List[ConfigReaderFailure] = head +: tail
+  def toList: List[ConfigReaderFailure] = head :: tail.toList
 
   def +:(failure: ConfigReaderFailure): ConfigReaderFailures =
-    new ConfigReaderFailures(failure, this.toList)
+    new ConfigReaderFailures(failure, this.toList: _*)
 
   def ++(that: ConfigReaderFailures): ConfigReaderFailures =
-    new ConfigReaderFailures(head, tail ++ that.toList)
+    new ConfigReaderFailures(head, (tail ++ that.toList): _*)
 
   def prettyPrint(identLevel: Int = 0, identSize: Int = 2): String = {
     def tabs(n: Int): String = " " * ((identLevel + n) * identSize)
@@ -48,10 +48,4 @@ case class ConfigReaderFailures(head: ConfigReaderFailure, tail: List[ConfigRead
     }
     linesBuffer.mkString(System.lineSeparator())
   }
-}
-
-object ConfigReaderFailures {
-
-  def apply(first: ConfigReaderFailure, rest: ConfigReaderFailure*): ConfigReaderFailures =
-    new ConfigReaderFailures(first, rest.toList)
 }

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
@@ -48,4 +48,6 @@ case class ConfigReaderFailures(head: ConfigReaderFailure, tail: ConfigReaderFai
     }
     linesBuffer.mkString(System.lineSeparator())
   }
+
+  override def toString = toList.map(_.toString).mkString("ConfigReaderFailures(", ",", ")")
 }

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable
  */
 case class ConfigReaderFailures(head: ConfigReaderFailure, tail: ConfigReaderFailure*) {
 
-  def toList: List[ConfigReaderFailure] = head :: tail.toList
+  lazy val toList: List[ConfigReaderFailure] = head :: tail.toList
 
   def +:(failure: ConfigReaderFailure): ConfigReaderFailures =
     new ConfigReaderFailures(failure, this.toList: _*)

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailures.scala
@@ -13,10 +13,10 @@ case class ConfigReaderFailures(head: ConfigReaderFailure, tail: ConfigReaderFai
   lazy val toList: List[ConfigReaderFailure] = head :: tail.toList
 
   def +:(failure: ConfigReaderFailure): ConfigReaderFailures =
-    new ConfigReaderFailures(failure, this.toList: _*)
+    ConfigReaderFailures(failure, this.toList: _*)
 
   def ++(that: ConfigReaderFailures): ConfigReaderFailures =
-    new ConfigReaderFailures(head, (tail ++ that.toList): _*)
+    ConfigReaderFailures(head, (tail ++ that.toList): _*)
 
   def prettyPrint(identLevel: Int = 0, identSize: Int = 2): String = {
     def tabs(n: Int): String = " " * ((identLevel + n) * identSize)

--- a/modules/cats/src/main/scala/pureconfig/module/cats/syntax/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/cats/syntax/package.scala
@@ -12,6 +12,6 @@ package object syntax {
      *
      * @return a non-empty list of failures.
      */
-    def toNonEmptyList: NonEmptyList[ConfigReaderFailure] = NonEmptyList(failures.head, failures.tail)
+    def toNonEmptyList: NonEmptyList[ConfigReaderFailure] = NonEmptyList(failures.head, failures.tail.toList)
   }
 }

--- a/modules/generic-base/src/main/scala/pureconfig/generic/ProductHint.scala
+++ b/modules/generic-base/src/main/scala/pureconfig/generic/ProductHint.scala
@@ -67,7 +67,7 @@ private[pureconfig] case class ProductHintImpl[A](
           keyCur.failureFor(UnknownKey(k))
       }
       unknownKeys match {
-        case h :: t => Some(new ConfigReaderFailures(h, t))
+        case h :: t => Some(ConfigReaderFailures(h, t: _*))
         case Nil => None
       }
     }

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/ProductHintSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/ProductHintSuite.scala
@@ -169,7 +169,7 @@ class ProductHintSuite extends BaseSuite {
     conf.getConfig("conf").to[Conf] shouldBe Left(
       ConfigReaderFailures(
         ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), stringConfigOrigin(3), "a"),
-        List(ConvertFailure(UnknownKey("b"), stringConfigOrigin(4), "b"))))
+        ConvertFailure(UnknownKey("b"), stringConfigOrigin(4), "b")))
   }
 
   it should "not use default arguments if specified through a product hint" in {

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/TupleConvertersSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/TupleConvertersSuite.scala
@@ -48,7 +48,7 @@ class TupleConvertersSuite extends BaseSuite {
   checkFailures[(Int, Int, Int)](
     ConfigValueFactory.fromAnyRef(Map("_1" -> "one", "_2" -> 2).asJava) -> ConfigReaderFailures(
       ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), emptyConfigOrigin, "_1"),
-      List(ConvertFailure(KeyNotFound("_3", Set()), emptyConfigOrigin, ""))))
+      ConvertFailure(KeyNotFound("_3", Set()), emptyConfigOrigin, "")))
 
   checkFailures[(String, Int)](
     ConfigValueFactory.fromAnyRef("str") -> ConfigReaderFailures(

--- a/modules/scalaz/README.md
+++ b/modules/scalaz/README.md
@@ -111,7 +111,7 @@ val anotherInvalidConf = parseString("""{ i: false }""")
 List(validConf, invalidConf, anotherInvalidConf).traverse { c =>
   Validation.fromEither(implicitly[ConfigReader[SimpleConfig]].from(c.root))
 }
-// res7: scalaz.Validation[pureconfig.error.ConfigReaderFailures,List[SimpleConfig]] = Failure(ConfigReaderFailures(ConvertFailure(KeyNotFound(i,Set()),Some(ConfigOrigin(String)),),List(ConvertFailure(WrongType(BOOLEAN,Set(NUMBER)),Some(ConfigOrigin(String)),i))))
+// res7: scalaz.Validation[pureconfig.error.ConfigReaderFailures,List[SimpleConfig]] = Failure(ConfigReaderFailures(ConvertFailure(KeyNotFound(i,Set()),Some(ConfigOrigin(String)),),ArrayBuffer(ConvertFailure(WrongType(BOOLEAN,Set(NUMBER)),Some(ConfigOrigin(String)),i))))
 ```
 
 ### Extra syntactic sugar

--- a/modules/scalaz/README.md
+++ b/modules/scalaz/README.md
@@ -111,7 +111,7 @@ val anotherInvalidConf = parseString("""{ i: false }""")
 List(validConf, invalidConf, anotherInvalidConf).traverse { c =>
   Validation.fromEither(implicitly[ConfigReader[SimpleConfig]].from(c.root))
 }
-// res7: scalaz.Validation[pureconfig.error.ConfigReaderFailures,List[SimpleConfig]] = Failure(ConfigReaderFailures(ConvertFailure(KeyNotFound(i,Set()),Some(ConfigOrigin(String)),),ArrayBuffer(ConvertFailure(WrongType(BOOLEAN,Set(NUMBER)),Some(ConfigOrigin(String)),i))))
+// res7: scalaz.Validation[pureconfig.error.ConfigReaderFailures,List[SimpleConfig]] = Failure(ConfigReaderFailures(ConvertFailure(KeyNotFound(i,Set()),Some(ConfigOrigin(String)),),ConvertFailure(WrongType(BOOLEAN,Set(NUMBER)),Some(ConfigOrigin(String)),i)))
 ```
 
 ### Extra syntactic sugar

--- a/modules/scalaz/src/test/scala/pureconfig/module/scalaz/arbitrary/package.scala
+++ b/modules/scalaz/src/test/scala/pureconfig/module/scalaz/arbitrary/package.scala
@@ -56,7 +56,7 @@ package object arbitrary {
       for {
         n <- Gen.choose(1, MaxCollectionLength)
         l <- Gen.listOfN(n, genFailureReason).map(_.map(r => ConvertFailure(r, None, "")))
-      } yield ConfigReaderFailures(l.head, l.tail)
+      } yield ConfigReaderFailures(l.head, l.tail: _*)
     }
 
   implicit val cogenConfigReaderFailures: Cogen[ConfigReaderFailures] =

--- a/tests/src/main/scala/pureconfig/ConfigReaderMatchers.scala
+++ b/tests/src/main/scala/pureconfig/ConfigReaderMatchers.scala
@@ -14,7 +14,7 @@ import org.scalatest.matchers.should.Matchers
 trait ConfigReaderMatchers { this: AnyFlatSpec with Matchers =>
 
   def failWith(reason: FailureReason): Matcher[ConfigReader.Result[Any]] =
-    matchPattern { case Left(ConfigReaderFailures(ConvertFailure(`reason`, _, _), Nil)) => }
+    matchPattern { case Left(ConfigReaderFailures(ConvertFailure(`reason`, _, _))) => }
 
   def failWith(
     reason: FailureReason,
@@ -26,16 +26,16 @@ trait ConfigReaderMatchers { this: AnyFlatSpec with Matchers =>
     be(Left(ConfigReaderFailures(failure)))
 
   def failWithType[Reason <: FailureReason: ClassTag]: Matcher[ConfigReader.Result[Any]] =
-    matchPattern { case Left(ConfigReaderFailures(ConvertFailure(_: Reason, _, _), Nil)) => }
+    matchPattern { case Left(ConfigReaderFailures(ConvertFailure(_: Reason, _, _))) => }
 
   def failWithType[Failure <: ConfigReaderFailure: ClassTag](implicit dummy: DummyImplicit): Matcher[ConfigReader.Result[Any]] =
-    matchPattern { case Left(ConfigReaderFailures(_: Failure, Nil)) => }
+    matchPattern { case Left(ConfigReaderFailures(_: Failure)) => }
 
   def failLike(pf: PartialFunction[ConfigReaderFailure, MatchResult]) =
     new Matcher[ConfigReader.Result[Any]] with Inside with PartialFunctionValues {
 
       def apply(left: ConfigReader.Result[Any]): MatchResult = {
-        inside(left) { case Left(ConfigReaderFailures(failure, Nil)) => pf.valueAt(failure) }
+        inside(left) { case Left(ConfigReaderFailures(failure)) => pf.valueAt(failure) }
       }
     }
 

--- a/tests/src/main/scala/pureconfig/ConfigReaderMatchers.scala
+++ b/tests/src/main/scala/pureconfig/ConfigReaderMatchers.scala
@@ -20,10 +20,10 @@ trait ConfigReaderMatchers { this: AnyFlatSpec with Matchers =>
     reason: FailureReason,
     path: String,
     origin: Option[ConfigOrigin] = None): Matcher[ConfigReader.Result[Any]] =
-    be(Left(ConfigReaderFailures(ConvertFailure(reason, origin, path), Nil)))
+    be(Left(ConfigReaderFailures(ConvertFailure(reason, origin, path))))
 
   def failWith(failure: ConfigReaderFailure): Matcher[ConfigReader.Result[Any]] =
-    be(Left(ConfigReaderFailures(failure, Nil)))
+    be(Left(ConfigReaderFailures(failure)))
 
   def failWithType[Reason <: FailureReason: ClassTag]: Matcher[ConfigReader.Result[Any]] =
     matchPattern { case Left(ConfigReaderFailures(ConvertFailure(_: Reason, _, _), Nil)) => }

--- a/tests/src/test/scala/pureconfig/ConfigReaderFailuresPrettyPrintSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderFailuresPrettyPrintSuite.scala
@@ -21,9 +21,8 @@ class ConfigReaderFailuresPrettyPrintSuite extends BaseSuite {
 
     val failures = ConfigReaderFailures(
       ThrowableFailure(new Exception("Throwable error"), origin(12)),
-      List(
-        ConvertFailure(KeyNotFound("unknown_key"), None, "path"),
-        CannotReadResource("resourceName", None)))
+      ConvertFailure(KeyNotFound("unknown_key"), None, "path"),
+      CannotReadResource("resourceName", None))
 
     failures.prettyPrint(0, 2) shouldBe
       s"""|- (file:/tmp/config: 12) Throwable error.
@@ -50,9 +49,8 @@ class ConfigReaderFailuresPrettyPrintSuite extends BaseSuite {
   it should "be printable with failures organized by path" in {
     val failures = ConfigReaderFailures(
       ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), None, "a"),
-      List(
-        ConvertFailure(KeyNotFound("b", Set()), None, ""),
-        ConvertFailure(KeyNotFound("c", Set()), None, "")))
+      ConvertFailure(KeyNotFound("b", Set()), None, ""),
+      ConvertFailure(KeyNotFound("c", Set()), None, ""))
 
     failures.prettyPrint() shouldBe
       s"""|at the root:
@@ -64,16 +62,14 @@ class ConfigReaderFailuresPrettyPrintSuite extends BaseSuite {
 
   it should "print errors that occur at the root of the config" in {
     val failures1 = ConfigReaderFailures(
-      ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, ""),
-      List())
+      ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, ""))
 
     failures1.prettyPrint() shouldBe
       s"""|at the root:
           |  - Expected type OBJECT. Found NUMBER instead.""".stripMargin
 
     val failures2 = ConfigReaderFailures(
-      ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, "conf"),
-      List())
+      ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, "conf"))
 
     failures2.prettyPrint() shouldBe
       s"""|at 'conf':
@@ -84,7 +80,7 @@ class ConfigReaderFailuresPrettyPrintSuite extends BaseSuite {
     val failures = ConfigReaderFailures(
       ConvertFailure(
         WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT)), None, "values.b"),
-      List(ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, "values.a.values.c")))
+      ConvertFailure(WrongType(ConfigValueType.NUMBER, Set(ConfigValueType.OBJECT)), None, "values.a.values.c"))
 
     failures.prettyPrint() shouldBe
       s"""|at 'values.a.values.c':
@@ -96,7 +92,7 @@ class ConfigReaderFailuresPrettyPrintSuite extends BaseSuite {
   it should "print a message displaying relevant errors for coproduct derivation" in {
     val failures = ConfigReaderFailures(
       ConvertFailure(UnexpectedValueForFieldCoproductHint(ConfigValueFactory.fromAnyRef("unexpected")), None, "values.v1.type"),
-      List(ConvertFailure(KeyNotFound("type", Set()), None, "values.v3")))
+      ConvertFailure(KeyNotFound("type", Set()), None, "values.v3"))
 
     failures.prettyPrint() shouldBe
       s"""|at 'values.v1.type':
@@ -108,10 +104,9 @@ class ConfigReaderFailuresPrettyPrintSuite extends BaseSuite {
   it should "print a message displaying candidate keys in case of a suspected misconfigured ProductHint" in {
     val failures = ConfigReaderFailures(
       ConvertFailure(KeyNotFound("camel-case-int", Set("camelCaseInt")), None, "camel-case-conf"),
-      List(
-        ConvertFailure(KeyNotFound("camel-case-string", Set("camelCaseString")), None, "camel-case-conf"),
-        ConvertFailure(KeyNotFound("snake-case-int", Set("snake_case_int")), None, "snake-case-conf"),
-        ConvertFailure(KeyNotFound("snake-case-string", Set("snake_case_string")), None, "snake-case-conf")))
+      ConvertFailure(KeyNotFound("camel-case-string", Set("camelCaseString")), None, "camel-case-conf"),
+      ConvertFailure(KeyNotFound("snake-case-int", Set("snake_case_int")), None, "snake-case-conf"),
+      ConvertFailure(KeyNotFound("snake-case-string", Set("snake_case_string")), None, "snake-case-conf"))
 
     failures.prettyPrint() shouldBe
       s"""|at 'camel-case-conf':
@@ -133,7 +128,7 @@ class ConfigReaderFailuresPrettyPrintSuite extends BaseSuite {
 
     val failures = ConfigReaderFailures(
       ConvertFailure(KeyNotFound("a", Set()), urlConfigOrigin(url, 1), ""),
-      List(ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), urlConfigOrigin(url, 3), "c")))
+      ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), urlConfigOrigin(url, 3), "c"))
 
     failures.prettyPrint() shouldBe
       s"""|at the root:
@@ -169,7 +164,7 @@ class ConfigReaderFailuresPrettyPrintSuite extends BaseSuite {
   it should "print a message showing lists of wrong size" in {
     val failures = ConfigReaderFailures(
       ConvertFailure(WrongSizeList(3, 4), None, "hlist"),
-      List(ConvertFailure(WrongSizeList(3, 6), None, "tuple")))
+      ConvertFailure(WrongSizeList(3, 6), None, "tuple"))
 
     failures.prettyPrint() shouldBe
       s"""|at 'hlist':

--- a/tests/src/test/scala/pureconfig/ConfigReaderFailuresPrettyPrintSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderFailuresPrettyPrintSuite.scala
@@ -143,7 +143,7 @@ class ConfigReaderFailuresPrettyPrintSuite extends BaseSuite {
     val url = new URL("file://" + workingDir + file)
 
     val failures = ConfigReaderFailures(
-      CannotParse("Expecting close brace } or a comma, got end of file", urlConfigOrigin(url, 2)), List())
+      CannotParse("Expecting close brace } or a comma, got end of file", urlConfigOrigin(url, 2)))
 
     failures.prettyPrint() shouldBe
       s"""|- (file:${workingDir}${file}: 2) Unable to parse the configuration: Expecting close brace } or a comma, got end of file.""".stripMargin
@@ -155,7 +155,7 @@ class ConfigReaderFailuresPrettyPrintSuite extends BaseSuite {
     val path = java.nio.file.Paths.get(workingDir + file)
 
     val failures = ConfigReaderFailures(
-      CannotReadFile(path, Some(new java.io.FileNotFoundException(workingDir + file + " (No such file or directory)"))), List())
+      CannotReadFile(path, Some(new java.io.FileNotFoundException(workingDir + file + " (No such file or directory)"))))
 
     failures.prettyPrint() shouldBe
       s"""|- Unable to read file ${workingDir}${file} (No such file or directory).""".stripMargin

--- a/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
@@ -39,7 +39,7 @@ class ConfigReaderSuite extends BaseSuite {
 
   it should "have a correct emap method" in forAll { (conf: ConfigValue, f: Int => Either[FailureReason, String]) =>
     def getReason[A](failures: ConfigReaderFailures): FailureReason = failures match {
-      case ConfigReaderFailures(ConvertFailure(reason, _, _), Nil) => reason
+      case ConfigReaderFailures(ConvertFailure(reason, _, _)) => reason
       case _ => throw new Exception(s"Unexpected value: $failures")
     }
     intReader.emap(f).from(conf).left.map(getReason) shouldEqual

--- a/tests/src/test/scala/pureconfig/ConfigSourceSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigSourceSuite.scala
@@ -132,7 +132,7 @@ class ConfigSourceSuite extends BaseSuite {
       withFallback(main).
       withFallback(defaults).
       at("my-service").load[MyService] should matchPattern {
-        case Left(ConfigReaderFailures(CannotReadResource("nonExistingResource1", _), Nil)) =>
+        case Left(ConfigReaderFailures(CannotReadResource("nonExistingResource1", _))) =>
       }
 
     overrides.
@@ -140,10 +140,10 @@ class ConfigSourceSuite extends BaseSuite {
       withFallback(main).
       withFallback(nonExisting2).
       withFallback(defaults).
-      at("my-service").load[MyService] should matchPattern {
-        case Left(ConfigReaderFailures(
+      at("my-service").load[MyService].left.map(_.toList) should matchPattern {
+        case Left(List(
           CannotReadResource("nonExistingResource1", _),
-          CannotReadResource("nonExistingResource2", _) :: Nil)) =>
+          CannotReadResource("nonExistingResource2", _))) =>
       }
   }
 
@@ -185,9 +185,9 @@ class ConfigSourceSuite extends BaseSuite {
 
     case class Conf(name: String, age: Int)
 
-    appSource.recoverWith { case ConfigReaderFailures(_: CannotRead, _) => otherSource }.load[Conf] shouldBe
+    appSource.recoverWith { case ConfigReaderFailures(_: CannotRead) => otherSource }.load[Conf] shouldBe
       Right(Conf("John", 33))
-    appSource.recoverWith { case ConfigReaderFailures(_: CannotParse, _) => otherSource }.load[Conf] should
+    appSource.recoverWith { case ConfigReaderFailures(_: CannotParse) => otherSource }.load[Conf] should
       failWithType[CannotReadFile]
   }
 

--- a/tests/src/test/scala/pureconfig/FluentConfigCursorSuite.scala
+++ b/tests/src/test/scala/pureconfig/FluentConfigCursorSuite.scala
@@ -16,7 +16,7 @@ class FluentConfigCursorSuite extends BaseSuite {
     ConfigCursor(conf(confStr), pathElems).fluent
 
   def failedCursor(reason: FailureReason, path: String, origin: Option[ConfigOrigin] = stringConfigOrigin(1)): FluentConfigCursor =
-    FluentConfigCursor(Left(ConfigReaderFailures(ConvertFailure(reason, origin, path), Nil)))
+    FluentConfigCursor(Left(ConfigReaderFailures(ConvertFailure(reason, origin, path))))
 
   behavior of "FluentConfigCursor"
 
@@ -68,7 +68,7 @@ class FluentConfigCursorSuite extends BaseSuite {
     cursor("[true, notTrue, false, nay]").mapList(_.asBoolean) shouldBe Left(
       ConfigReaderFailures(
         ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.BOOLEAN)), stringConfigOrigin(1), s"$defaultPathStr.1"),
-        ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.BOOLEAN)), stringConfigOrigin(1), s"$defaultPathStr.3") :: Nil))
+        ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.BOOLEAN)), stringConfigOrigin(1), s"$defaultPathStr.3")))
 
     cursor("abc").mapList(_.asInt) should failWith(
       WrongType(ConfigValueType.STRING, Set(ConfigValueType.LIST)), defaultPathStr, stringConfigOrigin(1))
@@ -80,7 +80,7 @@ class FluentConfigCursorSuite extends BaseSuite {
     cursor("{ a: abc, b: 5, c: [6] }").mapObject(_.asInt) shouldBe Left(
       ConfigReaderFailures(
         ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), stringConfigOrigin(1), s"$defaultPathStr.a"),
-        ConvertFailure(WrongType(ConfigValueType.LIST, Set(ConfigValueType.NUMBER)), stringConfigOrigin(1), s"$defaultPathStr.c") :: Nil))
+        ConvertFailure(WrongType(ConfigValueType.LIST, Set(ConfigValueType.NUMBER)), stringConfigOrigin(1), s"$defaultPathStr.c")))
 
     cursor("abc").mapObject(_.asInt) should failWith(
       WrongType(ConfigValueType.STRING, Set(ConfigValueType.OBJECT)), defaultPathStr, stringConfigOrigin(1))

--- a/tests/src/test/scala/pureconfig/ProductHintSuite.scala
+++ b/tests/src/test/scala/pureconfig/ProductHintSuite.scala
@@ -165,7 +165,7 @@ class ProductHintSuite extends BaseSuite {
     conf.getConfig("conf").to[Conf] shouldBe Left(
       ConfigReaderFailures(
         ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), stringConfigOrigin(3), "a"),
-        List(ConvertFailure(UnknownKey("b"), stringConfigOrigin(4), "b"))))
+        ConvertFailure(UnknownKey("b"), stringConfigOrigin(4), "b")))
   }
 
   it should "not use default arguments if specified through a product hint" in {

--- a/tests/src/test/scala/pureconfig/TupleConvertersSuite.scala
+++ b/tests/src/test/scala/pureconfig/TupleConvertersSuite.scala
@@ -45,7 +45,7 @@ class TupleConvertersSuite extends BaseSuite {
   checkFailures[(Int, Int, Int)](
     ConfigValueFactory.fromAnyRef(Map("_1" -> "one", "_2" -> 2).asJava) -> ConfigReaderFailures(
       ConvertFailure(WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)), emptyConfigOrigin, "_1"),
-      List(ConvertFailure(KeyNotFound("_3", Set()), emptyConfigOrigin, ""))))
+      ConvertFailure(KeyNotFound("_3", Set()), emptyConfigOrigin, "")))
 
   checkFailures[(String, Int)](
     ConfigValueFactory.fromAnyRef("str") -> ConfigReaderFailures(


### PR DESCRIPTION
Modifies the alternative `apply` method of `ConfigReaderFailures` to make them more convenient to create.