### PR TITLE
Start compiling and publishing PureConfig against Scala 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,14 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [adopt@1.8]
-        scala: ['2.12', '2.13', '3.0', '3.1']
+        scala: ['2.12', '2.13', '3.1']
         include:
           - scala: '2.12'
             scala-version: 2.12.16
           - scala: '2.13'
             scala-version: 2.13.8
-          - scala: '3.0'
-            scala-version: 3.0.2
           - scala: '3.1'
-            scala-version: 3.1.0
+            scala-version: 3.1.3
 
     steps:
       - name: Checkout repository

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,8 @@ lazy val commonSettings = Seq(
 
   scalaVersion := scala212,
 
-  resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots")),
+  resolvers ++= Resolver.sonatypeOssRepos("releases"),
+  resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
 
   crossVersionSharedSources(Compile / unmanagedSourceDirectories),
   crossVersionSharedSources(Test / unmanagedSourceDirectories),
@@ -109,9 +110,10 @@ lazy val commonSettings = Seq(
   Test / publishArtifact := false,
   publishTo := sonatypePublishToBundle.value,
 
-  // Don't publish for Scala 3.1 or later, only for 3.0. This is following the recommendation in
-  // https://scala-lang.org/blog/2021/10/21/scala-3.1.0-released.html#compatibility-notice.
-  publish / skip := forScalaVersions { case (3, x) if x > 0 => true; case _ => false }.value
+  // Publish only for Scala 3.1 (the oldest Scala 3 version we support), not for any other later version. See
+  // https://scala-lang.org/blog/2021/10/21/scala-3.1.0-released.html#compatibility-notice for details about binary
+  // compatibility.
+  publish / skip := forScalaVersions { case (3, x) if x > 1 => true; case _ => false }.value
   // format: on
 )
 
@@ -120,7 +122,7 @@ lazy val commonSettings = Seq(
 def crossVersionSharedSources(unmanagedSrcs: SettingKey[Seq[File]]) = {
   unmanagedSrcs ++= {
     val versionNumber = CrossVersion.partialVersion(scalaVersion.value)
-    val expectedVersions = Seq(scala212, scala213, scala30, scala31).flatMap(CrossVersion.partialVersion)
+    val expectedVersions = Seq(scala212, scala213, scala31).flatMap(CrossVersion.partialVersion)
     expectedVersions.flatMap { case v @ (major, minor) =>
       List(
         if (versionNumber.exists(_ <= v)) unmanagedSrcs.value.map { dir => new File(dir.getPath + s"-$major.$minor-") }

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -2,6 +2,6 @@ import Dependencies.Version._
 
 name := "pureconfig-core"
 
-crossScalaVersions := Seq(scala212, scala213, scala30, scala31)
+crossScalaVersions := Seq(scala212, scala213, scala31)
 
 libraryDependencies += Dependencies.typesafeConfig

--- a/modules/cats-effect/build.sbt
+++ b/modules/cats-effect/build.sbt
@@ -3,7 +3,7 @@ import Utilities._
 
 name := "pureconfig-cats-effect"
 
-crossScalaVersions := Seq(scala212, scala213, scala30, scala31)
+crossScalaVersions := Seq(scala212, scala213, scala31)
 
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-effect" % "3.3.14"

--- a/modules/cats-effect2/build.sbt
+++ b/modules/cats-effect2/build.sbt
@@ -3,7 +3,7 @@ import Utilities._
 
 name := "pureconfig-cats-effect2"
 
-crossScalaVersions := Seq(scala212, scala213, scala30, scala31)
+crossScalaVersions := Seq(scala212, scala213, scala31)
 
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-effect" % "2.5.5"

--- a/modules/sttp/build.sbt
+++ b/modules/sttp/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.Version._
 
 name := "pureconfig-sttp"
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala31)
 
 libraryDependencies ++= Seq(
   "com.softwaremill.sttp.model" %% "core" % "1.5.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,6 @@ object Dependencies {
   object Version {
     val scala212 = "2.12.16"
     val scala213 = "2.13.8"
-    val scala30 = "3.0.2"
     val scala31 = "3.1.3"
 
     val typesafeConfig = "1.4.2"
@@ -15,7 +14,7 @@ object Dependencies {
     // See https://github.com/scoverage/sbt-scoverage/issues/439
     val scalaTest212 = "3.2.10"
     val scalaTestPlusScalaCheck212 = "3.2.10.0"
-    val scalaTest = "3.2.11"
+    val scalaTest = "3.2.12"
     val scalaTestPlusScalaCheck = "3.2.11.0"
 
     val scalaCheck = "1.16.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.0-RC1
+sbt.version=1.7.1

--- a/testkit/build.sbt
+++ b/testkit/build.sbt
@@ -2,15 +2,12 @@ import Dependencies.Version._
 
 name := "pureconfig-testkit"
 
-crossScalaVersions := Seq(scala212, scala213, scala30, scala31)
+crossScalaVersions := Seq(scala212, scala213, scala31)
 
 libraryDependencies ++= Seq(
   Dependencies.scalaTest.value,
-  Dependencies.scalaCheck.cross(CrossVersion.for3Use2_13),
-  // We need to ignore the transitive dependencies to avoid having scalatest-core and scalactic with conflicting
-  // cross-version suffixes, since we'd get the native 3.x version from the `scalaTest` dependency and the 2.x
-  // dependency from `scalaTestPlusScalaCheck` with the `cross(CrossVersion.for3Use2_13)` flag.
-  Dependencies.scalaTestPlusScalaCheck.value.intransitive().cross(CrossVersion.for3Use2_13)
+  Dependencies.scalaCheck,
+  Dependencies.scalaTestPlusScalaCheck.value
 )
 
 // This is to avoid a warning due to the intransitive dependency of scalaTestPlusScalaCheck.

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -2,6 +2,6 @@ import Dependencies.Version._
 
 name := "pureconfig-tests"
 
-crossScalaVersions := Seq(scala212, scala213, scala30, scala31)
+crossScalaVersions := Seq(scala212, scala213, scala31)
 
 publish / skip := true


### PR DESCRIPTION
The latest scalatest version (3.2.12) is compiled against Scala 3.1, forcing us and many other projects that depend on Scala 3 to Scala 3.1 as well. Given how widely used scalatest is, I think it's time for us to drop Scala 3.0 as well and simplify our build assumptions (for now). Compared to scalatest, this PureConfig change has a much smaller blast radius (I suspect most PureConfig users are end projects, not libraries), so I think it won't have a lot of consequences.

On this PR I'm dropping Scala 3.0 and combining a lot of existing open PRs that depend on this, such as bumping scalatest, using SBT 1.7.x and a few other build nits.

Supersedes #1348, #1317 and #1220.