### PR TITLE
Have more stable status check names in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,16 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [adopt@1.8]
-        scala: [2.11.12, 2.12.12, 2.13.5, 3.0.0-M3]
+        scala: ['2.11', '2.12', '2.13', '3.0']
+        include:
+          - scala: '2.11'
+            scala-version: 2.11.12
+          - scala: '2.12'
+            scala-version: 2.12.12
+          - scala: '2.13'
+            scala-version: 2.13.5
+          - scala: '3.0'
+            scala-version: 3.0.0-M3
 
     steps:
       - name: Checkout repository
@@ -21,45 +30,45 @@ jobs:
           java-version: ${{ matrix.jdk }}
 
       - name: Check formatting
-        run: sbt "++${{ matrix.scala }} scalafmtCheckAll; scalafmtSbtCheck"
+        run: sbt "++${{ matrix.scala-version }} scalafmtCheckAll; scalafmtSbtCheck"
 
       - name: Compile
         run: >
           if [[ "${{ matrix.scala }}" =~ ^2\..* ]]; then
-            sbt coverage "++${{ matrix.scala }} test";
+            sbt coverage "++${{ matrix.scala-version }} test";
             else
-            sbt "++${{ matrix.scala }} test";
+            sbt "++${{ matrix.scala-version }} test";
             fi
 
       - name: Run tests
         run: >
           if [[ "${{ matrix.scala }}" =~ ^2\..* ]]; then
-            sbt coverage "++${{ matrix.scala }} test";
+            sbt coverage "++${{ matrix.scala-version }} test";
             else
-            sbt "++${{ matrix.scala }} test";
+            sbt "++${{ matrix.scala-version }} test";
             fi
 
       - name: Upload coverage data to Coveralls
         if: startsWith(matrix.scala, '2')
-        run: sbt ++${{ matrix.scala }} coverageAggregate coveralls
+        run: sbt ++${{ matrix.scala-version }} coverageAggregate coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
 
       - name: Build Scaladoc
-        run: sbt "++${{ matrix.scala }} doc"
+        run: sbt "++${{ matrix.scala-version }} doc"
 
       - name: Publish artifact locally
-        run: sbt "++${{ matrix.scala }} publishLocal"
+        run: sbt "++${{ matrix.scala-version }} publishLocal"
 
       - name: Compile example project
         if: startsWith(matrix.scala, '2')
-        run: cd example && sbt "++${{ matrix.scala }} test"
+        run: cd example && sbt "++${{ matrix.scala-version }} test"
 
       - name: Check mdoc output
-        if: startsWith(matrix.scala, '2.12')
+        if: matrix.scala == '2.12'
         run: >
-          sbt ++${{ matrix.scala }} mdoc &&
+          sbt ++${{ matrix.scala-version }} mdoc &&
           git diff --exit-code
 
   build_website:


### PR DESCRIPTION
This is an attempt to have more stable status check names in CI by not tagging checks all the way to the Scala patch version. This has the benefit of not forcing us to update the branch protection rules in GitHub on every patch update of a Scala version and also allows for more stable version tags in Coveralls.