### PR TITLE
Use while loop for "CapitalizedWordsNamingConvention.toTokens" instead of regex to improve performance

### DIFF
--- a/core/src/main/scala/pureconfig/NamingConvention.scala
+++ b/core/src/main/scala/pureconfig/NamingConvention.scala
@@ -7,13 +7,62 @@ trait NamingConvention {
 
 trait CapitalizedWordsNamingConvention extends NamingConvention {
   def toTokens(s: String): Seq[String] = {
-    CapitalizedWordsNamingConvention.wordBreakPattern.split(s).map(_.toLowerCase)
+    if (s.isEmpty) List.empty
+    else {
+      val buffer = List.newBuilder[String]
+      val currentTokenBuilder = new StringBuilder
+      val noneCtx = 0
+      val lowerCaseCtx = 1
+      val upperCaseCtx = 2
+      val notLetterCtx = 3
+      var ctx = noneCtx
+      val _ = {
+        val c = s.charAt(0)
+        if ('a' <= c && c <= 'z') {
+          currentTokenBuilder.append(c)
+          ctx = lowerCaseCtx
+        } else if ('A' <= c && c <= 'Z') {
+          currentTokenBuilder.append(c.toLower)
+          ctx = upperCaseCtx
+        } else {
+          currentTokenBuilder.append(c)
+          ctx = notLetterCtx
+        }
+      }
+      var i = 1
+      while (i < s.length) {
+        val c = s.charAt(i)
+        if ('a' <= c && c <= 'z') {
+          if (ctx == upperCaseCtx && currentTokenBuilder.length > 1) {
+            val previousChar = currentTokenBuilder.charAt(currentTokenBuilder.length - 1)
+            currentTokenBuilder.deleteCharAt(currentTokenBuilder.length - 1)
+            buffer += currentTokenBuilder.result()
+            currentTokenBuilder.clear()
+            currentTokenBuilder.append(previousChar)
+          }
+          currentTokenBuilder.append(c)
+          ctx = lowerCaseCtx
+        } else if ('A' <= c && c <= 'Z') {
+          if (ctx != upperCaseCtx) {
+            buffer += currentTokenBuilder.result()
+            currentTokenBuilder.clear()
+          }
+          currentTokenBuilder.append(c.toLower)
+          ctx = upperCaseCtx
+        } else {
+          if (ctx != notLetterCtx) {
+            buffer += currentTokenBuilder.result()
+            currentTokenBuilder.clear()
+          }
+          currentTokenBuilder.append(c)
+          ctx = notLetterCtx
+        }
+        i += 1
+      }
+      buffer += currentTokenBuilder.result()
+      buffer.result()
+    }
   }
-}
-
-object CapitalizedWordsNamingConvention {
-  private val wordBreakPattern =
-    String.format("%s|%s|%s", "(?<=[A-Z])(?=[A-Z][a-z])", "(?<=[^A-Z])(?=[A-Z])", "(?<=[A-Za-z])(?=[^A-Za-z])").r
 }
 
 /** CamelCase identifiers look like `camelCase` and `useMorePureconfig`


### PR DESCRIPTION
Thanks for your work on PureConfig, it's a great lib!

We use PureConfig to read and write quite big configs (~7MB), so I checked the performance the other day. 

For testing purposes, I used an app that in a loop performs:
```scala
val rendered = implicitly[ConfigWriter[AppConfig]].to(appConfig).render(ConfigRenderOptions.concise())
implicitly[ConfigReader[AppConfig]].from(ConfigFactory.parseString(rendered).root()) match {
  case Left(error) => throw new IllegalStateException(s"Invalid config: $error")
  case Right(v) => v
}
```

It seems that the majority of time is spent in regex that is used by `CapitalizedWordsNamingConvention.toTokens`:

<img width="1751" alt="pureconfig-master" src="https://user-images.githubusercontent.com/7759586/122118080-ee2e7300-ce27-11eb-947e-1036aab65e5c.png">

and here's a fragment of a Flame Graph:

<img width="1462" alt="pureconfig-master-flamegraph" src="https://user-images.githubusercontent.com/7759586/122119114-1e2a4600-ce29-11eb-8397-36ec3e51c60a.png">

This PR rewrites `CapitalizedWordsNamingConvention.toTokens` to use while loop instead of regex. After the change, "own time" of `CapitalizedWordsNamingConvention.toTokens` is over 8x lower:

<img width="1753" alt="image" src="https://user-images.githubusercontent.com/7759586/122120022-30f14a80-ce2a-11eb-85a4-165a556350e6.png">

and similarly, here's fragment of a Flame Graph:

<img width="1453" alt="pureconfig-fix-flamegraph" src="https://user-images.githubusercontent.com/7759586/122122612-4fa51080-ce2d-11eb-88e1-c524d2871d1b.png">

When it comes to reading our real-life config from JSON and writing that config to JSON, here are the results before and after the change:
| Type | Avg Time |
|------|------|
| Writing config before | 458ms |
| Reading config before | 905ms |
| Writing config after | 177ms |
| Reading config after | 522ms |

For our use case, the change means that reading configs from JSON to a case class representation is ~40% faster and writing configs from case class to JSON is ~60% faster.



