### PR TITLE
Update the olafurpg/setup-scala GitHub action to v10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [openjdk@1.8]
+        jdk: [adopt@1.8]
         scala: [2.11.12, 2.12.12, 2.13.3]
 
     steps:
@@ -61,9 +61,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Scala
-        uses: olafurpg/setup-scala@v7
+        uses: olafurpg/setup-scala@v10
         with:
-          java-version: openjdk@1.8
+          java-version: adopt@1.8
 
       - name: Set up Ruby
         uses: actions/setup-ruby@v1
@@ -96,9 +96,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Scala
-        uses: olafurpg/setup-scala@v7
+        uses: olafurpg/setup-scala@v10
         with:
-          java-version: openjdk@1.8
+          java-version: adopt@1.8
 
       - name: Set up Ruby
         uses: actions/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Scala
-        uses: olafurpg/setup-scala@v7
+        uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.jdk }}
 


### PR DESCRIPTION
This PR fixes the CI build by updating the olafurpg/setup-scala GitHub action to v10 and start using the OpenJDK version from [AdoptOpenJDK](https://adoptopenjdk.net/).