### PR TITLE
Fix spark-sql tests

### DIFF
--- a/modules/spark/src/test/scala/pureconfig/module/spark/sql/gen/package.scala
+++ b/modules/spark/src/test/scala/pureconfig/module/spark/sql/gen/package.scala
@@ -54,7 +54,7 @@ package object gen {
 
   def genStructField(tGen: Gen[DataType]): Gen[StructField] =
     for {
-      n <- Gen.nonEmptyBuildableOf[String, Char](Gen.oneOf(Gen.alphaLowerChar, Gen.alphaNumChar, Gen.const('_')))
+      n <- Gen.identifier
       t <- tGen
     } yield StructField(n, t)
 


### PR DESCRIPTION
For some time now, PureConfig spark-sql tests have been flaky with due to an incorrect scalacheck `Gen` implementation. I'm fixing it in this PR by ensuring generated struct fields always have valid identifiers.