### PR TITLE
Fix linter step in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         # Consider joining this action with the "Check formatting" one once Scalafix is supported for Scala 3.
       - name: Run linter
         if: startsWith(matrix.scala, '2')
-        run: sbt "++${{ matrix.scala-version }} scalafixAll --check"
+        run: sbt ++${{ matrix.scala-version }} "scalafixAll --check"
 
       - name: Compile
         run: sbt "++${{ matrix.scala-version }} compile"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         # Consider joining this action with the "Check formatting" one once Scalafix is supported for Scala 3.
       - name: Run linter
         if: startsWith(matrix.scala, '2')
-        run: sbt ++${{ matrix.scala-version }} "scalafixAll --check"
+        run: sbt "++${{ matrix.scala-version }} scalafixAll --check"
 
       - name: Compile
         run: sbt "++${{ matrix.scala-version }} compile"

--- a/build.sbt
+++ b/build.sbt
@@ -170,6 +170,9 @@ lazy val lintFlags = forScalaVersions {
 // Use the same Scala 2.12 version in the root project as in subprojects
 scalaVersion := scala212
 
+// Workaround for https://github.com/sbt/sbt/issues/3465
+crossScalaVersions := Nil
+
 // do not publish the root project
 publish / skip := true
 


### PR DESCRIPTION
Fixes the "Run linter" command, which is setting up the target Scala version in the wrong way.

The difference is subtle:
- `sbt ++2.13.6 <cmd>` makes SBT run two separate commands: `++2.13.6` changes _all_ projects to use Scala version 2.13.6, and `<cmd>` runs the given command after the change;
- `sbt "++2.13.6 <cmd>"` makes SBT run a single command, `++2.13.6 <cmd>`, meaning "run cmd on all projects that have 2.13.6 in their cross-version list".

This is the reason why #1095 is failing CI.