### PR TITLE
Adds combinator `ensure` to `ConfigReader`

### DIFF
--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 import com.typesafe.config.ConfigValue
 
 import pureconfig.ConvertHelpers._
-import pureconfig.error.{ConfigReaderFailure, ConfigReaderFailures, FailureReason, ValidationFailed}
+import pureconfig.error.{ConfigReaderFailure, ConfigReaderFailures, FailureReason, UserValidationFailed}
 
 /** Trait for objects capable of reading objects of a given type from `ConfigValues`.
   *
@@ -140,7 +140,7 @@ trait ConfigReader[A] {
     *   a `ConfigReader` returning the results of this reader if the condition holds or a failed reader otherwise.
     */
   def ensure(pred: A => Boolean, message: A => String): ConfigReader[A] =
-    emap(a => Either.cond(pred(a), a, ValidationFailed(message(a))))
+    emap(a => Either.cond(pred(a), a, UserValidationFailed(message(a))))
 }
 
 /** Provides methods to create [[ConfigReader]] instances.

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 import com.typesafe.config.ConfigValue
 
 import pureconfig.ConvertHelpers._
-import pureconfig.error.{ConfigReaderFailure, ConfigReaderFailures, FailureReason}
+import pureconfig.error.{ConfigReaderFailure, ConfigReaderFailures, FailureReason, ValidationFailed}
 
 /** Trait for objects capable of reading objects of a given type from `ConfigValues`.
   *
@@ -129,6 +129,18 @@ trait ConfigReader[A] {
     */
   def contramapCursor(f: ConfigCursor => ConfigCursor): ConfigReader[A] =
     fromCursor[A] { cur => from(f(cur)) }
+
+  /** Fails the reader if the condition does not hold for the result.
+    *
+    * @param pred
+    *   the condition to assert
+    * @param message
+    *   the failed validation message
+    * @return
+    *   a `ConfigReader` returning the results of this reader if the condition holds or a failed reader otherwise.
+    */
+  def ensure(pred: A => Boolean, message: A => String): ConfigReader[A] =
+    emap(a => Either.cond(pred(a), a, ValidationFailed(message(a))))
 }
 
 /** Provides methods to create [[ConfigReader]] instances.

--- a/core/src/main/scala/pureconfig/error/FailureReason.scala
+++ b/core/src/main/scala/pureconfig/error/FailureReason.scala
@@ -144,3 +144,10 @@ final case class WrongSizeList(expected: Int, found: Int) extends FailureReason 
 final case class WrongSizeString(expected: Int, found: Int) extends FailureReason {
   def description = s"String of wrong size found. Expected $expected characters. Found $found characters instead."
 }
+
+/** A failure reason given when a validation failed.
+  *
+  * @param description
+  *   the validation failed description
+  */
+final case class ValidationFailed(description: String) extends FailureReason

--- a/core/src/main/scala/pureconfig/error/FailureReason.scala
+++ b/core/src/main/scala/pureconfig/error/FailureReason.scala
@@ -145,9 +145,9 @@ final case class WrongSizeString(expected: Int, found: Int) extends FailureReaso
   def description = s"String of wrong size found. Expected $expected characters. Found $found characters instead."
 }
 
-/** A failure reason given when a validation failed.
+/** A failure reason given when a user validation failed.
   *
   * @param description
   *   the validation failed description
   */
-final case class ValidationFailed(description: String) extends FailureReason
+final case class UserValidationFailed(description: String) extends FailureReason

--- a/docs/docs/docs/combinators.md
+++ b/docs/docs/docs/combinators.md
@@ -52,18 +52,17 @@ ConfigSource.string("{ port = -1 }").load[PortConf]
 `ensure` allows users to quickly fail a reader if a condition does not hold:
 
 ```scala mdoc:silent
-case class Age(years: Int)
-case class User(age: Age)
+import pureconfig.generic.semiauto._
 
-// reads a valid age
-implicit val userReader = ConfigReader[Int]
-  .map(Age(_))
-  .ensure(_.years >= 0, _ => "Age must be positive")
+case class Bounds(min: Int, max: Int)
+
+implicit val boundsReader = deriveReader[Bounds]
+  .ensure(b => b.max > b.min, _ => "Max must be bigger than Min")
 ```
 
 ```scala mdoc
-ConfigSource.string("{ age = 18 }").load[User]
-ConfigSource.string("{ age = -1 }").load[User]
+ConfigSource.string("{ min = 1, max = 3 }").load[Bounds]
+ConfigSource.string("{ min = 5, max = 3 }").load[Bounds]
 ```
 
 `orElse` can be used to provide alternative ways to load a config:

--- a/docs/docs/docs/combinators.md
+++ b/docs/docs/docs/combinators.md
@@ -49,6 +49,23 @@ ConfigSource.string("{ port = 8080 }").load[PortConf]
 ConfigSource.string("{ port = -1 }").load[PortConf]
 ```
 
+`ensure` allows users to quickly fail a reader if a condition does not hold:
+
+```scala mdoc:silent
+case class Age(years: Int)
+case class User(age: Age)
+
+// reads a valid age
+implicit val userReader = ConfigReader[Int]
+  .map(Age(_))
+  .ensure(_.years >= 0, _ => "Age must be positive")
+```
+
+```scala mdoc
+ConfigSource.string("{ age = 18 }").load[User]
+ConfigSource.string("{ age = -1 }").load[User]
+```
+
 `orElse` can be used to provide alternative ways to load a config:
 
 ```scala mdoc:silent

--- a/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
@@ -96,6 +96,6 @@ class ConfigReaderSuite extends BaseSuite {
 
   it should "have a correct ensure method" in forAll { (conf: ConfigValue, f: Int => Boolean) =>
     intReader.ensure(f, v => s"Validation message $v.").from(conf) shouldEqual
-      intReader.emap(v => if (f(v)) Right(v) else Left(ValidationFailed(s"Validation message $v."))).from(conf)
+      intReader.emap(v => if (f(v)) Right(v) else Left(UserValidationFailed(s"Validation message $v."))).from(conf)
   }
 }

--- a/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
@@ -93,4 +93,9 @@ class ConfigReaderSuite extends BaseSuite {
 
     intReader.contramapConfig(unwrap).from(wrappedConf) shouldEqual intReader.from(conf)
   }
+
+  it should "have a correct ensure method" in forAll { (conf: ConfigValue, f: Int => Boolean) =>
+    intReader.ensure(f, v => s"Validation message $v.").from(conf) shouldEqual
+      intReader.emap(v => if (f(v)) Right(v) else Left(ValidationFailed(s"Validation message $v."))).from(conf)
+  }
 }


### PR DESCRIPTION
The `ensure` combinator allows a user to quickly fail a reader if a condition does not hold without having to deal with `Either`s nor the `emap` boilerplate.