### PR TITLE
Perform a minor cleanup to project settings after the sbt 1.4.x update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,15 +2,16 @@
 *.log
 
 # sbt specific
+.bsp
 .cache
 .history
 .lib/
 dist/*
-target/
 lib_managed/
-src_managed/
 project/boot/
 project/plugins/project/
+src_managed/
+target/
 
 # Scala-IDE specific
 .scala_dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -187,3 +187,8 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion,
   pushChanges
 )
+
+excludeLintKeys in Global ++= Set(
+  releaseCrossBuild,
+  releaseProcess
+)

--- a/build.sbt
+++ b/build.sbt
@@ -188,6 +188,9 @@ releaseProcess := Seq[ReleaseStep](
   pushChanges
 )
 
+// This avoids linting warnings in sbt.
+// FIXME: It should be possible to remove this once a new sbt version with the changes from
+// https://github.com/sbt/sbt/pull/5991 is released.
 excludeLintKeys in Global ++= Set(
   releaseCrossBuild,
   releaseProcess


### PR DESCRIPTION
This PR does a minor cleanup to some things that showed up after the sbt 1.4 update:

* Adds `.bsp` to `.gitignore`;
* Excludes sbt-release related keys from the sbt linter. Even though they aren't used by any other settings/tasks, they're relevant for the `release` command.