### PR TITLE
Format build files according to the Scalafmt config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,8 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
 
-      - name: Check sbt formatting
-        if: startsWith(matrix.scala, '2.12')
-        run: sbt "++${{ matrix.scala }} scalafmtSbtCheck"
-
       - name: Check formatting
-        run: sbt "++${{ matrix.scala }} scalafmtCheckAll"
+        run: sbt "++${{ matrix.scala }} scalafmtCheckAll; scalafmtSbtCheck"
 
       - name: Compile
         run: sbt coverage "++${{ matrix.scala }} compile"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,12 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
 
+      - name: Check sbt formatting
+        if: startsWith(matrix.scala, '2.12')
+        run: sbt "++${{ matrix.scala }} scalafmtSbtCheck"
+
       - name: Check formatting
-        run: sbt "++${{ matrix.scala }} fmtCheckAll"
+        run: sbt "++${{ matrix.scala }} scalafmtCheckAll"
 
       - name: Compile
         run: sbt coverage "++${{ matrix.scala }} compile"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: ${{ matrix.jdk }}
 
       - name: Check formatting
-        run: sbt "++${{ matrix.scala }} scalafmtCheckAll"
+        run: sbt "++${{ matrix.scala }} fmtCheckAll"
 
       - name: Compile
         run: sbt coverage "++${{ matrix.scala }} compile"

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import Dependencies.Version._
 import Utilities._
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 
+addCommandAlias("fmtCheckAll", "; scalafmtCheckAll; scalafmtSbtCheck")
+
 organization in ThisBuild := "com.github.pureconfig"
 
 lazy val core = (project in file("core"))

--- a/build.sbt
+++ b/build.sbt
@@ -4,51 +4,50 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 
 organization in ThisBuild := "com.github.pureconfig"
 
-lazy val core = (project in file("core")).
-  enablePlugins(BoilerplatePlugin, SbtOsgi, TutPlugin).
-  settings(commonSettings).
-  dependsOn(macros)
+lazy val core = (project in file("core"))
+  .enablePlugins(BoilerplatePlugin, SbtOsgi, TutPlugin)
+  .settings(commonSettings)
+  .dependsOn(macros)
 
 // Two special modules for now, since `tests` depend on them. We should improve this organization later by separating
 // the test helpers (which all projects' tests should depend on) from the core+generic test implementations.
-lazy val `generic-base` = (project in file("modules/generic-base")).
-  enablePlugins(SbtOsgi, TutPlugin).
-  dependsOn(core).
-  settings(commonSettings, tutTargetDirectory := baseDirectory.value)
+lazy val `generic-base` = (project in file("modules/generic-base"))
+  .enablePlugins(SbtOsgi, TutPlugin)
+  .dependsOn(core)
+  .settings(commonSettings, tutTargetDirectory := baseDirectory.value)
 
-lazy val generic = (project in file("modules/generic")).
-  enablePlugins(SbtOsgi, TutPlugin).
-  dependsOn(core, `generic-base`).
-  settings(commonSettings, tutTargetDirectory := baseDirectory.value)
+lazy val generic = (project in file("modules/generic"))
+  .enablePlugins(SbtOsgi, TutPlugin)
+  .dependsOn(core, `generic-base`)
+  .settings(commonSettings, tutTargetDirectory := baseDirectory.value)
 // -----
 
-lazy val macros = (project in file("macros")).
-  enablePlugins(TutPlugin).
-  settings(commonSettings)
+lazy val macros = (project in file("macros")).enablePlugins(TutPlugin).settings(commonSettings)
 
-lazy val tests = (project in file("tests")).
-  enablePlugins(BoilerplatePlugin).
-  settings(commonSettings).
-  dependsOn(core, generic).
-  dependsOn(macros % "test->test") // provides helpers to test pureconfig macros
+lazy val tests = (project in file("tests"))
+  .enablePlugins(BoilerplatePlugin)
+  .settings(commonSettings)
+  .dependsOn(core, generic)
+  .dependsOn(macros % "test->test") // provides helpers to test pureconfig macros
 
 // aggregates pureconfig-core and pureconfig-generic with the original "pureconfig" name
