### PR TITLE
Improve `ConfigConvert` Ergonomics

### DIFF
--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -58,9 +58,7 @@ object ConfigConvert extends ConvertHelpers {
     ConfigConvert(reader.value, writer.value)
 
   def viaString[A](fromF: String => Either[FailureReason, A], toF: A => String): ConfigConvert[A] =
-    fromReaderAndWriter(
-      Derivation.Successful(ConfigReader.fromString(fromF)),
-      Derivation.Successful(ConfigWriter.toString(toF)))
+    ConfigConvert(ConfigReader.fromString(fromF), ConfigWriter.toString(toF))
 
   def viaStringTry[A: ClassTag](fromF: String => Try[A], toF: A => String): ConfigConvert[A] = {
     viaString[A](tryF(fromF), toF)

--- a/tests/src/test/scala/pureconfig/ConfigConvertSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigConvertSuite.scala
@@ -2,7 +2,8 @@ package pureconfig
 
 import com.typesafe.config.{ ConfigValue, ConfigValueFactory, ConfigValueType }
 import org.scalacheck.{ Arbitrary, Gen }
-import pureconfig.error.{ ExceptionThrown, WrongType }
+import pureconfig.error.{ ExceptionThrown, WrongType, CannotConvert }
+import ConfigConvertSuite._
 
 class ConfigConvertSuite extends BaseSuite {
   implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
@@ -30,5 +31,29 @@ class ConfigConvertSuite extends BaseSuite {
       ExceptionThrown(throwable))
     cc.from(ConfigValueFactory.fromAnyRef("test")) should failWith(
       WrongType(ConfigValueType.STRING, Set(ConfigValueType.NUMBER)))
+  }
+
+  it should "have a xemap method that allows specifying custom failure messages" in {
+    ConfigConvert[EvenInt].from(ConfigValueFactory.fromAnyRef(1)) should
+      failWith(CannotConvert("1", "EvenInt", EvenInt.err(1)))
+  }
+
+  it should "correctly read using xemap" in {
+    ConfigConvert[EvenInt].from(ConfigValueFactory.fromAnyRef(2)) shouldEqual Right(EvenInt(2))
+  }
+}
+
+object ConfigConvertSuite {
+  case class EvenInt(i: Int) extends AnyVal
+  object EvenInt {
+    def err(i: Int): String = s"Cannot construct an EvenInt from $i because it's not even"
+
+    def safely(i: Int): Either[String, EvenInt] =
+      if (i % 2 == 0) Right(EvenInt(i)) else Left(err(i))
+
+    implicit val configConvert: ConfigConvert[EvenInt] =
+      ConfigConvert[Int].xemap(
+        i => safely(i).left.map(s => CannotConvert(i.toString, "EvenInt", s)),
+        _.i)
   }
 }


### PR DESCRIPTION
- Add more natural `ConfigConvert` constructor.
- Add xemap to allow reader function to specify `FailureReason`,
  analogous to `ConfigReader.emap`.