### PR TITLE
Specify dialects for Scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,9 +1,13 @@
 version = 3.0.6
 
+runner.dialect = scala213
 align.preset = none
 maxColumn = 120
 
 fileOverride {
+  "glob:**/*.sbt" {
+    runner.dialect = sbt1
+  }
   "glob:**/scala-3*/**" {
     runner.dialect = scala3
   }

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -5,9 +5,6 @@ align.preset = none
 maxColumn = 120
 
 fileOverride {
-  "glob:**/*.sbt" {
-    runner.dialect = sbt1
-  }
   "glob:**/scala-3*/**" {
     runner.dialect = scala3
   }


### PR DESCRIPTION
We were getting some warnings when running scalafmt like:

```
Default dialect is deprecated; use explicit: [Scala211,scala212,Scala212Source3,scala213,Scala213Source3,Sbt0137,Sbt1,scala3]
```

This PR modifies the Scalafmt configuration to specify a dialect for .scala and .sbt files.