### PR TITLE
Start using version 1.0.1 of actions-comment-pull-request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,7 @@ jobs:
 
       - name: Comment on pull request
         if: steps.diff_website.outcome == 'failure'
-        # FIXME: Stop using the master branch once a stable version with
-        #        https://github.com/thollander/actions-comment-pull-request/pull/18 is
-        #        released.
-        uses: thollander/actions-comment-pull-request@master
+        uses: thollander/actions-comment-pull-request@1.0.1
         with:
           message: >
             Warning: the content of the PureConfig website changed with this pull request. This may


### PR DESCRIPTION
This PR removes the dependency from the `master` branch of [thollander/actions-comment-pull-request](https://github.com/thollander/actions-comment-pull-request) to use version 1.0.1 instead, since it includes the changes from https://github.com/thollander/actions-comment-pull-request/pull/18.