### PR TITLE
Add a .jvmopts file

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,4 @@
+-Dfile.encoding=UTF8
+-Xms1g
+-Xmx3g
+-Xss2m


### PR DESCRIPTION
This PR adds a .jvmopts file to specify some sensible defaults for sbt. Should help with the build failures in #1172.