### PR TITLE
Drop support for Scala 2.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [adopt@1.8]
-        scala: ['2.11', '2.12', '2.13', '3.0']
+        scala: ['2.12', '2.13', '3.0']
         include:
-          - scala: '2.11'
-            scala-version: 2.11.12
           - scala: '2.12'
             scala-version: 2.12.12
           - scala: '2.13'

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ certain type. In other words, you define **what** to load and PureConfig provide
 
 ## Quick Start
 
-To use PureConfig in an existing SBT project with Scala 2.11 or a later version, add the following dependency to your
+To use PureConfig in an existing SBT project with Scala 2.12 or a later version, add the following dependency to your
 `build.sbt`:
 
 ```scala

--- a/build.sbt
+++ b/build.sbt
@@ -105,11 +105,11 @@ lazy val commonSettings = Seq(
 )
 
 // add support for Scala version ranges such as "scala-2.12+" or "scala-2.13-" in source folders (single version folders
-// such as "scala-2.11" are natively supported by SBT).
+// such as "scala-2.12" are natively supported by SBT).
 def crossVersionSharedSources(unmanagedSrcs: SettingKey[Seq[File]]) = {
   unmanagedSrcs ++= {
     val versionNumber = CrossVersion.partialVersion(scalaVersion.value)
-    val expectedVersions = Seq(scala211, scala212, scala213, scala30).flatMap(CrossVersion.partialVersion)
+    val expectedVersions = Seq(scala212, scala213, scala30).flatMap(CrossVersion.partialVersion)
     expectedVersions.flatMap { case v @ (major, minor) =>
       List(
         if (versionNumber.exists(_ <= v)) unmanagedSrcs.value.map { dir => new File(dir.getPath + s"-$major.$minor-") }
@@ -122,21 +122,6 @@ def crossVersionSharedSources(unmanagedSrcs: SettingKey[Seq[File]]) = {
 }
 
 lazy val lintFlags = forScalaVersions {
-  case (2, 11) =>
-    List(
-      "-encoding",
-      "UTF-8", // arg for -encoding
-      "-feature",
-      "-unchecked",
-      "-deprecation",
-      "-Xlint",
-      "-Xfatal-warnings",
-      "-Yno-adapted-args",
-      "-Ywarn-unused-import",
-      "-Ywarn-dead-code",
-      "-Ywarn-numeric-widen"
-    )
-
   case (2, 12) =>
     List(
       "-encoding",

--- a/bundle/build.sbt
+++ b/bundle/build.sbt
@@ -2,4 +2,4 @@ import Dependencies.Version._
 
 name := "pureconfig"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)

--- a/bundle/docs/README.md
+++ b/bundle/docs/README.md
@@ -29,7 +29,7 @@ certain type. In other words, you define **what** to load and PureConfig provide
 
 ## Quick Start
 
-To use PureConfig in an existing SBT project with Scala 2.11 or a later version, add the following dependency to your
+To use PureConfig in an existing SBT project with Scala 2.12 or a later version, add the following dependency to your
 `build.sbt`:
 
 ```scala

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-core"
 
-crossScalaVersions := Seq(scala211, scala212, scala213, scala30)
+crossScalaVersions := Seq(scala212, scala213, scala30)
 
 libraryDependencies += Dependencies.typesafeConfig
 