-lazy val bundle = (project in file("bundle")).
-  enablePlugins(SbtOsgi, TutPlugin).
-  settings(commonSettings, tutTargetDirectory := file(".")).
-  dependsOn(core, generic)
+lazy val bundle = (project in file("bundle"))
+  .enablePlugins(SbtOsgi, TutPlugin)
+  .settings(commonSettings, tutTargetDirectory := file("."))
+  .dependsOn(core, generic)
 
-lazy val docs = (project in file("docs")).
-  enablePlugins(MicrositesPlugin).
-  settings(commonSettings, publishArtifact := false).
-  settings(docsSettings).
-  dependsOn(bundle)
+lazy val docs = (project in file("docs"))
+  .enablePlugins(MicrositesPlugin)
+  .settings(commonSettings, publishArtifact := false)
+  .settings(docsSettings)
+  .dependsOn(bundle)
 
-def module(proj: Project) = proj.
-  enablePlugins(SbtOsgi, TutPlugin).
-  dependsOn(core).
-  dependsOn(tests % "test").
-  dependsOn(generic % "Tut"). // Allow auto-derivation in documentation
+def module(proj: Project) = proj
+  .enablePlugins(SbtOsgi, TutPlugin)
+  .dependsOn(core)
+  .dependsOn(tests % "test")
+  .dependsOn(generic % "Tut")
+  . // Allow auto-derivation in documentation
   settings(commonSettings, tutTargetDirectory := baseDirectory.value)
 
 lazy val akka = module(project) in file("modules/akka")
@@ -74,40 +73,30 @@ lazy val yaml = module(project) in file("modules/yaml")
 lazy val commonSettings = Seq(
   homepage := Some(url("https://github.com/pureconfig/pureconfig")),
   licenses := Seq("Mozilla Public License, version 2.0" -> url("https://www.mozilla.org/MPL/2.0/")),
-
   developers := List(
     Developer("melrief", "Mario Pastorelli", "pastorelli.mario@gmail.com", url("https://github.com/melrief")),
     Developer("leifwickland", "Leif Wickland", "leifwickland@gmail.com", url("https://github.com/leifwickland")),
     Developer("jcazevedo", "Joao Azevedo", "joao.c.azevedo@gmail.com", url("https://github.com/jcazevedo")),
     Developer("ruippeixotog", "Rui Gonçalves", "ruippeixotog@gmail.com", url("https://github.com/ruippeixotog")),
-    Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr"))),
-
+    Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr"))
+  ),
   crossScalaVersions := Seq(scala211, scala212, scala213),
   scalaVersion := scala212,
-
-  resolvers ++= Seq(
-    Resolver.sonatypeRepo("releases"),
-    Resolver.sonatypeRepo("snapshots")),
-
+  resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots")),
   crossVersionSharedSources(unmanagedSourceDirectories in Compile),
   crossVersionSharedSources(unmanagedSourceDirectories in Test),
-
   scalacOptions ++= lintFlags.value,
-
   scalacOptions in Test ~= { _.filterNot(_.contains("-Ywarn-unused")) },
   scalacOptions in Test += "-Xmacro-settings:materialize-derivations",
-
   scalacOptions in (Compile, console) --= Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-unused:_,-implicits"),
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
   scalacOptions in Tut --= Seq("-Ywarn-unused-import", "-Xmacro-settings:materialize-derivations"),
-
   scalafmtOnCompile := true,
-
   autoAPIMappings := true,
-
   publishMavenStyle := true,
   publishArtifact in Test := false,
-  publishTo := sonatypePublishToBundle.value)
+  publishTo := sonatypePublishToBundle.value
+)
 
 lazy val docsSettings = Seq(
   micrositeName := "PureConfig",
@@ -121,14 +110,15 @@ lazy val docsSettings = Seq(
   micrositeTheme := "pattern",
   micrositeHighlightTheme := "default",
   micrositePalette := Map(
-        "brand-primary"   /* link color       */  -> "#ab4b4b",
-        "brand-secondary" /* nav/sidebar back */  -> "#4b4b4b",
-        "brand-tertiary"  /* sidebar top back */  -> "#292929",
-        "gray-dark"       /* section title    */  -> "#453E46",
-        "gray"            /* text color       */  -> "#837F84",
-        "gray-light"      /* star back        */  -> "#E3E2E3",
-        "gray-lighter"    /* code back        */  -> "#F4F3F4",
-        "white-color"                             -> "#FFFFFF"),
+    "brand-primary" /* link color       */ -> "#ab4b4b",
+    "brand-secondary" /* nav/sidebar back */ -> "#4b4b4b",
+    "brand-tertiary" /* sidebar top back */ -> "#292929",
+    "gray-dark" /* section title    */ -> "#453E46",
+    "gray" /* text color       */ -> "#837F84",
+    "gray-light" /* star back        */ -> "#E3E2E3",
+    "gray-lighter" /* code back        */ -> "#F4F3F4",
+    "white-color" -> "#FFFFFF"
+  ),
   micrositeGitterChannel := false, // ugly
   mdocExtraArguments += "--no-link-hygiene"
 )
