### PR TITLE
Remove unnecessary libcurl4-openssl-dev dependency from CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install dependencies
         run: >
-          sudo apt install libcurl4-openssl-dev libxslt-dev &&
+          sudo apt install libxslt-dev &&
           gem install sass jekyll:4.0.0 html-proofer:3.9.3
 
       - name: Build website


### PR DESCRIPTION
Cherry-picked from #783 to fix the CI build.