### PR TITLE
Disable sbt doc in GitHub Actions on Scala 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
 
       - name: Build Scaladoc
+        if: startsWith(matrix.scala, '2')
         run: sbt "++${{ matrix.scala }} doc"
 
       - name: Publish artifact locally


### PR DESCRIPTION
`sbc doc` is non-deterministically failing for the last few CI builds. I suspect this is due to Scaladoc's microsites-like static site generation feature on 3.0 (https://dotty.epfl.ch/docs/usage/scaladoc/staticSite.html). This expects Markdown on a `docs`  folder just like we have and outputs a `_site` directory that seems to be causing some trouble. Let's disable this for now.