### PR TITLE
Remove explicit exclusion of sbt-release keys from sbt linting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -180,11 +180,3 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion,
   pushChanges
 )
-
-// This avoids linting warnings in sbt.
-// FIXME: It should be possible to remove this once a new sbt version with the changes from
-// https://github.com/sbt/sbt/pull/5991 is released.
-excludeLintKeys in Global ++= Set(
-  releaseCrossBuild,
-  releaseProcess
-)


### PR DESCRIPTION
Keys prefixed with "release" are now automatically excluded from sbt linting.