@@ -141,43 +131,42 @@ def crossVersionSharedSources(unmanagedSrcs: SettingKey[Seq[File]]) = {
   unmanagedSrcs ++= {
     val minor = CrossVersion.partialVersion(scalaVersion.value).map(_._2)
     List(
-      if (minor.exists(_ <= 12)) unmanagedSrcs.value.map { dir => new File(dir.getPath + "-2.12-") } else Nil,
-      if (minor.exists(_ >= 12)) unmanagedSrcs.value.map { dir => new File(dir.getPath + "-2.12+") } else Nil,
+      if (minor.exists(_ <= 12)) unmanagedSrcs.value.map { dir => new File(dir.getPath + "-2.12-") }
+      else Nil,
+      if (minor.exists(_ >= 12)) unmanagedSrcs.value.map { dir => new File(dir.getPath + "-2.12+") }
+      else Nil
     ).flatten
   }
 }
 
 lazy val lintFlags = {
   lazy val allVersionLintFlags = List(
-    "-encoding", "UTF-8", // yes, this is 2 args
+    "-encoding",
+    "UTF-8", // yes, this is 2 args
     "-feature",
     "-unchecked",
     "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen")
+    "-Ywarn-numeric-widen"
+  )
 
   def withCommon(flags: String*) =
     allVersionLintFlags ++ flags
 
   forScalaVersions {
     case (2, 11) =>
-      withCommon(
-        "-deprecation",
-        "-Xlint",
-        "-Xfatal-warnings",
-        "-Yno-adapted-args",
-        "-Ywarn-unused-import")
+      withCommon("-deprecation", "-Xlint", "-Xfatal-warnings", "-Yno-adapted-args", "-Ywarn-unused-import")
 
     case (2, 12) =>
       withCommon(
-        "-deprecation",                // Either#right is deprecated on Scala 2.13
+        "-deprecation", // Either#right is deprecated on Scala 2.13
         "-Xlint:_,-unused",
         "-Xfatal-warnings",
         "-Yno-adapted-args",
-        "-Ywarn-unused:_,-implicits")  // Some implicits are intentionally used just as evidences, triggering warnings
+        "-Ywarn-unused:_,-implicits"
+      ) // Some implicits are intentionally used just as evidences, triggering warnings
 
     case (2, 13) =>
-      withCommon(
-        "-Ywarn-unused:_,-implicits")
+      withCommon("-Ywarn-unused:_,-implicits")
 
     case _ =>
       withCommon()
@@ -208,4 +197,5 @@ releaseProcess := Seq[ReleaseStep](
   releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,
-  pushChanges)
+  pushChanges
+)

