### PR TITLE
[Proposal] Add secret

### DIFF
--- a/core/src/main/scala/pureconfig/Secret.scala
+++ b/core/src/main/scala/pureconfig/Secret.scala
@@ -1,0 +1,33 @@
+package pureconfig
+
+import pureconfig.Secret.SecretBytes
+
+import java.nio.charset.{Charset, StandardCharsets}
+
+case class Secret[+T](value: T) extends AnyVal {
+
+  def map[U](f: T => U): Secret[U] =
+    Secret(f(value))
+
+  override final def toString: String = Secret.placeHolder
+}
+object Secret extends SecretSyntax {
+
+  type SecretBytes = Secret[Array[Byte]]
+
+  val placeHolder: String = "** MASKED **"
+
+  implicit def secretConfigReader[T: ConfigReader]: ConfigReader[Secret[T]] =
+    ConfigReader[T].map(n => Secret(n))
+
+  implicit def secretConfigWriter[T: ConfigWriter]: ConfigWriter[Secret[T]] =
+    ConfigWriter[T].contramap(_.value)
+}
+
+sealed trait SecretSyntax {
+
+  implicit class SecretBytesOps(sb: SecretBytes) {
+    def stringValue(cs: Charset = StandardCharsets.UTF_8): String =
+      new String(sb.value, cs)
+  }
+}

--- a/modules/cats/src/main/scala/pureconfig/module/cats/instances/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/cats/instances/package.scala
@@ -70,4 +70,23 @@ package object instances {
 
   implicit val configObjectSourceCatsMonoid: Monoid[ConfigObjectSource] =
     Monoid.instance(ConfigSource.empty, (a, b) => b.withFallback(a))
+
+  // secret
+  private val secretAnyShow: Show[Secret[Any]] =
+    Show.show(_ => Secret.placeHolder)
+
+  implicit def secretShow[T]: Show[Secret[T]] =
+    secretAnyShow.asInstanceOf[Show[Secret[T]]]
+
+  implicit def secretEq[T: Eq]: Eq[Secret[T]] =
+    (x, y) => Eq[T].eqv(x.value, y.value)
+
+  implicit def secretApplicative: Applicative[Secret] =
+    new Applicative[Secret] {
+      override def pure[A](x: A): Secret[A] =
+        Secret(x)
+
+      override def ap[A, B](ff: Secret[A => B])(fa: Secret[A]): Secret[B] =
+        ff.map(f => f(fa.value))
+    }
 }

--- a/modules/cats/src/test/scala/pureconfig/module/cats/CatsLawsSuite.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/CatsLawsSuite.scala
@@ -12,6 +12,7 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
 import pureconfig._
+import pureconfig.arbitrary._
 import pureconfig.error.ConfigReaderFailures
 import pureconfig.module.cats.arbitrary._
 import pureconfig.module.cats.eq._
@@ -29,4 +30,6 @@ class CatsLawsSuite extends AnyFunSuite with ScalaCheckDrivenPropertyChecks with
   checkAll("Config", MonoidTests[Config].monoid)
   checkAll("ConfigReaderFailures", SemigroupTests[ConfigReaderFailures].semigroup)
   checkAll("ConfigObjectSource", MonoidTests[ConfigObjectSource].monoid)
+
+  checkAll("Secret[Int]", ApplicativeTests[Secret].applicative[Int, Int, Int])
 }

--- a/modules/circe/src/main/scala/pureconfig/module/circe/instances/package.scala
+++ b/modules/circe/src/main/scala/pureconfig/module/circe/instances/package.scala
@@ -1,0 +1,17 @@
+package pureconfig.module.circe
+
+import io.circe.{Decoder, Encoder}
+
+import pureconfig.Secret
+
+package object instances {
+
+  private val encodeSecretAny: Encoder[Secret[Any]] =
+    Encoder.encodeString.contramap(_ => Secret.placeHolder)
+
+  implicit def encodeSecret[T]: Encoder[Secret[T]] =
+    encodeSecretAny.contramap(identity)
+
+  implicit def decodeSecret[T: Decoder]: Decoder[Secret[T]] =
+    Decoder[T].map(Secret(_))
+}

--- a/modules/circe/src/test/scala/pureconfig/module/circe/CirceInstancesSuite.scala
+++ b/modules/circe/src/test/scala/pureconfig/module/circe/CirceInstancesSuite.scala
@@ -1,0 +1,19 @@
+package pureconfig.module.circe
+
+import io.circe._
+import io.circe.literal._
+
+import pureconfig._
+
+class CirceInstancesSuite extends BaseSuite {
+
+  import pureconfig.module.circe.instances._
+
+  "Secret Encoder" should "encode a Secret instance to JSON masking the value" in {
+    Encoder[Secret[Int]].apply(Secret(1)).noSpaces shouldBe "\"** MASKED **\""
+  }
+
+  "Secret Decoder" should "decode a Json Int into a Secret instance" in {
+    Decoder[Secret[Int]].decodeJson(json"1") shouldEqual Right(Secret(1))
+  }
+}

--- a/modules/circe/src/test/scala/pureconfig/module/circe/CirceSuite.scala
+++ b/modules/circe/src/test/scala/pureconfig/module/circe/CirceSuite.scala
@@ -1,6 +1,5 @@
 package pureconfig.module.circe
 
-import com.typesafe.config.ConfigFactory
 import io.circe._
 import io.circe.literal._
 

--- a/testkit/src/main/scala/pureconfig/arbitrary/package.scala
+++ b/testkit/src/main/scala/pureconfig/arbitrary/package.scala
@@ -40,4 +40,6 @@ package object arbitrary {
   implicit val arbYearMonth: Arbitrary[YearMonth] = Arbitrary(genYearMonth)
   implicit val arbZoneId: Arbitrary[ZoneId] = Arbitrary(genZoneId)
   implicit val arbZonedDateTime: Arbitrary[ZonedDateTime] = Arbitrary(genZonedDateTime)
+
+  implicit def arbSecret[T](implicit arb: Arbitrary[T]): Arbitrary[Secret[T]] = Arbitrary(arb.arbitrary.map(Secret(_)))
 }

--- a/tests/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/tests/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -148,6 +148,8 @@ class BasicConvertersSuite extends BaseSuite {
 
   checkArbitrary[File]
 
+  checkArbitrary[Secret[Int]]
+
   checkReadWriteString[DayOfWeek]("MONDAY" -> DayOfWeek.MONDAY)
   checkReadWriteString[Month]("JULY" -> Month.JULY)
   checkFailure[DayOfWeek, CannotConvert](


### PR DESCRIPTION
I've opened this PR to share my solution about secret configs. In every microservice, I've copied and pasted this class `Secret` which is "transparent" to Pureconfig but since you have a wrapper type you can change some behaviours like `toString` or JSON encoding. 

In every project after the config load I print it during the startup, In this way, I can avoid the printing of secrets.
So, I wonder if this solution can be part of PureConfig. I've tried to add it with this PR.
I guess I'm not the only one with this "problem", in this way you can provide an out of the box solution.

Let me know what do you think about it 👍 