### PR TITLE
Update scalafmt to 3.0.0-RC1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,13 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
 
-      - name: Check formatting and run linter
+      - name: Check formatting
+        run: sbt ++${{ matrix.scala-version }} scalafmtCheckAll scalafmtSbtCheck
+
+        # Consider joining this action with the "Check formatting" one once Scalafix is supported for Scala 3.
+      - name: Run linter
         if: startsWith(matrix.scala, '2')
-        run: sbt "++${{ matrix.scala-version }} scalafmtCheckAll; scalafmtSbtCheck; scalafixAll --check"
+        run: sbt ++${{ matrix.scala-version }} "scalafixAll --check"
 
       - name: Compile
         run: sbt "++${{ matrix.scala-version }} compile"

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,10 @@
-version = 2.7.5
+version = 3.0.0-RC1
 
 align.preset = none
 maxColumn = 120
+
+fileOverride {
+  "glob:**/scala-3*/**" {
+    runner.dialect = scala3
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -92,9 +92,7 @@ lazy val commonSettings = Seq(
   Compile / console / scalacOptions --= Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-unused:_,-implicits"),
   Test / console / scalacOptions := (Compile / console / scalacOptions).value,
 
-  // Even though Scalafmt won't raise any issues as long as you don't use Scala 3 specific syntax, it still lacks
-  // support for it (https://github.com/scalameta/scalafmt/issues/2216).
-  scalafmtOnCompile := forScalaVersions { case (2, _) => true; case _ => false }.value,
+  scalafmtOnCompile := true,
 
   // We can't use Scalafix in Scala 3 yet.
   libraryDependencies ++= forScalaVersions {


### PR DESCRIPTION
Scalafmt 3.0.0-RC1 [adds support for Scala 3](https://github.com/scalameta/scalafmt/issues/2216#issuecomment-820573731).