### PR TITLE
add converter for shapeless singleton literals

### DIFF
--- a/modules/generic/src/main/scala/pureconfig/generic/singleton.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/singleton.scala
@@ -1,0 +1,26 @@
+package pureconfig.generic
+
+import scala.reflect.runtime.universe._
+
+import shapeless._
+import shapeless.syntax.typeable._
+
+import pureconfig.error.CannotConvert
+import pureconfig.{ConfigReader, ConfigWriter}
+
+object singleton {
+  final implicit def singletonReader[T: Typeable, W >: T](implicit
+      ev: Widen.Aux[T, W],
+      tt: TypeTag[T],
+      reader: ConfigReader[W]
+  ): ConfigReader[T] =
+    reader.emap(w =>
+      w.narrowTo[T].toRight(CannotConvert(w.toString, tt.tpe.toString, "Unable to narrow to singleton type."))
+    )
+
+  final implicit def singletonWriter[T, W >: T](implicit
+      ev: Widen.Aux[T, W],
+      writer: ConfigWriter[W]
+  ): ConfigWriter[T] =
+    writer.contramap(identity)
+}

--- a/modules/generic/src/test/scala/pureconfig/SingletonSuite.scala
+++ b/modules/generic/src/test/scala/pureconfig/SingletonSuite.scala
@@ -1,0 +1,40 @@
+package pureconfig
+
+import com.typesafe.config.ConfigValueFactory
+import shapeless.Witness
+import shapeless.syntax.singleton._
+
+import pureconfig.error.CannotConvert
+import pureconfig.generic.singleton._
+
+class SingletonSuite extends BaseSuite {
+  val W = Witness
+
+  val _42 = 42.narrow
+  val config42 = ConfigValueFactory.fromAnyRef(_42)
+
+  checkRead[W.`42`.T](config42 -> _42)
+  checkWrite[W.`42`.T](_42 -> config42)
+
+  it should "fail to read other integer values" in {
+    forAll { i: Int =>
+      whenever(i != _42) {
+        ConfigReader[W.`42`.T].from(ConfigValueFactory.fromAnyRef(i)) should failWithReason[CannotConvert]
+      }
+    }
+  }
+
+  val _traverse = "traverse".narrow
+  val configTraverse = ConfigValueFactory.fromAnyRef(_traverse)
+
+  checkRead[W.`"traverse"`.T](configTraverse -> _traverse)
+  checkWrite[W.`"traverse"`.T](_traverse -> configTraverse)
+
+  it should "fail to read other string values" in {
+    forAll { s: String =>
+      whenever(s != _traverse) {
+        ConfigReader[W.`"traverse"`.T].from(ConfigValueFactory.fromAnyRef(s)) should failWithReason[CannotConvert]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Not sure why you might need this but this PR allows you to constrain config fields to singleton literal values.

Example with Scala 2.13 (you will need `Witness` for Scala 2.12):
```scala
case class Profile(name: "foo", age: 42, theAnswerIsAlways: "traverse")
ConfigSource.string("{ name = foo, age = 42, the-answer-is-always: traverse }").load[Profile]
```

Technically you could also do the same with `refined-pureconfig` (e.g. `Int Refined Equal[42]`) but it's not as neat as with singleton literals.