### PR TITLE
Update Scala 3 version used in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - scala: '2.13'
             scala-version: 2.13.6
           - scala: '3.0'
-            scala-version: 3.0.0
+            scala-version: 3.0.2
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
We were still using 3.0.0 in CI.