### PR TITLE
Use mdoc variables in website

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,8 @@ lazy val docsSettings = Seq(
     "white-color" -> "#FFFFFF"
   ),
   micrositeGitterChannel := false, // ugly
-  mdocExtraArguments += "--no-link-hygiene"
+  mdocExtraArguments += "--no-link-hygiene",
+  mdocVariables := Map("VERSION" -> version.value)
 )
 
 // add support for Scala version ranges such as "scala-2.12+" in source folders (single version folders such as

--- a/docs/docs/docs/index.md
+++ b/docs/docs/docs/index.md
@@ -9,7 +9,7 @@ To use PureConfig in an existing SBT project with Scala 2.11 or a later version,
 `build.sbt`:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig" % "@VERSION@"
 ```
 
 For a full example of `build.sbt` you can have a look at this [build.sbt](https://github.com/pureconfig/pureconfig/blob/master/example/build.sbt).


### PR DESCRIPTION
This makes sure the version on the website is always in sync with the build version (I happened to miss it on our last deploy and had to do [a post-release commit](https://github.com/pureconfig/pureconfig/commit/11ede7e43e62b6158163f3611ae3914f6de955f9) to master 🙁 ).