--- a/build.sbt
+++ b/build.sbt
@@ -112,13 +112,13 @@ lazy val docsSettings = Seq(
   micrositeTheme := "pattern",
   micrositeHighlightTheme := "default",
   micrositePalette := Map(
-    "brand-primary" /* link color       */ -> "#ab4b4b",
-    "brand-secondary" /* nav/sidebar back */ -> "#4b4b4b",
-    "brand-tertiary" /* sidebar top back */ -> "#292929",
-    "gray-dark" /* section title    */ -> "#453E46",
-    "gray" /* text color       */ -> "#837F84",
-    "gray-light" /* star back        */ -> "#E3E2E3",
-    "gray-lighter" /* code back        */ -> "#F4F3F4",
+    "brand-primary" -> "#ab4b4b", // link color
+    "brand-secondary" -> "#4b4b4b", // nav/sidebar back
+    "brand-tertiary" -> "#292929", // sidebar top back
+    "gray-dark" -> "#453E46", // section title
+    "gray" -> "#837F84", // text color
+    "gray-light" -> "#E3E2E3", // star back
+    "gray-lighter" -> "#F4F3F4", // code back
     "white-color" -> "#FFFFFF"
   ),
   micrositeGitterChannel := false, // ugly
@@ -144,7 +144,7 @@ def crossVersionSharedSources(unmanagedSrcs: SettingKey[Seq[File]]) = {
 lazy val lintFlags = {
   lazy val allVersionLintFlags = List(
     "-encoding",
-    "UTF-8", // yes, this is 2 args
+    "UTF-8", // arg for -encoding
     "-feature",
     "-unchecked",
     "-Ywarn-dead-code",
@@ -164,8 +164,8 @@ lazy val lintFlags = {
         "-Xlint:_,-unused",
         "-Xfatal-warnings",
         "-Yno-adapted-args",
-        "-Ywarn-unused:_,-implicits"
-      ) // Some implicits are intentionally used just as evidences, triggering warnings
+        "-Ywarn-unused:_,-implicits" // Some implicits are intentionally used just as evidences, triggering warnings
+      )
 
     case (2, 13) =>
       withCommon("-Ywarn-unused:_,-implicits")

--- a/build.sbt
+++ b/build.sbt
@@ -70,8 +70,10 @@ lazy val sttp = module(project) in file("modules/sttp")
 lazy val yaml = module(project) in file("modules/yaml")
 
 lazy val commonSettings = Seq(
+  // format: off
   homepage := Some(url("https://github.com/pureconfig/pureconfig")),
   licenses := Seq("Mozilla Public License, version 2.0" -> url("https://www.mozilla.org/MPL/2.0/")),
+
   developers := List(
     Developer("melrief", "Mario Pastorelli", "pastorelli.mario@gmail.com", url("https://github.com/melrief")),
     Developer("leifwickland", "Leif Wickland", "leifwickland@gmail.com", url("https://github.com/leifwickland")),
@@ -79,22 +81,32 @@ lazy val commonSettings = Seq(
     Developer("ruippeixotog", "Rui Gonçalves", "ruippeixotog@gmail.com", url("https://github.com/ruippeixotog")),
     Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr"))
   ),
+
   crossScalaVersions := Seq(scala211, scala212, scala213),
   scalaVersion := scala212,
+
   resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots")),
+
   crossVersionSharedSources(unmanagedSourceDirectories in Compile),
   crossVersionSharedSources(unmanagedSourceDirectories in Test),
+
   scalacOptions ++= lintFlags.value,
+
   scalacOptions in Test ~= { _.filterNot(_.contains("-Ywarn-unused")) },
   scalacOptions in Test += "-Xmacro-settings:materialize-derivations",
+
   scalacOptions in (Compile, console) --= Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-unused:_,-implicits"),
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
   scalacOptions in Tut --= Seq("-Ywarn-unused-import", "-Xmacro-settings:materialize-derivations"),
+
   scalafmtOnCompile := true,
+
   autoAPIMappings := true,
+
   publishMavenStyle := true,
   publishArtifact in Test := false,
   publishTo := sonatypePublishToBundle.value
+  // format: on
 )
 
 lazy val docsSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -46,9 +46,8 @@ def module(proj: Project) = proj
   .enablePlugins(SbtOsgi, TutPlugin)
   .dependsOn(core)
   .dependsOn(tests % "test")
-  .dependsOn(generic % "Tut")
-  . // Allow auto-derivation in documentation
-  settings(commonSettings, tutTargetDirectory := baseDirectory.value)
+  .dependsOn(generic % "Tut") // Allow auto-derivation in documentation
+  .settings(commonSettings, tutTargetDirectory := baseDirectory.value)
 
 lazy val akka = module(project) in file("modules/akka")
 lazy val `akka-http` = module(project) in file("modules/akka-http")

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@ import Dependencies.Version._
 import Utilities._
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 
-addCommandAlias("fmtCheckAll", "; scalafmtCheckAll; scalafmtSbtCheck")
-
 organization in ThisBuild := "com.github.pureconfig"
 
 lazy val core = (project in file("core"))
@@ -201,3 +199,6 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion,
   pushChanges
 )
+
+// Alias to check the formatting of both scala and sbt files
+addCommandAlias("fmtCheckAll", "; scalafmtCheckAll; scalafmtSbtCheck")

--- a/build.sbt
+++ b/build.sbt
@@ -199,6 +199,3 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion,
   pushChanges
 )
-
-// Alias to check the formatting of both scala and sbt files
-addCommandAlias("fmtCheckAll", "; scalafmtCheckAll; scalafmtSbtCheck")

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -8,4 +8,7 @@ osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -4,10 +4,12 @@ name := "pureconfig-macros"
 
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
-  "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided)
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
+)
 
 // Scala has excessive warnings about unused implicits on macro exps (https://github.com/scala/bug/issues/10270)
 scalacOptions ~= { _.filterNot(_.contains("-Ywarn-unused")) }
 
 developers := List(
-  Developer("ruippeixotog", "Rui Gonçalves", "ruippeixotog@gmail.com", url("https://github.com/ruippeixotog")))
+  Developer("ruippeixotog", "Rui Gonçalves", "ruippeixotog@gmail.com", url("https://github.com/ruippeixotog"))
+)

