### PR TITLE
Add Metals files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@ target/
 .ensime
 .ensime_cache
 
-# Bloop specific
-.bloop
+# Metals specific
+.bloop/
+.metals/
+metals.sbt


### PR DESCRIPTION
As per https://scalameta.org/metals/docs/editors/vscode.html#files-and-directories-to-include-in-your-gitignore.