### PR TITLE
Fix more deprecated usages of `in` in sbt files

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -28,4 +28,4 @@ micrositeGitterChannel := false // ugly
 mdocExtraArguments += "--no-link-hygiene"
 mdocVariables := Map("VERSION" -> version.value)
 
-skip in publish := true
+publish / skip := true

--- a/docs/docs/docs/faq.md
+++ b/docs/docs/docs/faq.md
@@ -26,7 +26,7 @@ can [shade](https://github.com/sbt/sbt-assembly#shading) shapeless by
 adding to your `assembly.sbt` file the following setting:
 
 ```scala
-assemblyShadeRules in assembly := Seq(ShadeRule.rename("shapeless.**" -> "new_shapeless.@1").inAll)
+assembly / assemblyShadeRules := Seq(ShadeRule.rename("shapeless.**" -> "new_shapeless.@1").inAll)
 ```
 
 #### Maven

--- a/scripts/update_website.sh
+++ b/scripts/update_website.sh
@@ -28,13 +28,13 @@ fi
 ls -d -1 "$WEBSITE_DIR"/** | grep -Ev 'v[0-9]+\.[0-9]+' | xargs rm -r
 
 # generate the main website pages
-sbt "set siteDirectory in docs := file(\"$WEBSITE_DIR\")" \
+sbt "set docs / siteDirectory := file(\"$WEBSITE_DIR\")" \
     makeMicrosite
 
 # generate the website pages for this version
 rm -rf 'docs/target/streams/_global/makeSite'
-sbt "set siteDirectory in docs := file(\"$WEBSITE_DIR/v$VERSION\")" \
-    "set micrositeBaseUrl in docs := \"v$VERSION\"" \
+sbt "set docs / siteDirectory := file(\"$WEBSITE_DIR/v$VERSION\")" \
+    "set docs / micrositeBaseUrl := \"v$VERSION\"" \
     makeMicrosite
 
 # show Git status and prompt for user confirmation before pushing changes

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -4,4 +4,4 @@ name := "pureconfig-tests"
 
 crossScalaVersions := Seq(scala212, scala213, scala30)
 
-skip in publish := true
+publish / skip := true


### PR DESCRIPTION
Sorry for another one of those after #1005 and #1013, but sbt doesn't seem to consistently warn about all deprecations.