--- a/modules/akka-http/build.sbt
+++ b/modules/akka-http/build.sbt
@@ -4,13 +4,18 @@ crossScalaVersions ~= { _.filterNot(_.startsWith("2.11")) }
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-stream" % "2.6.9" % "provided,Tut",
-  "com.typesafe.akka" %% "akka-http" % "10.2.0")
+  "com.typesafe.akka" %% "akka-http" % "10.2.0"
+)
 
 developers := List(
-  Developer("himanshu4141", "Himanshu Yadav", "himanshu4141@gmail.com", url("https://github.com/himanshu4141")))
+  Developer("himanshu4141", "Himanshu Yadav", "himanshu4141@gmail.com", url("https://github.com/himanshu4141"))
+)
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.akkahttp.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/akka/build.sbt
+++ b/modules/akka/build.sbt
@@ -1,14 +1,17 @@
 name := "pureconfig-akka"
 
-libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.5.31")
+libraryDependencies ++= Seq("com.typesafe.akka" %% "akka-actor" % "2.5.31")
 
 developers := List(
   Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr")),
-  Developer("ruippeixotog", "Rui Gonçalves", "ruippeixotog@gmail.com", url("https://github.com/ruippeixotog")))
+  Developer("ruippeixotog", "Rui Gonçalves", "ruippeixotog@gmail.com", url("https://github.com/ruippeixotog"))
+)
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.akka.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/circe/build.sbt
+++ b/modules/circe/build.sbt
@@ -3,16 +3,20 @@ import Utilities._
 name := "pureconfig-circe"
 
 libraryDependencies ++= Seq(
-  "io.circe"      %% "circe-core"    % forScalaVersions { case (2, 11) => "0.11.2"; case _ => "0.13.0" }.value,
-  "io.circe"      %% "circe-literal" % forScalaVersions { case (2, 11) => "0.11.2"; case _ => "0.13.0" }.value % Test,
-  "org.typelevel" %% "jawn-parser"   % forScalaVersions { case (2, 11) => "0.14.3"; case _ => "1.0.0" }.value % Test
+  "io.circe" %% "circe-core" % forScalaVersions { case (2, 11) => "0.11.2"; case _ => "0.13.0" }.value,
+  "io.circe" %% "circe-literal" % forScalaVersions { case (2, 11) => "0.11.2"; case _ => "0.13.0" }.value % Test,
+  "org.typelevel" %% "jawn-parser" % forScalaVersions { case (2, 11) => "0.14.3"; case _ => "1.0.0" }.value % Test
 )
 
 developers := List(
-  Developer("moradology", "Nathan Zimmerman", "npzimmerman@gmail.com", url("https://github.com/moradology")))
+  Developer("moradology", "Nathan Zimmerman", "npzimmerman@gmail.com", url("https://github.com/moradology"))
+)
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.circe.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/cron4s/build.sbt
+++ b/modules/cron4s/build.sbt
@@ -5,10 +5,14 @@ crossScalaVersions ~= { _.filterNot(_.startsWith("2.11")) }
 libraryDependencies += "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.6.1"
 
 developers := List(
-  Developer("bardurdam", "Bárður Viberg Dam", "bardurdam@gmail.com", url("https://github.com/bardurdam")))
+  Developer("bardurdam", "Bárður Viberg Dam", "bardurdam@gmail.com", url("https://github.com/bardurdam"))
+)
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.cron4s.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/enum/build.sbt
+++ b/modules/enum/build.sbt
@@ -1,14 +1,17 @@
 name := "pureconfig-enum"
 