--- a/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
+++ b/core/src/main/boilerplate/pureconfig/ProductReaders.scala.template
@@ -11,7 +11,7 @@ trait ProductReaders {
       if (reader.isInstanceOf[ReadsMissingKeys])
         reader.from(cursor.atKeyOrUndefined(key))
       else
-        cursor.atKey(key).right.flatMap(reader.from))(_(_))
+        cursor.atKey(key).flatMap(reader.from))(_(_))
 
   /**
    * Builds a `ConfigReader` for an object created from the value of 1 key.
@@ -26,7 +26,7 @@ trait ProductReaders {
     readerA0: ConfigReader[A0]
   ): ConfigReader[B] = new ConfigReader[B] {
     def from(cur: ConfigCursor): ConfigReader.Result[B] =
-      cur.asObjectCursor.right.flatMap { objCur =>
+      cur.asObjectCursor.flatMap { objCur =>
         val a0Result: ConfigReader.Result[A0 => B] = Right(f)
         val a1Result = combineReaderResult(a0Result, readerA0, keyA0, objCur)
         a1Result
@@ -45,7 +45,7 @@ trait ProductReaders {
     [#readerA0: ConfigReader[A0]#]
   ): ConfigReader[B] = new ConfigReader[B] {
     def from(cur: ConfigCursor): ConfigReader.Result[B] =
-      cur.asObjectCursor.right.flatMap { objCur =>
+      cur.asObjectCursor.flatMap { objCur =>
         val a##0Result: ConfigReader.Result[[#A0# => ] => B] = Right(f.curried)
         [#val a1Result = combineReaderResult(a0Result, readerA0, keyA0, objCur)#
         ]

--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -40,7 +40,7 @@ trait PrimitiveReaders {
       case v => v.toDouble
     })
 
-    cur.asString.right.flatMap(s => cur.scopeFailure(asStringReader(s))).left.flatMap(_ => cur.asDouble)
+    cur.asString.flatMap(s => cur.scopeFailure(asStringReader(s))).left.flatMap(_ => cur.asDouble)
   })
 
   implicit val floatConfigReader: ConfigReader[Float] = ConfigReader.fromCursor({ cur =>
@@ -49,7 +49,7 @@ trait PrimitiveReaders {
       case v => v.toFloat
     })
 
-    cur.asString.right.flatMap(s => cur.scopeFailure(asStringReader(s))).left.flatMap(_ => cur.asFloat)
+    cur.asString.flatMap(s => cur.scopeFailure(asStringReader(s))).left.flatMap(_ => cur.asFloat)
   })
 
   implicit val intConfigReader: ConfigReader[Int] = ConfigReader.fromCursor(_.asInt)
@@ -125,7 +125,7 @@ trait DurationReaders {
 
   implicit val finiteDurationConfigReader: ConfigReader[FiniteDuration] = {
     val fromString: String => Either[FailureReason, FiniteDuration] = { string =>
-      DurationUtils.fromString(string).right.flatMap {
+      DurationUtils.fromString(string).flatMap {
         case d: FiniteDuration => Right(d)
         case _ =>
           Left(
@@ -163,16 +163,16 @@ trait NumericReaders {
 trait TypesafeConfigReaders {
 
   implicit val configConfigReader: ConfigReader[Config] =
-    ConfigReader.fromCursor(_.asObjectCursor.right.map(_.objValue.toConfig))
+    ConfigReader.fromCursor(_.asObjectCursor.map(_.objValue.toConfig))
 
   implicit val configObjectConfigReader: ConfigReader[ConfigObject] =
-    ConfigReader.fromCursor(_.asObjectCursor.right.map(_.objValue))
+    ConfigReader.fromCursor(_.asObjectCursor.map(_.objValue))
 
   implicit val configValueConfigReader: ConfigReader[ConfigValue] =
     ConfigReader.fromCursor(_.asConfigValue)
 
   implicit val configListConfigReader: ConfigReader[ConfigList] =
-    ConfigReader.fromCursor(_.asListCursor.right.map(_.listValue))
+    ConfigReader.fromCursor(_.asListCursor.map(_.listValue))
 
   // TODO: improve error handling by copying the parsing logic from Typesafe and making it use PureConfig Results
   // (see PeriodUtils and DurationUtils)

--- a/core/src/main/scala/pureconfig/CollectionReaders.scala
+++ b/core/src/main/scala/pureconfig/CollectionReaders.scala
@@ -19,7 +19,7 @@ trait CollectionReaders {
     new ConfigReader[Option[A]] with ReadsMissingKeys {
       override def from(cur: ConfigCursor): ConfigReader.Result[Option[A]] = {
         if (cur.isUndefined || cur.isNull) Right(None)
-        else conv.value.from(cur).right.map(Some(_))
+        else conv.value.from(cur).map(Some(_))
       }
     }
 
@@ -30,7 +30,7 @@ trait CollectionReaders {
     new ConfigReader[F[A]] {
 
       override def from(cur: ConfigCursor): ConfigReader.Result[F[A]] = {
-        cur.fluent.mapList { valueCur => configConvert.value.from(valueCur) }.right.map { coll =>
+        cur.fluent.mapList { valueCur => configConvert.value.from(valueCur) }.map { coll =>
           val builder = cbf.newBuilder()
           (builder ++= coll).result()
         }
@@ -47,7 +47,7 @@ trait CollectionReaders {
   implicit def arrayReader[A: ClassTag](implicit reader: Derivation[ConfigReader[A]]): ConfigReader[Array[A]] =
     new ConfigReader[Array[A]] {
       override def from(cur: ConfigCursor): ConfigReader.Result[Array[A]] =
-        cur.fluent.mapList(reader.value.from).right.map(_.toArray)
+        cur.fluent.mapList(reader.value.from).map(_.toArray)
     }
 }
 

--- a/core/src/main/scala/pureconfig/ConfigConvert.scala
+++ b/core/src/main/scala/pureconfig/ConfigConvert.scala
@@ -70,7 +70,7 @@ object ConfigConvert extends ConvertHelpers {
   def viaNonEmptyString[A](fromF: String => Either[FailureReason, A], toF: A => String)(implicit
       ct: ClassTag[A]
   ): ConfigConvert[A] = {
-    viaString[A](string => ensureNonEmpty(ct)(string).right.flatMap(s => fromF(s)), toF)
+    viaString[A](string => ensureNonEmpty(ct)(string).flatMap(s => fromF(s)), toF)
   }
 
   def viaNonEmptyStringTry[A: ClassTag](fromF: String => Try[A], toF: A => String): ConfigConvert[A] = {

--- a/core/src/main/scala/pureconfig/ConfigCursor.scala
+++ b/core/src/main/scala/pureconfig/ConfigCursor.scala
@@ -173,7 +173,7 @@ sealed trait ConfigCursor {
     *         otherwise.
     */
   def asListCursor: ConfigReader.Result[ConfigListCursor] =
-    castOrFail(LIST, v => Right(v.asInstanceOf[ConfigList])).right.map(ConfigListCursor(_, pathElems))
+    castOrFail(LIST, v => Right(v.asInstanceOf[ConfigList])).map(ConfigListCursor(_, pathElems))
 
   /** Casts this cursor to a list of cursors.
     *
@@ -181,7 +181,7 @@ sealed trait ConfigCursor {
     *         otherwise.
     */
   def asList: ConfigReader.Result[List[ConfigCursor]] =
