### PR TITLE
Make CI commands adequately scoped on Scala version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,12 @@ jobs:
           java-version: ${{ matrix.jdk }}
 
       - name: Check formatting
-        run: sbt ++${{ matrix.scala-version }} scalafmtCheckAll scalafmtSbtCheck
+        run: sbt "++${{ matrix.scala-version }} scalafmtCheckAll" scalafmtSbtCheck
 
         # Consider joining this action with the "Check formatting" one once Scalafix is supported for Scala 3.
       - name: Run linter
         if: startsWith(matrix.scala, '2')
-        run: sbt ++${{ matrix.scala-version }} "scalafixAll --check"
+        run: sbt "++${{ matrix.scala-version }} scalafixCheckAll"
 
       - name: Compile
         run: sbt "++${{ matrix.scala-version }} compile"
@@ -66,7 +66,7 @@ jobs:
       - name: Check mdoc output
         if: matrix.scala == '2.12'
         run: >
-          sbt ++${{ matrix.scala-version }} mdoc &&
+          sbt "++${{ matrix.scala-version }} mdoc" &&
           git diff --exit-code
 
   build_website:

--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,9 @@ lazy val sttp = module(project) in file("modules/sttp")
 lazy val yaml = module(project) in file("modules/yaml")
 lazy val `zio-config` = module(project) in file("modules/zio-config")
 
+// Workaround for https://github.com/scalacenter/scalafix/issues/1488
+val scalafixCheckAll = taskKey[Unit]("No-arg alias for 'scalafixAll --check'")
+
 lazy val commonSettings = Seq(
   // format: off
   homepage := Some(url("https://github.com/pureconfig/pureconfig")),
@@ -101,6 +104,7 @@ lazy val commonSettings = Seq(
     case _ => List.empty
   }.value,
   scalafixOnCompile := forScalaVersions { case (2, _) => true; case _ => false }.value,
+  scalafixCheckAll := scalafixAll.toTask(" --check").value,
 
   autoAPIMappings := true,
 


### PR DESCRIPTION
Fixes all CI commands to be correctly scoped on the Scala version being tested, introducing a new SBT task to work around https://github.com/scalacenter/scalafix/issues/1488.

As I mentioned in a previous PR, the difference is subtle but important:

- `sbt ++2.13.6 <cmd>` makes SBT run two separate commands, one after the other: `++2.13.6` changes the `scalaVersion` projects that have 2.13.6 in their `crossScalaVersions` to that one, ignoring all the other projects. It then runs `<cmd>`, which runs *for all subprojects* (since they are all children of the root project). The consequence of this is that if a project doesn't support Scala 2.13, `<cmd>` will still run using the original `scalaVersion` (currently 2.12).
- `sbt "++2.13.6 <cmd>"` makes SBT run a single command, `++2.13.6 <cmd>`, which means "run `<cmd>` on all projects that have 2.13.6 in their cross-version list" and it explicitly leaves some subprojects out (running `+2.13.6 -v` shows more details on which projects are left out).

Our current CI pipeline only works now because all projects support at least Scala 2.12 and 2.13, but it's the main reason why #1095 is failing CI.