-libraryDependencies ++= Seq(
-  "org.julienrf" %% "enum" % "3.1")
+libraryDependencies ++= Seq("org.julienrf" %% "enum" % "3.1")
 
 developers := List(
   Developer("melrief", "Mario Pastorelli", "pastorelli.mario@gmail.com", url("https://github.com/melrief")),
-  Developer("leifwickland", "Leif Wickland", "leifwickland@gmail.com", url("https://github.com/leifwickland")))
+  Developer("leifwickland", "Leif Wickland", "leifwickland@gmail.com", url("https://github.com/leifwickland"))
+)
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.enum.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/enumeratum/build.sbt
+++ b/modules/enumeratum/build.sbt
@@ -1,13 +1,14 @@
 name := "pureconfig-enumeratum"
 
-libraryDependencies ++= Seq(
-  "com.beachape" %% "enumeratum" % "1.6.1")
+libraryDependencies ++= Seq("com.beachape" %% "enumeratum" % "1.6.1")
 
-developers := List(
-  Developer("aeons", "Bjørn Madsen", "bm@aeons.dk", url("https://github.com/aeons")))
+developers := List(Developer("aeons", "Bjørn Madsen", "bm@aeons.dk", url("https://github.com/aeons")))
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.enumeratum.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/fs2/build.sbt
+++ b/modules/fs2/build.sbt
@@ -1,14 +1,14 @@
 name := "pureconfig-fs2"
 
-libraryDependencies ++= Seq(
-  "co.fs2" %% "fs2-core" % "2.1.0",
-  "co.fs2" %% "fs2-io" % "2.1.0")
+libraryDependencies ++= Seq("co.fs2" %% "fs2-core" % "2.1.0", "co.fs2" %% "fs2-io" % "2.1.0")
 
-developers := List(
-  Developer("keirlawson", "Keir Lawson", "keirlawson@gmail.com", url("https://github.com/keirlawson")))
+developers := List(Developer("keirlawson", "Keir Lawson", "keirlawson@gmail.com", url("https://github.com/keirlawson")))
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.fs2.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/generic/build.sbt
+++ b/modules/generic/build.sbt
@@ -2,12 +2,13 @@ import Dependencies._
 
 name := "pureconfig-generic"
 
-libraryDependencies ++= Seq(
-  "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
-  shapeless)
+libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided, shapeless)
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.generic.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/hadoop/build.sbt
+++ b/modules/hadoop/build.sbt
@@ -1,13 +1,14 @@
 name := "pureconfig-hadoop"
 
-libraryDependencies ++= Seq(
-  "org.apache.hadoop" % "hadoop-common" % "3.3.0" % "provided,Tut")
+libraryDependencies ++= Seq("org.apache.hadoop" % "hadoop-common" % "3.3.0" % "provided,Tut")
 
