### PR TITLE
Support Scala 3 in cats-effect and cats-effect2

### DIFF
--- a/modules/cats-effect/build.sbt
+++ b/modules/cats-effect/build.sbt
@@ -3,7 +3,7 @@ import Utilities._
 
 name := "pureconfig-cats-effect"
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala30)
 
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-effect" % "3.2.9"

--- a/modules/cats-effect/build.sbt
+++ b/modules/cats-effect/build.sbt
@@ -3,7 +3,7 @@ import Utilities._
 
 name := "pureconfig-cats-effect"
 
-crossScalaVersions := Seq(scala212, scala213, scala30)
+crossScalaVersions := Seq(scala212, scala213, scala30, scala31)
 
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-effect" % "3.2.9"

--- a/modules/cats-effect/src/test/scala/pureconfig/module/catseffect/CatsEffectSuite.scala
+++ b/modules/cats-effect/src/test/scala/pureconfig/module/catseffect/CatsEffectSuite.scala
@@ -14,6 +14,11 @@ import pureconfig.{BaseSuite, ConfigReader, ConfigSource, ConfigWriter}
 final class CatsEffectSuite extends BaseSuite {
 
   case class SomeCaseClass(somefield: Int, anotherfield: String)
+
+  object SomeCaseClass {
+    def unapply(c: SomeCaseClass): Option[(Int, String)] = Some((c.somefield, c.anotherfield))
+  }
+
   implicit val reader: ConfigReader[SomeCaseClass] =
     ConfigReader.forProduct2("somefield", "anotherfield")(SomeCaseClass.apply)
   implicit val writer: ConfigWriter[SomeCaseClass] =
@@ -31,7 +36,7 @@ final class CatsEffectSuite extends BaseSuite {
   }
 
   "ConfigSource#loadF" should "fail when the expected file is not present" in {
-    val load = ConfigSource.default.at("non-existent-namespace").loadF[IO, SomeCaseClass]
+    val load = ConfigSource.default.at("non-existent-namespace").loadF[IO, SomeCaseClass]()
 
     a[ConfigReaderException[SomeCaseClass]] should be thrownBy load.unsafeRunSync()
   }
@@ -39,7 +44,7 @@ final class CatsEffectSuite extends BaseSuite {
   it should "run successfully when correctly formatted file is specified as path" in {
     val propertiesPath = getPath("application.properties")
 
-    val load = ConfigSource.file(propertiesPath).loadF[IO, SomeCaseClass]
+    val load = ConfigSource.file(propertiesPath).loadF[IO, SomeCaseClass]()
 
     load.unsafeRunSync() shouldBe SomeCaseClass(1234, "some string")
   }
@@ -47,7 +52,7 @@ final class CatsEffectSuite extends BaseSuite {
   it should "fail when a file does not specify required keys" in {
     val propertiesPath = getPath("wrong.properties")
 
-    val load = ConfigSource.file(propertiesPath).loadF[IO, SomeCaseClass]
+    val load = ConfigSource.file(propertiesPath).loadF[IO, SomeCaseClass]()
 
     val thrown = the[ConfigReaderException[SomeCaseClass]] thrownBy load.unsafeRunSync()
     thrown.failures.head shouldBe a[ConvertFailure]
@@ -56,7 +61,7 @@ final class CatsEffectSuite extends BaseSuite {
   it should "run successfully from a Typesafe Config object" in {
     val config = ConfigFactory.load("application.properties")
 
-    val load = ConfigSource.fromConfig(config).loadF[IO, SomeCaseClass]
+    val load = ConfigSource.fromConfig(config).loadF[IO, SomeCaseClass]()
 
     load.unsafeRunSync() shouldBe SomeCaseClass(1234, "some string")
   }
@@ -64,7 +69,7 @@ final class CatsEffectSuite extends BaseSuite {
   it should "run successfully from a Typesafe Config object with a namespace" in {
     val config = ConfigFactory.load("namespaced.properties")
 
-    val load = ConfigSource.fromConfig(config).at("somecaseclass").loadF[IO, SomeCaseClass]
+    val load = ConfigSource.fromConfig(config).at("somecaseclass").loadF[IO, SomeCaseClass]()
 
     load.unsafeRunSync() shouldBe SomeCaseClass(1234, "some string")
   }
@@ -72,7 +77,7 @@ final class CatsEffectSuite extends BaseSuite {
   it should "fail when ran with a Typesafe Config object that doesn't match the format" in {
     val config = ConfigFactory.load("wrong.properties")
 
-    val load = ConfigSource.fromConfig(config).loadF[IO, SomeCaseClass]
+    val load = ConfigSource.fromConfig(config).loadF[IO, SomeCaseClass]()
 
     val thrown = the[ConfigReaderException[SomeCaseClass]] thrownBy load.unsafeRunSync()
     thrown.failures.head shouldBe a[ConvertFailure]
@@ -81,7 +86,7 @@ final class CatsEffectSuite extends BaseSuite {
   it should "fail if the Typesafe config object doesn't have the required field in a namespace" in {
     val config = ConfigFactory.load("namespaced-wrong.properties")
 
-    val load = ConfigSource.fromConfig(config).at("somecaseclass").loadF[IO, SomeCaseClass]
+    val load = ConfigSource.fromConfig(config).at("somecaseclass").loadF[IO, SomeCaseClass]()
 
     val thrown = the[ConfigReaderException[SomeCaseClass]] thrownBy load.unsafeRunSync()
     thrown.failures.head shouldBe a[ConvertFailure]

--- a/modules/cats-effect/src/test/scala/pureconfig/module/catseffect/CatsEffectSuite.scala
+++ b/modules/cats-effect/src/test/scala/pureconfig/module/catseffect/CatsEffectSuite.scala
@@ -15,14 +15,10 @@ final class CatsEffectSuite extends BaseSuite {
 
   case class SomeCaseClass(somefield: Int, anotherfield: String)
 
-  object SomeCaseClass {
-    def unapply(c: SomeCaseClass): Option[(Int, String)] = Some((c.somefield, c.anotherfield))
-  }
-
   implicit val reader: ConfigReader[SomeCaseClass] =
     ConfigReader.forProduct2("somefield", "anotherfield")(SomeCaseClass.apply)
   implicit val writer: ConfigWriter[SomeCaseClass] =
-    ConfigWriter.forProduct2("somefield", "anotherfield")(SomeCaseClass.unapply(_).get)
+    ConfigWriter.forProduct2("somefield", "anotherfield") { case SomeCaseClass(s, a) => (s, a) }
 
   private def getPath(classPathPath: String): Path = {
     val resource = getClass.getClassLoader.getResource(classPathPath)

--- a/modules/cats-effect2/build.sbt
+++ b/modules/cats-effect2/build.sbt
@@ -3,7 +3,7 @@ import Utilities._
 
 name := "pureconfig-cats-effect2"
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala30)
 
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-effect" % "2.5.4"

--- a/modules/cats-effect2/build.sbt
+++ b/modules/cats-effect2/build.sbt
@@ -3,7 +3,7 @@ import Utilities._
 
 name := "pureconfig-cats-effect2"
 
-crossScalaVersions := Seq(scala212, scala213, scala30)
+crossScalaVersions := Seq(scala212, scala213, scala30, scala31)
 
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-effect" % "2.5.4"

--- a/modules/cats-effect2/src/main/scala/pureconfig/module/catseffect2/package.scala
+++ b/modules/cats-effect2/src/main/scala/pureconfig/module/catseffect2/package.scala
@@ -72,12 +72,12 @@ package object catseffect2 {
       options: ConfigRenderOptions = ConfigRenderOptions.defaults()
   )(implicit F: Sync[F]): F[Unit] = {
     val fileAlreadyExists =
-      F.raiseError(
+      F.raiseError[Unit](
         new IllegalArgumentException(s"Cannot save configuration in file '$outputPath' because it already exists")
       )
 
     val fileIsDirectory =
-      F.raiseError(
+      F.raiseError[Unit](
         new IllegalArgumentException(s"Cannot save configuration in file '$outputPath' because it is a directory")
       )
 

--- a/modules/cats-effect2/src/test/scala/pureconfig/module/catseffect2/CatsEffectSuite.scala
+++ b/modules/cats-effect2/src/test/scala/pureconfig/module/catseffect2/CatsEffectSuite.scala
@@ -16,14 +16,11 @@ import pureconfig.{BaseSuite, ConfigReader, ConfigSource, ConfigWriter}
 final class CatsEffectSuite extends BaseSuite {
 
   case class SomeCaseClass(somefield: Int, anotherfield: String)
-  object SomeCaseClass {
-    def unapply(c: SomeCaseClass): Option[(Int, String)] = Some((c.somefield, c.anotherfield))
-  }
 
   implicit val reader: ConfigReader[SomeCaseClass] =
     ConfigReader.forProduct2("somefield", "anotherfield")(SomeCaseClass.apply)
   implicit val writer: ConfigWriter[SomeCaseClass] =
-    ConfigWriter.forProduct2("somefield", "anotherfield")(SomeCaseClass.unapply(_).get)
+    ConfigWriter.forProduct2("somefield", "anotherfield") { case SomeCaseClass(s, a) => (s, a) }
 
   private val blocker: Blocker = Blocker.liftExecutorService(Executors.newCachedThreadPool())
 

--- a/modules/cats-effect2/src/test/scala/pureconfig/module/catseffect2/CatsEffectSuite.scala
+++ b/modules/cats-effect2/src/test/scala/pureconfig/module/catseffect2/CatsEffectSuite.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.Executors
 
 import scala.concurrent.ExecutionContext
 
-import cats.effect.{Blocker, IO}
+import cats.effect.{Blocker, ContextShift, IO}
 import com.typesafe.config.ConfigFactory
 
 import pureconfig.error.{ConfigReaderException, ConvertFailure}
@@ -16,6 +16,10 @@ import pureconfig.{BaseSuite, ConfigReader, ConfigSource, ConfigWriter}
 final class CatsEffectSuite extends BaseSuite {
 
   case class SomeCaseClass(somefield: Int, anotherfield: String)
+  object SomeCaseClass {
+    def unapply(c: SomeCaseClass): Option[(Int, String)] = Some((c.somefield, c.anotherfield))
+  }
+
   implicit val reader: ConfigReader[SomeCaseClass] =
     ConfigReader.forProduct2("somefield", "anotherfield")(SomeCaseClass.apply)
   implicit val writer: ConfigWriter[SomeCaseClass] =
@@ -23,7 +27,7 @@ final class CatsEffectSuite extends BaseSuite {
 
   private val blocker: Blocker = Blocker.liftExecutorService(Executors.newCachedThreadPool())
 
-  private implicit val ioCS = IO.contextShift(ExecutionContext.global)
+  private implicit val ioCS: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   private def getPath(classPathPath: String): Path = {
     val resource = getClass.getClassLoader.getResource(classPathPath)


### PR DESCRIPTION
Hi,

  I've added Scala 3 support for cats-effect and cats-effect2 modules. However I wasn't able to add it in cats module, because of `for3Use2_13` dependencies in the testkit module. Also I faced with a weird behavior of crossbuild, when sbt tries to build for scala3 *-docs modules, even though they doesn't have Scala 3 enabled in their settings. I'll try to improve this PR, to add Scala 3 in cats as well, or I can create another one, since it looks like it will required significant changes in build.