### PR TITLE
Remove Scaladoc link for scala.concurrent.duration.Duration

### DIFF
--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -115,7 +115,7 @@ trait JavaTimeReaders {
     ConfigReader.fromNonEmptyString[Year](catchReadError(Year.parse))
 }
 
-/** Trait containing `ConfigReader` instances for [[scala.concurrent.duration.Duration]] and
+/** Trait containing `ConfigReader` instances for `scala.concurrent.duration.Duration` and
   * [[scala.concurrent.duration.FiniteDuration]].
   */
 trait DurationReaders {

--- a/core/src/main/scala/pureconfig/BasicWriters.scala
+++ b/core/src/main/scala/pureconfig/BasicWriters.scala
@@ -74,7 +74,7 @@ trait JavaTimeWriters {
   implicit val javaDurationConfigWriter: ConfigWriter[JavaDuration] = ConfigWriter.toDefaultString[JavaDuration]
 }
 
-/** Trait containing `ConfigWriter` instances for [[scala.concurrent.duration.Duration]] and
+/** Trait containing `ConfigWriter` instances for `scala.concurrent.duration.Duration` and
   * [[scala.concurrent.duration.FiniteDuration]].
   */
 trait DurationWriters {


### PR DESCRIPTION
For some reason unknown to me, all CI builds started to fail on Scala 2.11 as Scaladoc doesn't recognize `scala.concurrent.duration.Duration`. I wasn't able to reproduce this locally and I couldn't find any relevant information online, so I'm removing the link to unblock the other PRs.