### PR TITLE
Remove dependency on scalacheck-shapeless

### DIFF
--- a/modules/generic/build.sbt
+++ b/modules/generic/build.sbt
@@ -6,7 +6,6 @@ crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(
   Dependencies.shapeless,
-  Dependencies.scalaCheckShapeless % "test",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
 )
 

--- a/modules/generic/src/test/scala/pureconfig/ProductConvertersSuite.scala
+++ b/modules/generic/src/test/scala/pureconfig/ProductConvertersSuite.scala
@@ -4,7 +4,6 @@ import scala.collection.JavaConverters._
 
 import com.typesafe.config.{ConfigFactory, ConfigRenderOptions, ConfigValueFactory}
 import org.scalacheck.Arbitrary
-import org.scalacheck.ScalacheckShapeless._
 
 import pureconfig.ConfigConvert.catchReadError
 import pureconfig.error.{KeyNotFound, WrongType}
@@ -30,11 +29,22 @@ class ProductConvertersSuite extends BaseSuite {
 
   case class RecType(ls: List[RecType])
 
+  implicit val arbFlatConfig: Arbitrary[FlatConfig] = Arbitrary {
+    Arbitrary.arbitrary[(Boolean, Double, Float, Int, Long, String, Option[String])].map((FlatConfig.apply _).tupled)
+  }
+
+  implicit val arbMyType: Arbitrary[MyType] = Arbitrary {
+    Arbitrary.arbitrary[String].map(new MyType(_))
+  }
+
+  implicit val arbConfigWithUnknownType: Arbitrary[ConfigWithUnknownType] = Arbitrary {
+    Arbitrary.arbitrary[MyType].map(ConfigWithUnknownType.apply)
+  }
+
   // tests
 
   checkArbitrary[FlatConfig]
 
-  implicit val arbMyType = Arbitrary(Arbitrary.arbitrary[String].map(new MyType(_)))
   implicit val myTypeConvert = ConfigConvert.viaString[MyType](catchReadError(new MyType(_)), _.getMyField)
   checkArbitrary[ConfigWithUnknownType]
 

--- a/modules/generic/src/test/scala/pureconfig/TupleConvertersSuite.scala
+++ b/modules/generic/src/test/scala/pureconfig/TupleConvertersSuite.scala
@@ -3,12 +3,17 @@ package pureconfig
 import scala.collection.JavaConverters._
 
 import com.typesafe.config.{ConfigValueFactory, ConfigValueType}
-import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.Arbitrary
 
 import pureconfig.error._
 import pureconfig.generic.auto._
 
 class TupleConvertersSuite extends BaseSuite {
+  case class Foo(a: Int, b: String)
+
+  implicit val arbFoo: Arbitrary[Foo] = Arbitrary {
+    Arbitrary.arbitrary[(Int, String)].map((Foo.apply _).tupled)
+  }
 
   behavior of "ConfigConvert"
 
@@ -18,7 +23,6 @@ class TupleConvertersSuite extends BaseSuite {
   checkArbitrary[(Int, (Long, String), Boolean)]
 
   // Check arbitrary Tuples with custom types
-  case class Foo(a: Int, b: String)
   checkArbitrary[(Long, Foo, Boolean, Foo)]
 
   // Check readers from objects and lists

--- a/modules/magnolia/build.sbt
+++ b/modules/magnolia/build.sbt
@@ -6,7 +6,6 @@ crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(
   "com.propensive" %% "magnolia" % "0.17.0",
-  Dependencies.scalaCheckShapeless % "test",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
 )
 

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/ProductConvertersSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/ProductConvertersSuite.scala
@@ -5,7 +5,6 @@ import scala.language.higherKinds
 
 import com.typesafe.config.{ConfigFactory, ConfigRenderOptions, ConfigValueFactory}
 import org.scalacheck.Arbitrary
-import org.scalacheck.ScalacheckShapeless._
 
 import pureconfig.ConfigConvert.catchReadError
 import pureconfig._
@@ -33,11 +32,22 @@ class ProductConvertersSuite extends BaseSuite {
 
   case class RecType(ls: List[RecType])
 
+  implicit val arbFlatConfig: Arbitrary[FlatConfig] = Arbitrary {
+    Arbitrary.arbitrary[(Boolean, Double, Float, Int, Long, String, Option[String])].map((FlatConfig.apply _).tupled)
+  }
+
+  implicit val arbMyType: Arbitrary[MyType] = Arbitrary {
+    Arbitrary.arbitrary[String].map(new MyType(_))
+  }
+
+  implicit val arbConfigWithUnknownType: Arbitrary[ConfigWithUnknownType] = Arbitrary {
+    Arbitrary.arbitrary[MyType].map(ConfigWithUnknownType.apply)
+  }
+
   // tests
 
   checkArbitrary[FlatConfig]
 
-  implicit val arbMyType = Arbitrary(Arbitrary.arbitrary[String].map(new MyType(_)))
   implicit val myTypeConvert = ConfigConvert.viaString[MyType](catchReadError(new MyType(_)), _.getMyField)
   checkArbitrary[ConfigWithUnknownType]
 

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/TupleConvertersSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/TupleConvertersSuite.scala
@@ -4,7 +4,7 @@ import scala.collection.JavaConverters._
 import scala.language.higherKinds
 
 import com.typesafe.config.{ConfigValueFactory, ConfigValueType}
-import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.Arbitrary
 
 import pureconfig._
 import pureconfig.error._
@@ -12,6 +12,11 @@ import pureconfig.module.magnolia.auto.reader._
 import pureconfig.module.magnolia.auto.writer._
 
 class TupleConvertersSuite extends BaseSuite {
+  case class Foo(a: Int, b: String)
+
+  implicit val arbFoo: Arbitrary[Foo] = Arbitrary {
+    Arbitrary.arbitrary[(Int, String)].map((Foo.apply _).tupled)
+  }
 
   behavior of "ConfigConvert"
 
@@ -21,7 +26,6 @@ class TupleConvertersSuite extends BaseSuite {
   checkArbitrary[(Int, (Long, String), Boolean)]
 
   // Check arbitrary Tuples with custom types
-  case class Foo(a: Int, b: String)
   checkArbitrary[(Long, Foo, Boolean, Foo)]
 
   // Check readers from objects and lists

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,6 @@ object Dependencies {
     val scalaTestPlusScalaCheck = "3.2.9.0"
 
     val scalaCheck = "1.15.4"
-    val scalaCheckShapeless = "1.3.0"
   }
 
   val shapeless = "com.chuusai" %% "shapeless" % Version.shapeless
@@ -24,6 +23,4 @@ object Dependencies {
   val scalaTest = "org.scalatest" %% "scalatest" % Version.scalaTest
   val scalaTestPlusScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % Version.scalaTestPlusScalaCheck
   val scalaCheck = "org.scalacheck" %% "scalacheck" % Version.scalaCheck
-  val scalaCheckShapeless =
-    "com.github.alexarchambault" %% s"scalacheck-shapeless_1.15" % Version.scalaCheckShapeless
 }

--- a/testkit/src/main/scala/pureconfig/BaseSuite.scala
+++ b/testkit/src/main/scala/pureconfig/BaseSuite.scala
@@ -7,8 +7,8 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class BaseSuite
     extends AnyFlatSpec
-    with ConfigConvertChecks
     with Matchers
-    with ConfigReaderMatchers
     with EitherValues
     with ScalaCheckDrivenPropertyChecks
+    with ConfigConvertChecks
+    with ConfigReaderMatchers


### PR DESCRIPTION
It's fairly easy to create `Arbitrary` instances for case classes by generating tuples and mapping. Removing this dependency helps with #1082.