### PR TITLE
Review Scala 3 publishing settings for better compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,14 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [adopt@1.8]
-        scala: ['2.12', '2.13', '3.1']
+        scala: ['2.12', '2.13', '3.0', '3.1']
         include:
           - scala: '2.12'
             scala-version: 2.12.15
           - scala: '2.13'
             scala-version: 2.13.6
+          - scala: '3.0'
+            scala-version: 3.0.2
           - scala: '3.1'
             scala-version: 3.1.0
 

--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,11 @@ lazy val commonSettings = Seq(
 
   publishMavenStyle := true,
   Test / publishArtifact := false,
-  publishTo := sonatypePublishToBundle.value
+  publishTo := sonatypePublishToBundle.value,
+
+  // Don't publish for Scala 3.1 or later, only for 3.0. This is following the recommendation in
+  // https://scala-lang.org/blog/2021/10/21/scala-3.1.0-released.html#compatibility-notice.
+  publish / skip := forScalaVersions { case (3, x) if x > 0 => true; case _ => false }.value
   // format: on
 )
 
@@ -119,7 +123,7 @@ lazy val commonSettings = Seq(
 def crossVersionSharedSources(unmanagedSrcs: SettingKey[Seq[File]]) = {
   unmanagedSrcs ++= {
     val versionNumber = CrossVersion.partialVersion(scalaVersion.value)
-    val expectedVersions = Seq(scala212, scala213, scala3).flatMap(CrossVersion.partialVersion)
+    val expectedVersions = Seq(scala212, scala213, scala30, scala31).flatMap(CrossVersion.partialVersion)
     expectedVersions.flatMap { case v @ (major, minor) =>
       List(
         if (versionNumber.exists(_ <= v)) unmanagedSrcs.value.map { dir => new File(dir.getPath + s"-$major.$minor-") }

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -2,6 +2,6 @@ import Dependencies.Version._
 
 name := "pureconfig-core"
 
-crossScalaVersions := Seq(scala212, scala213, scala3)
+crossScalaVersions := Seq(scala212, scala213, scala30, scala31)
 
 libraryDependencies += Dependencies.typesafeConfig

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,8 @@ object Dependencies {
   object Version {
     val scala212 = "2.12.15"
     val scala213 = "2.13.6"
-    val scala3 = "3.1.0"
+    val scala30 = "3.0.2"
+    val scala31 = "3.1.0"
 
     val typesafeConfig = "1.4.1"
 

--- a/testkit/build.sbt
+++ b/testkit/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-testkit"
 
-crossScalaVersions := Seq(scala212, scala213, scala3)
+crossScalaVersions := Seq(scala212, scala213, scala30, scala31)
 
 libraryDependencies ++= Seq(
   Dependencies.scalaTest,

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -2,6 +2,6 @@ import Dependencies.Version._
 
 name := "pureconfig-tests"
 
-crossScalaVersions := Seq(scala212, scala213, scala3)
+crossScalaVersions := Seq(scala212, scala213, scala30, scala31)
 
 publish / skip := true


### PR DESCRIPTION
Following the [Scala 3.1.0 release announcement](https://scala-lang.org/blog/2021/10/21/scala-3.1.0-released.html), the official recommendation is to publish libraries with Scala 3.0, while still testing them with Scala 3.1:

> If you are a library maintainer, updating to 3.1.0 will force all of your users to update to 3.1.0 as well. We understand that the current state of binary compatibility may be unsatisfactory. We are actively working on technical solutions to support forward-compatibility in 3.2.0. In the meantime, we recommend testing your library with Scala 3.1.0 and 3.0.2, but publishing it with 3.0.2. This will allow downstream users to use your library even if they can’t update to Scala 3.1.0. 