### PR TITLE
Fix issue with docker build in the "Diff Website" CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,10 @@ jobs:
 
       - name: Comment on pull request
         if: steps.diff_website.outcome == 'failure'
-        uses: thollander/actions-comment-pull-request@1.0.0
+        # FIXME: Stop using the master branch once a stable version with
+        #        https://github.com/thollander/actions-comment-pull-request/pull/18 is
+        #        released.
+        uses: thollander/actions-comment-pull-request@master
         with:
           message: >
             Warning: the content of the PureConfig website changed with this pull request. This may


### PR DESCRIPTION
This pull request attempts to fix an issue with building the docker container for the "Comment on pull request" step in the "Diff Website" check.

The issue was fixed in https://github.com/thollander/actions-comment-pull-request/pull/18, but no stable version has been released yet. For the time being, I think we can use the `master` branch of the action.