-    asListCursor.right.map(_.list)
+    asListCursor.map(_.list)
 
   /** Casts this cursor to a `ConfigObjectCursor`.
     *
@@ -189,7 +189,7 @@ sealed trait ConfigCursor {
     *         otherwise.
     */
   def asObjectCursor: ConfigReader.Result[ConfigObjectCursor] =
-    castOrFail(OBJECT, v => Right(v.asInstanceOf[ConfigObject])).right.map(ConfigObjectCursor(_, pathElems))
+    castOrFail(OBJECT, v => Right(v.asInstanceOf[ConfigObject])).map(ConfigObjectCursor(_, pathElems))
 
   /** Casts this cursor to a map from config keys to cursors.
     *
@@ -197,7 +197,7 @@ sealed trait ConfigCursor {
     *         otherwise.
     */
   def asMap: ConfigReader.Result[Map[String, ConfigCursor]] =
-    asObjectCursor.right.map(_.map)
+    asObjectCursor.map(_.map)
 
   /** Returns a cursor to the config at the path composed of given path segments.
     *
@@ -215,15 +215,15 @@ sealed trait ConfigCursor {
     */
   @deprecated("Use `asListCursor` and/or `asObjectCursor` instead", "0.10.1")
   def asCollectionCursor: ConfigReader.Result[Either[ConfigListCursor, ConfigObjectCursor]] = {
-    asConfigValue.right.flatMap { value =>
-      val listAtLeft = asListCursor.right.map(Left.apply)
-      lazy val mapAtRight = asObjectCursor.right.map(Right.apply)
+    asConfigValue.flatMap { value =>
+      val listAtLeft = asListCursor.map(Left.apply)
+      lazy val mapAtRight = asObjectCursor.map(Right.apply)
       listAtLeft.left.flatMap(_ => mapAtRight).left.flatMap(_ => failed(WrongType(value.valueType, Set(LIST, OBJECT))))
     }
   }
 
   def fluent: FluentConfigCursor =
-    FluentConfigCursor(asConfigValue.right.map(_ => this))
+    FluentConfigCursor(asConfigValue.map(_ => this))
 
   /** Returns a failed `ConfigReader` result resulting from scoping a `FailureReason` into the context of this cursor.
     *
@@ -265,8 +265,8 @@ sealed trait ConfigCursor {
       cast: ConfigValue => Either[FailureReason, A]
   ): ConfigReader.Result[A] = {
 
-    asConfigValue.right.flatMap { value =>
-      scopeFailure(ConfigCursor.transform(value, expectedType).right.flatMap(cast))
+    asConfigValue.flatMap { value =>
+      scopeFailure(ConfigCursor.transform(value, expectedType).flatMap(cast))
     }
   }
 }

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -38,7 +38,7 @@ trait ConfigReader[A] {
     * @return a `ConfigReader` returning the results of this reader mapped by `f`.
     */
   def map[B](f: A => B): ConfigReader[B] =
-    fromCursor[B] { cur => from(cur).right.flatMap { v => cur.scopeFailure(toResult(f)(v)) } }
+    fromCursor[B] { cur => from(cur).flatMap { v => cur.scopeFailure(toResult(f)(v)) } }
 
   /** Maps a function that can possibly fail over the results of this reader.
     *
@@ -48,7 +48,7 @@ trait ConfigReader[A] {
     *         as a success or failure.
     */
   def emap[B](f: A => Either[FailureReason, B]): ConfigReader[B] =
-    fromCursor[B] { cur => from(cur).right.flatMap { v => cur.scopeFailure(f(v)) } }
+    fromCursor[B] { cur => from(cur).flatMap { v => cur.scopeFailure(f(v)) } }
 
   /** Monadically bind a function over the results of this reader.
     *
@@ -57,7 +57,7 @@ trait ConfigReader[A] {
     * @return a `ConfigReader` returning the results of this reader bound by `f`.
     */
   def flatMap[B](f: A => ConfigReader[B]): ConfigReader[B] =
-    fromCursor[B] { cur => from(cur).right.flatMap(f(_).from(cur)) }
+    fromCursor[B] { cur => from(cur).flatMap(f(_).from(cur)) }
 
   /** Combines this reader with another, returning both results as a pair.
     *
@@ -131,8 +131,7 @@ object ConfigReader extends BasicReaders with CollectionReaders with ProductRead
         case (Left(err), Right(_)) => Left(err)
         case (Right(_), Left(err)) => Left(err)
         case (Left(errs), Left(err)) => Left(errs ++ err)
-      }.right
-        .map(_.result())
+      }.map(_.result())
     }
 
     /** Merges two `Result`s using a given function.
@@ -172,7 +171,7 @@ object ConfigReader extends BasicReaders with CollectionReaders with ProductRead
     * @return a `ConfigReader` for reading objects of type `A` using `fromF`.
     */
   def fromFunction[A](fromF: ConfigValue => ConfigReader.Result[A]) =
-    fromCursor(_.asConfigValue.right.flatMap(fromF))
+    fromCursor(_.asConfigValue.flatMap(fromF))
 
   def fromString[A](fromF: String => Either[FailureReason, A]): ConfigReader[A] =
     ConfigReader.fromCursor(_.asString).emap(fromF)
@@ -186,7 +185,7 @@ object ConfigReader extends BasicReaders with CollectionReaders with ProductRead
   }
 
   def fromNonEmptyString[A](fromF: String => Either[FailureReason, A])(implicit ct: ClassTag[A]): ConfigReader[A] = {
-    fromString(string => ensureNonEmpty(ct)(string).right.flatMap(s => fromF(s)))
+    fromString(string => ensureNonEmpty(ct)(string).flatMap(s => fromF(s)))
   }
 
   def fromNonEmptyStringTry[A](fromF: String => Try[A])(implicit ct: ClassTag[A]): ConfigReader[A] = {

--- a/core/src/main/scala/pureconfig/ConfigSource.scala
+++ b/core/src/main/scala/pureconfig/ConfigSource.scala
@@ -34,7 +34,7 @@ trait ConfigSource {
     * @return a cursor for a `ConfigValue` retrieved from this source.
     */
   def cursor(): Result[ConfigCursor] =
-    value().right.map(ConfigCursor(_, Nil))
+    value().map(ConfigCursor(_, Nil))
 
   /** Returns a fluent cursor for a `ConfigValue` retrieved from this source.
     *
@@ -58,7 +58,7 @@ trait ConfigSource {
     *         `A` from this source, a `Failure` with details on why it isn't possible otherwise
     */
   final def load[A](implicit reader: Derivation[ConfigReader[A]]): Result[A] =
-    cursor().right.flatMap(reader.value.from)
+    cursor().flatMap(reader.value.from)
 
   /** Loads a configuration of type `A` from this source. If it is not possible to create an
     * instance of `A`, this method throws a `ConfigReaderException`.
@@ -83,11 +83,11 @@ trait ConfigSource {
 final class ConfigObjectSource private (getConf: () => Result[Config]) extends ConfigSource {
 
   def value(): Result[ConfigObject] =
-    config().right.flatMap(_.resolveSafe()).right.map(_.root)
+    config().flatMap(_.resolveSafe()).map(_.root)
 
   // Avoids unnecessary cast on `ConfigCursor#asObjectCursor`.
   override def cursor(): Result[ConfigCursor] =
-    value().right.map(ConfigObjectCursor(_, Nil))
+    value().map(ConfigObjectCursor(_, Nil))
 
   /** Reads a `Config` from this config source. The returned config is usually unresolved, unless
     * the source forces it otherwise.
@@ -179,7 +179,7 @@ object ConfigSource {
     *         custom application config source.
     */
   def default(appSource: ConfigObjectSource): ConfigObjectSource =
-    ConfigObjectSource(appSource.config().right.flatMap(ConfigFactoryWrapper.load))
+    ConfigObjectSource(appSource.config().flatMap(ConfigFactoryWrapper.load))
 
   /** A config source that always provides empty configs.
     */
@@ -301,7 +301,7 @@ object ConfigSource {
     */
   private[pureconfig] def fromCursor(cur: FluentConfigCursor): ConfigSource =
     new ConfigSource {
-      def value(): Result[ConfigValue] = cur.cursor.right.flatMap(_.asConfigValue)
+      def value(): Result[ConfigValue] = cur.cursor.flatMap(_.asConfigValue)
       override def cursor() = cur.cursor
       override def fluentCursor() = cur
     }

--- a/core/src/main/scala/pureconfig/FluentConfigCursor.scala
+++ b/core/src/main/scala/pureconfig/FluentConfigCursor.scala
@@ -16,63 +16,63 @@ case class FluentConfigCursor(cursor: ConfigReader.Result[ConfigCursor]) {
     * @return a `Right` with the string value pointed to by this cursor if the cast can be done, `Left` with a list of
     *         failures otherwise.
     */
-  def asString: ConfigReader.Result[String] = cursor.right.flatMap(_.asString)
+  def asString: ConfigReader.Result[String] = cursor.flatMap(_.asString)
 
   /** Casts this cursor to a boolean.
     *
     * @return a `Right` with the boolean value pointed to by this cursor if the cast can be done, `Left` with a list of
     *         failures otherwise.
     */
-  def asBoolean: ConfigReader.Result[Boolean] = cursor.right.flatMap(_.asBoolean)
+  def asBoolean: ConfigReader.Result[Boolean] = cursor.flatMap(_.asBoolean)
 
   /** Casts this cursor to a long.
     *
     * @return a `Right` with the long value pointed to by this cursor if the cast can be done, `Left` with a list of
     *         failures otherwise.
     */
-  def asLong: ConfigReader.Result[Long] = cursor.right.flatMap(_.asLong)
+  def asLong: ConfigReader.Result[Long] = cursor.flatMap(_.asLong)
 
   /** Casts this cursor to an int.
     *
     * @return a `Right` with the int value pointed to by this cursor if the cast can be done, `Left` with a list of
     *         failures otherwise.
     */
-  def asInt: ConfigReader.Result[Int] = cursor.right.flatMap(_.asInt)
+  def asInt: ConfigReader.Result[Int] = cursor.flatMap(_.asInt)
 
   /** Casts this cursor to a short.
     *
     * @return a `Right` with the short value pointed to by this cursor if the cast can be done, `Left` with a list of
     *         failures otherwise.
     */
-  def asShort: ConfigReader.Result[Short] = cursor.right.flatMap(_.asShort)
+  def asShort: ConfigReader.Result[Short] = cursor.flatMap(_.asShort)
 
   /** Casts this cursor to a double.
     *
     * @return a `Right` with the double value pointed to by this cursor if the cast can be done, `Left` with a list of
     *         failures otherwise.
     */
-  def asDouble: ConfigReader.Result[Double] = cursor.right.flatMap(_.asDouble)
+  def asDouble: ConfigReader.Result[Double] = cursor.flatMap(_.asDouble)
 
   /** Casts this cursor to a float.
     *
     * @return a `Right` with the float value pointed to by this cursor if the cast can be done, `Left` with a list of
     *         failures otherwise.
     */
-  def asFloat: ConfigReader.Result[Float] = cursor.right.flatMap(_.asFloat)
+  def asFloat: ConfigReader.Result[Float] = cursor.flatMap(_.asFloat)
 
   /** Casts this cursor to a `ConfigListCursor`.
     *
     * @return a `Right` with this cursor as a list cursor if the cast can be done, `Left` with a list of failures
     *         otherwise.
     */
-  def asListCursor: ConfigReader.Result[ConfigListCursor] = cursor.right.flatMap(_.asListCursor)
+  def asListCursor: ConfigReader.Result[ConfigListCursor] = cursor.flatMap(_.asListCursor)
 
   /** Casts this cursor to a `ConfigObjectCursor`.
     *
     * @return a `Right` with this cursor as an object cursor if it points to an object, `Left` with a list of failures
     *         otherwise.
     */
-  def asObjectCursor: ConfigReader.Result[ConfigObjectCursor] = cursor.right.flatMap(_.asObjectCursor)
+  def asObjectCursor: ConfigReader.Result[ConfigObjectCursor] = cursor.flatMap(_.asObjectCursor)
 
   /** Returns a cursor to the config at a given path.
     *
@@ -82,8 +82,8 @@ case class FluentConfigCursor(cursor: ConfigReader.Result[ConfigCursor]) {
   def at(segments: PathSegment*): FluentConfigCursor =
     FluentConfigCursor {
       segments.foldLeft(this.cursor) {
-        case (Right(cur), PathSegment.Key(k)) => cur.asObjectCursor.right.flatMap(_.atKey(k))
-        case (Right(cur), PathSegment.Index(i)) => cur.asListCursor.right.flatMap(_.atIndex(i))
+        case (Right(cur), PathSegment.Key(k)) => cur.asObjectCursor.flatMap(_.atKey(k))
+        case (Right(cur), PathSegment.Index(i)) => cur.asListCursor.flatMap(_.atIndex(i))
         case (Left(err), _) => Left(err)
       }
     }
@@ -97,7 +97,7 @@ case class FluentConfigCursor(cursor: ConfigReader.Result[ConfigCursor]) {
     *         casts and mappings can be done, `Left` with a list of failures otherwise.
     */
   def mapList[A](f: ConfigCursor => ConfigReader.Result[A]): ConfigReader.Result[List[A]] =
-    asListCursor.right.flatMap { listCur => ConfigReader.Result.sequence(listCur.list.map(f)) }
+    asListCursor.flatMap { listCur => ConfigReader.Result.sequence(listCur.list.map(f)) }
 
   /** Casts this cursor to a `ConfigObjectCursor` and maps each value to a result. This method tries to map all
     * elements, combining failures from all of them if more than one exists.
@@ -108,8 +108,8 @@ case class FluentConfigCursor(cursor: ConfigReader.Result[ConfigCursor]) {
     *         casts and mappings can be done, `Left` with a list of failures otherwise.
     */
   def mapObject[A](f: ConfigCursor => ConfigReader.Result[A]): ConfigReader.Result[Map[String, A]] =
-    asObjectCursor.right.flatMap { objCur =>
-      val kvResults = objCur.map.map { case (key, cur) => f(cur).right.map((key, _)) }
-      ConfigReader.Result.sequence[(String, A), Iterable](kvResults).right.map(_.toMap)
+    asObjectCursor.flatMap { objCur =>
+      val kvResults = objCur.map.map { case (key, cur) => f(cur).map((key, _)) }
+      ConfigReader.Result.sequence[(String, A), Iterable](kvResults).map(_.toMap)
     }
 }

--- a/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
+++ b/core/src/main/scala/pureconfig/backend/ConfigFactoryWrapper.scala
@@ -74,5 +74,5 @@ object ConfigFactoryWrapper {
 
   /** Utility methods that parse a file and then calls `ConfigFactory.load` */
   def loadFile(path: Path): ConfigReader.Result[Config] =
-    parseFile(path.toFile).right.flatMap(rawConfig => unsafeToReaderResult(ConfigFactory.load(rawConfig)))
+    parseFile(path.toFile).flatMap(rawConfig => unsafeToReaderResult(ConfigFactory.load(rawConfig)))
 }

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -52,7 +52,7 @@ package object configurable {
       keyParser: String => Either[FailureReason, K]
   )(implicit readerV: Derivation[ConfigReader[V]]): ConfigReader[Map[K, V]] =
     ConfigReader.fromCursor { cursor =>
-      cursor.asMap.right.flatMap { map =>
+      cursor.asMap.flatMap { map =>
         map.foldLeft[ConfigReader.Result[Map[K, V]]](Right(Map.empty)) { case (acc, (key, valueCursor)) =>
           val eitherKeyOrError = cursor.scopeFailure(keyParser(key))
           val eitherValueOrError = readerV.value.from(valueCursor)

--- a/docs/docs/docs/built-in-supported-types.md
+++ b/docs/docs/docs/built-in-supported-types.md
@@ -36,7 +36,7 @@ Additionally, PureConfig also handles the following collections and composite Sc
   [Configurable Converters](configurable-converters.html));
 - `shapeless.HList`s of elements whose type is on this list;
 - case classes;
-- classes with only public `val` and `var` parameters in their constructor (Scala 2.11+);
+- classes with only public `val` and `var` parameters in their constructor;
 - sealed families of case classes (ADTs).
 
 The support for these types already covers most simple cases, such as the one shown in [Quick Start](index.html). See

--- a/docs/docs/docs/config-cursors.md
+++ b/docs/docs/docs/config-cursors.md
@@ -65,8 +65,7 @@ assert(ConfigSource.fromConfig(conf).load[Conf].isRight)
 The factory method `ConfigReader.fromCursor` allows us to create a `ConfigReader` without much boilerplate by providing
 the required `ConfigCursor => ConfigReader.Result[A]` function. Since most methods in the cursor API return
 `Either` values with failures at their left side,
-[for comprehensions](https://docs.scala-lang.org/tour/for-comprehensions.html) are a natural fit (note that on Scala
-2.11 and below you need to add `.right` projections at the end of each `Either` result). Let's analyze the lines
+[for comprehensions](https://docs.scala-lang.org/tour/for-comprehensions.html) are a natural fit. Let's analyze the lines
 marked above:
 
 1. `asObjectCursor` casts a cursor to a special `ConfigObjectCursor`, which contains methods exclusive to config

--- a/docs/docs/docs/index.md
+++ b/docs/docs/docs/index.md
@@ -5,7 +5,7 @@ title: Quick Start
 
 ## {{page.title}}
 
-To use PureConfig in an existing SBT project with Scala 2.11 or a later version, add the following dependency to your
+To use PureConfig in an existing SBT project with Scala 2.12 or a later version, add the following dependency to your
 `build.sbt`:
 
 ```scala

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -2,7 +2,7 @@ name := "example"
 
 version := "1.0"
 
-scalaVersion := "2.12.11"
+scalaVersion := "2.12.12"
 
 val VersionPattern = """version in ThisBuild := "([^"]*)"""".r
 val pureconfigVersion = IO.read(file("../version.sbt")).trim match {
@@ -15,7 +15,7 @@ val pureconfigVersion = IO.read(file("../version.sbt")).trim match {
 libraryDependencies ++= Seq(
   "com.github.pureconfig" %% "pureconfig" % pureconfigVersion)
 
-crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.5")
+crossScalaVersions := Seq("2.12.12", "2.13.5")
 
 val lintFlags =
   Def.setting {

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-macros"
 
-crossScalaVersions := Seq(scala211, scala212, scala213, scala30)
+crossScalaVersions := Seq(scala212, scala213, scala30)
 
 libraryDependencies ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {

--- a/modules/cats-effect/build.sbt
+++ b/modules/cats-effect/build.sbt
@@ -3,10 +3,10 @@ import Utilities._
 
 name := "pureconfig-cats-effect"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-effect" % forScalaVersions { case (2, 11) => "2.0.0"; case _ => "2.3.3" }.value
+  "org.typelevel" %% "cats-effect" % "2.3.3"
 )
 
 developers := List(Developer("keirlawson", "Keir Lawson", "keirlawson@gmail.com", url("https://github.com/keirlawson")))

--- a/modules/cats/build.sbt
+++ b/modules/cats/build.sbt
@@ -3,11 +3,11 @@ import Utilities._
 
 name := "pureconfig-cats"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-core" % forScalaVersions { case (2, 11) => "2.0.0"; case _ => "2.4.2" }.value,
-  "org.typelevel" %% "cats-laws" % forScalaVersions { case (2, 11) => "2.0.0"; case _ => "2.4.2" }.value % "test",
+  "org.typelevel" %% "cats-core" % "2.4.2",
+  "org.typelevel" %% "cats-laws" % "2.4.2" % "test",
   "org.typelevel" %% "discipline-scalatest" % "2.1.1" % "test"
 )
 

--- a/modules/circe/build.sbt
+++ b/modules/circe/build.sbt
@@ -3,12 +3,12 @@ import Utilities._
 
 name := "pureconfig-circe"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(
-  "io.circe" %% "circe-core" % forScalaVersions { case (2, 11) => "0.11.2"; case _ => "0.13.0" }.value,
-  "io.circe" %% "circe-literal" % forScalaVersions { case (2, 11) => "0.11.2"; case _ => "0.13.0" }.value % Test,
-  "org.typelevel" %% "jawn-parser" % forScalaVersions { case (2, 11) => "0.14.3"; case _ => "1.0.1" }.value % Test
+  "io.circe" %% "circe-core" % "0.13.0",
+  "io.circe" %% "circe-literal" % "0.13.0" % Test,
+  "org.typelevel" %% "jawn-parser" % "1.0.1" % Test
 )
 
 developers := List(

--- a/modules/enum/build.sbt
+++ b/modules/enum/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-enum"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("org.julienrf" %% "enum" % "3.1")
 

--- a/modules/enumeratum/build.sbt
+++ b/modules/enumeratum/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-enumeratum"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("com.beachape" %% "enumeratum" % "1.6.1")
 

--- a/modules/generic-base/build.sbt
+++ b/modules/generic-base/build.sbt
@@ -2,4 +2,4 @@ import Dependencies.Version._
 
 name := "pureconfig-generic-base"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)

--- a/modules/generic-base/src/main/scala/pureconfig/generic/CoproductHint.scala
+++ b/modules/generic-base/src/main/scala/pureconfig/generic/CoproductHint.scala
@@ -60,16 +60,15 @@ class FieldCoproductHint[A](key: String) extends CoproductHint[A] {
 
   def from(cursor: ConfigCursor, options: Seq[String]): ConfigReader.Result[CoproductHint.Action] = {
     for {
-      objCur <- cursor.asObjectCursor.right
-      valueCur <- objCur.atKey(key).right
-      valueStr <- valueCur.asString.right
+      objCur <- cursor.asObjectCursor
+      valueCur <- objCur.atKey(key)
+      valueStr <- valueCur.asString
       option <-
         options
           .find(valueStr == fieldValue(_))
           .toRight(
             ConfigReaderFailures(valueCur.failureFor(UnexpectedValueForFieldCoproductHint(valueCur.valueOpt.get)))
           )
-          .right
     } yield Use(objCur.withoutKey(key), option)
   }
 

--- a/modules/generic/build.sbt
+++ b/modules/generic/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-generic"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(
   Dependencies.shapeless,

--- a/modules/generic/src/main/scala/pureconfig/generic/EnumCoproductHint.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/EnumCoproductHint.scala
@@ -26,7 +26,7 @@ class EnumCoproductHint[A] extends CoproductHint[A] {
   protected def fieldValue(name: String): String = name.toLowerCase
 
   def from(cursor: ConfigCursor, options: Seq[String]): ConfigReader.Result[CoproductHint.Action] =
-    cursor.asString.right.flatMap { str =>
+    cursor.asString.flatMap { str =>
       options.find(str == fieldValue(_)) match {
         case Some(opt) => Right(Use(cursor, opt))
         case None => cursor.failed[CoproductHint.Action](NoValidCoproductOptionFound(cursor.valueOpt.get, Seq.empty))

--- a/modules/generic/src/main/scala/pureconfig/generic/EnumerationConfigReaderBuilder.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/EnumerationConfigReaderBuilder.scala
@@ -21,7 +21,7 @@ object EnumerationConfigReaderBuilder {
       def build(transformName: String => String): ConfigReader[CNil] =
         new ConfigReader[CNil] {
           def from(cur: ConfigCursor): Result[CNil] =
-            cur.asConfigValue.right.flatMap(v => cur.failed(NoValidCoproductOptionFound(v, Seq.empty)))
+            cur.asConfigValue.flatMap(v => cur.failed(NoValidCoproductOptionFound(v, Seq.empty)))
         }
     }
 
@@ -37,7 +37,7 @@ object EnumerationConfigReaderBuilder {
           def from(cur: ConfigCursor): Result[FieldType[K, H] :+: T] =
             cur.asString match {
               case Right(s) if s == transformName(vName.value.name) => Right(Inl(field[K](hGen.from(HNil))))
-              case Right(_) => tReader.from(cur).right.map(Inr.apply)
+              case Right(_) => tReader.from(cur).map(Inr.apply)
               case Left(err) => Left(err)
             }
         }

--- a/modules/generic/src/main/scala/pureconfig/generic/SeqShapedReader.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/SeqShapedReader.scala
@@ -15,7 +15,7 @@ object SeqShapedReader {
 
   implicit val hNilReader: SeqShapedReader[HNil] = new SeqShapedReader[HNil] {
     def from(cur: ConfigCursor): ConfigReader.Result[HNil] = {
-      cur.asList.right.flatMap {
+      cur.asList.flatMap {
         case Nil => Right(HNil)
         case cl => cur.failed(WrongSizeList(0, cl.size))
       }
@@ -29,7 +29,7 @@ object SeqShapedReader {
   ): SeqShapedReader[H :: T] =
     new SeqShapedReader[H :: T] {
       def from(cur: ConfigCursor): ConfigReader.Result[H :: T] = {
-        cur.asListCursor.right.flatMap {
+        cur.asListCursor.flatMap {
           case listCur if listCur.size != tl().length + 1 =>
             cur.failed(WrongSizeList(tl().length + 1, listCur.size))
 

--- a/modules/hadoop/build.sbt
+++ b/modules/hadoop/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-hadoop"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("org.apache.hadoop" % "hadoop-common" % "3.3.0" % "provided")
 mdocLibraryDependencies ++= Seq("org.apache.hadoop" % "hadoop-common" % "3.3.0")

--- a/modules/javax/build.sbt
+++ b/modules/javax/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-javax"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 developers := List(Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr")))
 

--- a/modules/joda/build.sbt
+++ b/modules/joda/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-joda"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("joda-time" % "joda-time" % "2.10.10", "org.joda" % "joda-convert" % "2.2.1")
 

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/EnumerationConfigReaderBuilder.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/EnumerationConfigReaderBuilder.scala
@@ -30,7 +30,7 @@ object EnumerationConfigReaderBuilder {
           def from(cur: ConfigCursor): Result[A] =
             if (ctx.isObject) Right(ctx.rawConstruct(Seq.empty))
             else
-              cur.asString.right.flatMap(v =>
+              cur.asString.flatMap(v =>
                 cur.failed(
                   CannotConvert(
                     v,
@@ -50,7 +50,7 @@ object EnumerationConfigReaderBuilder {
             cur.asString.flatMap { stringValue =>
               ctx.subtypes.find(typ => transformName(typ.typeName.short) == stringValue) match {
                 case Some(typ) => typ.typeclass.build(transformName).from(cur)
-                case None => cur.asConfigValue.right.flatMap(v => cur.failed(NoValidCoproductOptionFound(v, Seq.empty)))
+                case None => cur.asConfigValue.flatMap(v => cur.failed(NoValidCoproductOptionFound(v, Seq.empty)))
               }
             }
           }

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/MagnoliaConfigReader.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/MagnoliaConfigReader.scala
@@ -79,7 +79,7 @@ object MagnoliaConfigReader {
         def readerFor(option: String) =
           ctx.subtypes.find(_.typeName.short == option).map(_.typeclass)
 
-        hint.from(cur, ctx.subtypes.map(_.typeName.short).sorted).right.flatMap {
+        hint.from(cur, ctx.subtypes.map(_.typeName.short).sorted).flatMap {
           case CoproductHint.Use(cur, option) =>
             readerFor(option) match {
               case Some(value) => value.from(cur)

--- a/modules/scala-xml/build.sbt
+++ b/modules/scala-xml/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-scala-xml"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("org.scala-lang.modules" %% "scala-xml" % "1.3.0")
 

--- a/modules/scalaz/build.sbt
+++ b/modules/scalaz/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-scalaz"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.3.3",

--- a/modules/squants/build.sbt
+++ b/modules/squants/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-squants"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("org.typelevel" %% "squants" % "1.7.0")
 

--- a/modules/sttp/build.sbt
+++ b/modules/sttp/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-sttp"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(
   "com.softwaremill.sttp.model" %% "core" % "1.3.3"

--- a/modules/yaml/build.sbt
+++ b/modules/yaml/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-yaml"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("org.yaml" % "snakeyaml" % "1.28")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,6 @@ import sbt._
 object Dependencies {
 
   object Version {
-    val scala211 = "2.11.12"
     val scala212 = "2.12.12"
     val scala213 = "2.13.5"
     val scala30 = "3.0.0-M3"

--- a/testkit/build.sbt
+++ b/testkit/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-testkit"
 
-crossScalaVersions := Seq(scala211, scala212, scala213, scala30)
+crossScalaVersions := Seq(scala212, scala213, scala30)
 
 libraryDependencies ++= Seq(
   Dependencies.scalaTest,

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -2,6 +2,6 @@ import Dependencies.Version._
 
 name := "pureconfig-tests"
 
-crossScalaVersions := Seq(scala211, scala212, scala213, scala30)
+crossScalaVersions := Seq(scala212, scala213, scala30)
 
 skip in publish := true

--- a/tests/src/test/scala/pureconfig/ConfigConvertSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigConvertSuite.scala
@@ -22,7 +22,7 @@ class ConfigConvertSuite extends BaseSuite {
 
   it should "have a correct xmap method" in forAll { (f: Int => String, g: String => Int) =>
     forAll { (str: String) => intConvert.xmap(f, g).to(str) shouldEqual intConvert.to(g(str)) }
-    forAll { (conf: ConfigValue) => intConvert.xmap(f, g).from(conf) shouldEqual intConvert.from(conf).right.map(f) }
+    forAll { (conf: ConfigValue) => intConvert.xmap(f, g).from(conf) shouldEqual intConvert.from(conf).map(f) }
   }
 
   it should "have a xmap method that wraps exceptions in a ConfigReaderFailure" in {

--- a/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
@@ -12,7 +12,7 @@ class ConfigReaderSuite extends BaseSuite {
 
   def intSummedReader(n: Int) =
     new ConfigReader[Int] {
-      def from(cur: ConfigCursor) = intReader.from(cur).right.map(_ + n)
+      def from(cur: ConfigCursor) = intReader.from(cur).map(_ + n)
     }
 
   // generate configs that always read correctly as strings, but not always as integers
@@ -30,7 +30,7 @@ class ConfigReaderSuite extends BaseSuite {
   behavior of "ConfigReader"
 
   it should "have a correct map method" in forAll { (conf: ConfigValue, f: Int => String) =>
-    intReader.map(f).from(conf) shouldEqual intReader.from(conf).right.map(f)
+    intReader.map(f).from(conf) shouldEqual intReader.from(conf).map(f)
   }
 
   it should "have a map method that wraps exceptions in a ConfigReaderFailure" in {
@@ -46,12 +46,12 @@ class ConfigReaderSuite extends BaseSuite {
         case _ => throw new Exception(s"Unexpected value: $failures")
       }
     intReader.emap(f).from(conf).left.map(getReason) shouldEqual
-      intReader.from(conf).left.map(getReason).right.flatMap(f)
+      intReader.from(conf).left.map(getReason).flatMap(f)
   }
 
   it should "have a correct flatMap method" in forAll { (conf: ConfigValue) =>
     val g: Int => ConfigReader[Int] = intSummedReader
-    intReader.flatMap(g).from(conf) shouldEqual intReader.from(conf).right.flatMap(g(_).from(conf))
+    intReader.flatMap(g).from(conf) shouldEqual intReader.from(conf).flatMap(g(_).from(conf))
   }
 
   it should "have a correct zip method" in forAll { (conf: ConfigValue) =>


### PR DESCRIPTION
Stops compiling all modules for Scala 2.11, simplifies the build and removes all redundant `.right` calls from the code.