-developers := List(
-  Developer("lmnet", "Yuriy Badalyantc", "lmnet89@gmail.com", url("https://github.com/lmnet")))
+developers := List(Developer("lmnet", "Yuriy Badalyantc", "lmnet89@gmail.com", url("https://github.com/lmnet")))
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.hadoop.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/http4s/build.sbt
+++ b/modules/http4s/build.sbt
@@ -2,14 +2,17 @@ name := "pureconfig-http4s"
 
 crossScalaVersions ~= { _.filterNot(_.startsWith("2.11")) }
 
-libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-core" % "0.21.7")
+libraryDependencies ++= Seq("org.http4s" %% "http4s-core" % "0.21.7")
 
 developers := List(
-  Developer("jcranky", "Paulo Siqueira", "paulo.siqueira@gmail.com", url("https://github.com/jcranky")))
+  Developer("jcranky", "Paulo Siqueira", "paulo.siqueira@gmail.com", url("https://github.com/jcranky"))
+)
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.http4s.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/javax/build.sbt
+++ b/modules/javax/build.sbt
@@ -1,10 +1,12 @@
 name := "pureconfig-javax"
 
-developers := List(
-  Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr")))
+developers := List(Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr")))
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.javax.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/joda/build.sbt
+++ b/modules/joda/build.sbt
@@ -1,15 +1,17 @@
 name := "pureconfig-joda"
 
-libraryDependencies ++= Seq(
-  "joda-time" % "joda-time" % "2.10.6",
-  "org.joda" % "joda-convert" % "2.2.1")
+libraryDependencies ++= Seq("joda-time" % "joda-time" % "2.10.6", "org.joda" % "joda-convert" % "2.2.1")
 
 developers := List(
   Developer("melrief", "Mario Pastorelli", "pastorelli.mario@gmail.com", url("https://github.com/melrief")),
-  Developer("leifwickland", "Leif Wickland", "leifwickland@gmail.com", url("https://github.com/leifwickland")))
+  Developer("leifwickland", "Leif Wickland", "leifwickland@gmail.com", url("https://github.com/leifwickland"))
+)
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.joda.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/magnolia/build.sbt
+++ b/modules/magnolia/build.sbt
@@ -7,13 +7,18 @@ crossScalaVersions ~= { _.filterNot(_.startsWith("2.11")) }
 libraryDependencies ++= Seq(
   "com.propensive" %% "magnolia" % "0.17.0",
   scalaCheckShapeless % "test",
-  "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided)
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
+)
 
 developers := List(
-  Developer("ruippeixotog", "Rui Gonçalves", "ruippeixotog@gmail.com", url("https://github.com/ruippeixotog")))
+  Developer("ruippeixotog", "Rui Gonçalves", "ruippeixotog@gmail.com", url("https://github.com/ruippeixotog"))
+)
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.magnolia.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/scala-xml/build.sbt
+++ b/modules/scala-xml/build.sbt
@@ -1,13 +1,14 @@
 name := "pureconfig-scala-xml"
 
-libraryDependencies ++= Seq(
-  "org.scala-lang.modules" %% "scala-xml" % "1.3.0")
+libraryDependencies ++= Seq("org.scala-lang.modules" %% "scala-xml" % "1.3.0")
 
-developers := List(
-  Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr")))
+developers := List(Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr")))
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.scalaxml.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/scalaz/build.sbt
+++ b/modules/scalaz/build.sbt
@@ -15,4 +15,7 @@ osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.scalaz.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/squants/build.sbt
+++ b/modules/squants/build.sbt
@@ -1,14 +1,17 @@
 name := "pureconfig-squants"
 
-libraryDependencies ++= Seq(
-  "org.typelevel" %% "squants" % "1.7.0")
+libraryDependencies ++= Seq("org.typelevel" %% "squants" % "1.7.0")
 
 developers := List(
   Developer("melrief", "Mario Pastorelli", "pastorelli.mario@gmail.com", url("https://github.com/melrief")),
-  Developer("cranst0n", "Ian McIntosh", "cranston.ian@gmail.com", url("https://github.com/cranst0n")))
+  Developer("cranst0n", "Ian McIntosh", "cranston.ian@gmail.com", url("https://github.com/cranst0n"))
+)
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.squants.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/sttp/build.sbt
+++ b/modules/sttp/build.sbt
@@ -4,11 +4,13 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.model" %% "core" % "1.1.4"
 )
 
