### PR TITLE
Add support for Scala 3.0 in pureconfig-bundle

### DIFF
--- a/bundle/build.sbt
+++ b/bundle/build.sbt
@@ -2,4 +2,4 @@ import Dependencies.Version._
 
 name := "pureconfig"
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala30)


### PR DESCRIPTION
We forgot to add it to the bundle project, so the `pureconfig` artifact was not published on our latest release (https://mvnrepository.com/artifact/com.github.pureconfig/pureconfig).

After this is accepted I'm going to to an ad-hoc release of `pureconfig` for v0.14.1.