### PR TITLE
Bump Scala 3 to version 3.0.0-RC1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [adopt@1.8]
-        scala: [2.11.12, 2.12.12, 2.13.3, 3.0.0-M3]
+        scala: [2.11.12, 2.12.12, 2.13.3, 3.0.0-RC1]
 
     steps:
       - name: Checkout repository

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val scala211 = "2.11.12"
     val scala212 = "2.12.12"
     val scala213 = "2.13.3"
-    val scala30 = "3.0.0-M3"
+    val scala30 = "3.0.0-RC1"
 
     val shapeless = "2.3.3"
     val typesafeConfig = "1.4.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,8 +11,8 @@ object Dependencies {
     val shapeless = "2.3.3"
     val typesafeConfig = "1.4.1"
 
-    val scalaTest = "3.2.3"
-    val scalaTestPlusScalaCheck = "3.2.2.0"
+    val scalaTest = "3.2.5"
+    val scalaTestPlusScalaCheck = "3.2.5.0"
 
     val scalaCheck = "1.15.2"
     val scalaCheckShapeless = "1.2.5"
@@ -23,7 +23,7 @@ object Dependencies {
 
   // testing libraries
   val scalaTest = "org.scalatest" %% "scalatest" % Version.scalaTest
-  val scalaTestPlusScalaCheck = "org.scalatestplus" %% "scalacheck-1-14" % Version.scalaTestPlusScalaCheck
+  val scalaTestPlusScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % Version.scalaTestPlusScalaCheck
   val scalaCheck = "org.scalacheck" %% "scalacheck" % Version.scalaCheck
   val scalaCheckShapeless =
     "com.github.alexarchambault" %% s"scalacheck-shapeless_1.14" % Version.scalaCheckShapeless


### PR DESCRIPTION
Bumping Scala 3 ahead of a new PureConfig release (as per #854).