### PR TITLE
Fix deprecated usage of `in` in sbt build files

### DIFF
--- a/project/ModuleMdocPlugin.scala
+++ b/project/ModuleMdocPlugin.scala
@@ -45,15 +45,15 @@ object ModuleMdocPlugin extends AutoPlugin {
           // format: off
           name := docProjId,
 
-          mdocIn := (mdocIn in moduleProj).value,
-          mdocOut := (mdocOut in moduleProj).value,
+          mdocIn := (moduleProj / mdocIn).value,
+          mdocOut := (moduleProj / mdocOut).value,
           mdocExtraArguments += "--no-link-hygiene",
           mdocVariables := Map("VERSION" -> latestPureconfigRelease),
 
-          libraryDependencies ++= (mdocLibraryDependencies in moduleProj).value,
-          scalacOptions ++= (mdocScalacOptions in moduleProj).value,
+          libraryDependencies ++= (moduleProj / mdocLibraryDependencies).value,
+          scalacOptions ++= (moduleProj / mdocScalacOptions).value,
 
-          skip in publish := true
+          publish / skip := true
           // format: on
         )
 

--- a/testkit/build.sbt
+++ b/testkit/build.sbt
@@ -16,4 +16,4 @@ libraryDependencies ++= Seq(
 // This is to avoid a warning due to the intransitive dependency of scalaTestPlusScalaCheck.
 publishMavenStyle := false
 
-skip in publish := true
+publish / skip := true


### PR DESCRIPTION
Overlooked these in #1005.