### PR TITLE
Dont redundantly scalafmt on compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
 
-      - name: Check formatting
-        run: sbt ++${{ matrix.scala-version }} scalafmtCheckAll scalafmtSbtCheck
-
         # Consider joining this action with the "Check formatting" one once Scalafix is supported for Scala 3.
       - name: Run linter
         if: startsWith(matrix.scala, '2')

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: Scalafmt
+
+on:
+  pull_request:
+    branches: ['**']
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    name: Code is formatted
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v1
+        with:
+          version: '3.0.1'

--- a/build.sbt
+++ b/build.sbt
@@ -93,8 +93,6 @@ lazy val commonSettings = Seq(
   Compile / console / scalacOptions --= Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-unused:_,-implicits"),
   Test / console / scalacOptions := (Compile / console / scalacOptions).value,
 
-  scalafmtOnCompile := true,
-
   // We can't use Scalafix in Scala 3 yet.
   libraryDependencies ++= forScalaVersions {
     case (2, _) => List(compilerPlugin(scalafixSemanticdb))


### PR DESCRIPTION
This opts for checking scalafmt when a PR is opened rather than doing it on compile. This can be considered a subjective change however here is my personal reasoning

* Doing format on compile significantly impacts IDE/editor performance when working on the codebase. Since editors/IDE's index/track source files, its more ideal to do this once then every time you compile (especially for a language like Scala where you do frequently compile just to check your code is correct). Furthemore some editors such as Intellij can sometimes report file conflicts when a formatted file is quickly edited.
* Doing a double check of both formatting and checking on compile can be considered redundant. In terms of practicality you don't really care that much if a PR in progress is not formatted, you only want to make sure that code is formatted in the final step before merging.

Note that the PR removes using `scalafmt` in `ci.yaml` and instead creates it as a separate pipeline that uses scalafmt-native. This has the following advantages
* scalafmt-native is significantly faster than standard scalafmt in sbt (I haven't seen it ever take longer than 10 seconds on massive codebases)
* it runs in parallel to the main compile/test rather than sequentially. For the same reason it also doesn't block the build/test if your code is formatted (it only blocks the merging of the PR). This gives you quick feedback that the code isn't formatted.

Note that I have submitted this kind of scalafmt checking on numerous Scala projects and there haven't been any issues.