### PR TITLE
Use computed latest released version in modules' READMEs

### DIFF
--- a/bundle/docs/README.md
+++ b/bundle/docs/README.md
@@ -33,7 +33,7 @@ To use PureConfig in an existing SBT project with Scala 2.11 or a later version,
 `build.sbt`:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig" % "@VERSION@"
 ```
 
 For a full example of `build.sbt` you can have a look at this [build.sbt](https://github.com/pureconfig/pureconfig/blob/master/example/build.sbt).

--- a/modules/akka-http/docs/README.md
+++ b/modules/akka-http/docs/README.md
@@ -9,7 +9,7 @@ for other classes are welcome :)
 In addition to [core PureConfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-akka-http" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-akka-http" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/akka/docs/README.md
+++ b/modules/akka/docs/README.md
@@ -7,7 +7,7 @@ Adds support for selected [Akka](http://akka.io/) classes to PureConfig.
 In addition to [core PureConfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-akka" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-akka" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/cats-effect/docs/README.md
+++ b/modules/cats-effect/docs/README.md
@@ -7,7 +7,7 @@ Adds support for loading configuration using [cats-effect](https://github.com/ty
 In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats-effect" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats-effect" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/cats/docs/README.md
+++ b/modules/cats/docs/README.md
@@ -9,7 +9,7 @@ classes.
 In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/circe/docs/README.md
+++ b/modules/circe/docs/README.md
@@ -7,7 +7,7 @@ Adds support for [Circe](https://circe.github.io/circe/) `Json` to PureConfig.
 In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-circe" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-circe" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/cron4s/docs/README.md
+++ b/modules/cron4s/docs/README.md
@@ -8,7 +8,7 @@ Adds support for [Cron4s](https://github.com/alonsodomin/cron4s)'s CronExpr clas
 In addition to [core PureConfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-cron4s" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-cron4s" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/enum/docs/README.md
+++ b/modules/enum/docs/README.md
@@ -11,7 +11,7 @@ Automatically create a converter to read [enum](https://github.com/julienrf/enum
 In addition to [core PureConfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-enum" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-enum" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/enumeratum/docs/README.md
+++ b/modules/enumeratum/docs/README.md
@@ -11,7 +11,7 @@ Automatically create a converters to read [Enumeratum](https://github.com/lloydm
 In addition to [core PureConfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-enumeratum" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-enumeratum" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/fs2/docs/README.md
+++ b/modules/fs2/docs/README.md
@@ -7,7 +7,7 @@ Adds support for loading and saving configurations from [fs2](https://github.com
 In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-fs2" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-fs2" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/hadoop/docs/README.md
+++ b/modules/hadoop/docs/README.md
@@ -7,7 +7,7 @@ Adds support for selected [Hadoop](http://hadoop.apache.org/) classes to PureCon
 In addition to [core PureConfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-hadoop" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-hadoop" % "@VERSION@"
 ```
 
 Also, `pureconfig-hadoop` depends on `hadoop-common` with `provided` scope. This means that you should explicitly add a dependency on `hadoop-common` or any other Hadoop library which depends on `hadoop-common`. Usually it would be something like this:

--- a/modules/http4s/docs/README.md
+++ b/modules/http4s/docs/README.md
@@ -9,7 +9,7 @@ for other classes are welcome :)
 In addition to [core PureConfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-http4s" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-http4s" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/javax/docs/README.md
+++ b/modules/javax/docs/README.md
@@ -7,7 +7,7 @@ Adds support for selected javax classes to PureConfig.
 In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-javax" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-javax" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/joda/docs/README.md
+++ b/modules/joda/docs/README.md
@@ -13,7 +13,7 @@ The converters need to be provided a `org.joda.time.format.DateTimeFormatter` to
 In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-joda" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-joda" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/magnolia/docs/README.md
+++ b/modules/magnolia/docs/README.md
@@ -12,7 +12,7 @@ configuration using the same [product](https://pureconfig.github.io/docs/overrid
 In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-magnolia" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-magnolia" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/scala-xml/docs/README.md
+++ b/modules/scala-xml/docs/README.md
@@ -7,7 +7,7 @@ Adds support for XML via [Scala XML](https://github.com/scala/scala-xml) to Pure
 In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-scala-xml" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-scala-xml" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/scalaz/docs/README.md
+++ b/modules/scalaz/docs/README.md
@@ -9,7 +9,7 @@ classes.
 In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-scalaz" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-scalaz" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/squants/docs/README.md
+++ b/modules/squants/docs/README.md
@@ -11,7 +11,7 @@ Automatically create a converter to read [Squants](http://www.squants.com/)'s be
 In addition to [core pureconfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-squants" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-squants" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/sttp/docs/README.md
+++ b/modules/sttp/docs/README.md
@@ -7,7 +7,7 @@ Adds support for [sttp](https://github.com/softwaremill/sttp). Currently support
 In addition to [core PureConfig](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-sttp" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-sttp" % "@VERSION@"
 ```
 
 ## Example

--- a/modules/yaml/docs/README.md
+++ b/modules/yaml/docs/README.md
@@ -8,7 +8,7 @@ of `ConfigReader`s and hints to read configurations to domain objects without bo
 In addition to the [PureConfig core](https://github.com/pureconfig/pureconfig), you'll need:
 
 ```scala
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-yaml" % "0.14.0"
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-yaml" % "@VERSION@"
 ```
 
 ## Example

--- a/project/ModuleMdocPlugin.scala
+++ b/project/ModuleMdocPlugin.scala
@@ -46,7 +46,7 @@ object ModuleMdocPlugin extends AutoPlugin {
           mdocIn := (mdocIn in moduleProj).value,
           mdocOut := (mdocOut in moduleProj).value,
           mdocExtraArguments += "--no-link-hygiene",
-          mdocVariables := Map("VERSION" -> version.value),
+          mdocVariables := Map("VERSION" -> latestPureconfigRelease),
 
           libraryDependencies ++= (mdocLibraryDependencies in moduleProj).value,
           scalacOptions ++= (mdocScalacOptions in moduleProj).value,
@@ -57,4 +57,9 @@ object ModuleMdocPlugin extends AutoPlugin {
 
     List(docProj)
   }
+
+  val changelogVersionRegex = "^### ([^\\s]+)".r
+
+  lazy val latestPureconfigRelease: String =
+    IO.readLines(file("CHANGELOG.md")).flatMap(changelogVersionRegex.findFirstMatchIn).head.group(1)
 }


### PR DESCRIPTION
As titled. The strategy of parsing CHANGELOG to get the latest version is kinda hacky, but this is the easiest option I can think of that:

- Computes reliably the latest version that was actually released;
- Does not depend on state external to the repo (i.e. the value of `@VERSION@` should be constant over time in any given revision, even if we check out old commits).

Incidentally, this forces us to always update generated READMEs when we add a new version section to the CHANGELOG. We usually do this right before we release versions and push all changes together, so this doesn't seem like a problem.