-developers := List(
-  Developer("bszwej", "Bartlomiej Szwej", "bszwej@gmail.com", url("https://github.com/bszwej")))
+developers := List(Developer("bszwej", "Bartlomiej Szwej", "bszwej@gmail.com", url("https://github.com/bszwej")))
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.sttp.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/modules/yaml/build.sbt
+++ b/modules/yaml/build.sbt
@@ -1,13 +1,16 @@
 name := "pureconfig-yaml"
 
-libraryDependencies ++= Seq(
-  "org.yaml" % "snakeyaml" % "1.27")
+libraryDependencies ++= Seq("org.yaml" % "snakeyaml" % "1.27")
 
 developers := List(
-  Developer("ruippeixotog", "Rui Gonçalves", "ruippeixotog@gmail.com", url("https://github.com/ruippeixotog")))
+  Developer("ruippeixotog", "Rui Gonçalves", "ruippeixotog@gmail.com", url("https://github.com/ruippeixotog"))
+)
 
 osgiSettings
 
 OsgiKeys.exportPackage := Seq("pureconfig.module.yaml.*")
 OsgiKeys.privatePackage := Seq()
-OsgiKeys.importPackage := Seq(s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""", "*")
+OsgiKeys.importPackage := Seq(
+  s"""scala.*;version="[${scalaBinaryVersion.value}.0,${scalaBinaryVersion.value}.50)"""",
+  "*"
+)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,18 +3,18 @@ import sbt._
 object Dependencies {
 
   object Version {
-    val scala211                = "2.11.12"
-    val scala212                = "2.12.12"
-    val scala213                = "2.13.3"
+    val scala211 = "2.11.12"
+    val scala212 = "2.12.12"
+    val scala213 = "2.13.3"
 
-    val shapeless               = "2.3.3"
-    val typesafeConfig          = "1.4.0"
+    val shapeless = "2.3.3"
+    val typesafeConfig = "1.4.0"
 
-    val scalaTest               = "3.2.2"
+    val scalaTest = "3.2.2"
     val scalaTestPlusScalaCheck = "3.2.2.0"
 
-    val scalaCheck              = "1.14.3"
-    val scalaCheckShapeless     = "1.2.5"
+    val scalaCheck = "1.14.3"
+    val scalaCheckShapeless = "1.2.5"
   }
 
   val shapeless = "com.chuusai" %% "shapeless" % Version.shapeless

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,13 @@
-addSbtPlugin("com.47deg"         % "sbt-microsites"  % "1.2.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release"     % "1.0.13")
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"         % "2.0.1")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-osgi"        % "0.9.5")
-addSbtPlugin("io.spray"          % "sbt-boilerplate" % "0.6.1")
-addSbtPlugin("net.ruippeixotog"  % "sbt-coveralls"   % "1.3.0")  // fork with scoverage/sbt-coveralls#128 merged in
-addSbtPlugin("org.scalameta"     % "sbt-mdoc"        % "2.2.9")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"    % "2.4.2")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage"   % "1.6.1")
-addSbtPlugin("org.tpolecat"      % "tut-plugin"      % "0.6.13")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"    % "3.9.4")
+addSbtPlugin("com.47deg" % "sbt-microsites" % "1.2.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.5")
+addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
+addSbtPlugin("net.ruippeixotog" % "sbt-coveralls" % "1.3.0") // fork with scoverage/sbt-coveralls#128 merged in
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.9")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.13")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
 
 libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.30"

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -2,10 +2,6 @@ import Dependencies._
 
 name := "pureconfig-tests"
 
-libraryDependencies ++= Seq(
-  scalaTest,
-  scalaCheck,
-  scalaTestPlusScalaCheck,
-  scalaCheckShapeless % "test")
+libraryDependencies ++= Seq(scalaTest, scalaCheck, scalaTestPlusScalaCheck, scalaCheckShapeless % "test")
 
 skip in publish := true


### PR DESCRIPTION
Applies our Scalafmt config to build files and adds an additional CI check to make sure they're properly formatted. I don't think we should automatically format these like we do for Scala files on compile, since it can become annoying in an interactive environment.