### PR TITLE
Support for Either[A, B]

### DIFF
--- a/core/src/main/scala/pureconfig/CollectionReaders.scala
+++ b/core/src/main/scala/pureconfig/CollectionReaders.scala
@@ -26,13 +26,13 @@ trait CollectionReaders {
   implicit def eitherReader[A, B](implicit convA: ConfigReader[A], convB: ConfigReader[B]): ConfigReader[Either[A, B]] =
     new ConfigReader[Either[A, B]] {
       override def from(cur: ConfigCursor): ConfigReader.Result[Either[A, B]] = {
-        convA.from(cur) match {
-          case Left(aErr) ⇒
-            convB.from(cur) match {
-              case Left(bErr) ⇒ Left(aErr ++ bErr)
-              case Right(bType) ⇒ Right(Right[A, B](bType))
+        convB.from(cur) match {
+          case Left(bErr) ⇒
+            convA.from(cur) match {
+              case Left(aErr) ⇒ Left(bErr ++ aErr)
+              case Right(aType) ⇒ Right(Left[A, B](aType))
             }
-          case Right(aType) ⇒ Right(Left[A, B](aType))
+          case Right(bType) ⇒ Right(Right[A, B](bType))
         }
       }
     }

--- a/core/src/main/scala/pureconfig/CollectionReaders.scala
+++ b/core/src/main/scala/pureconfig/CollectionReaders.scala
@@ -23,6 +23,20 @@ trait CollectionReaders {
       }
     }
 
+  implicit def eitherReader[A, B](implicit convA: ConfigReader[A], convB: ConfigReader[B]): ConfigReader[Either[A, B]] =
+    new ConfigReader[Either[A, B]] {
+      override def from(cur: ConfigCursor): ConfigReader.Result[Either[A, B]] = {
+        convA.from(cur) match {
+          case Left(aErr) ⇒
+            convB.from(cur) match {
+              case Left(bErr) ⇒ Left(aErr ++ bErr)
+              case Right(bType) ⇒ Right(Right[A, B](bType))
+            }
+          case Right(aType) ⇒ Right(Left[A, B](aType))
+        }
+      }
+    }
+
   implicit def traversableReader[A, F[A] <: TraversableOnce[A]](implicit
       configConvert: ConfigReader[A],
       cbf: FactoryCompat[A, F[A]]

--- a/core/src/main/scala/pureconfig/CollectionWriters.scala
+++ b/core/src/main/scala/pureconfig/CollectionWriters.scala
@@ -29,6 +29,16 @@ trait CollectionWriters {
       def toOpt(t: Option[A]): Option[ConfigValue] = t.map(conv.to)
     }
 
+  implicit def eitherWriter[A, B](implicit convA: ConfigWriter[A], convB: ConfigWriter[B]): ConfigWriter[Either[A, B]] =
+    new ConfigWriter[Either[A, B]] {
+      override def to(e: Either[A, B]): ConfigValue = {
+        e match {
+          case Left(lValue) => convA.to(lValue)
+          case Right(rValue) => convB.to(rValue)
+        }
+      }
+    }
+
   implicit def traversableWriter[A, F[A] <: TraversableOnce[A]](implicit
       configConvert: ConfigWriter[A]
   ): ConfigWriter[F[A]] =

--- a/docs/docs/docs/built-in-supported-types.md
+++ b/docs/docs/docs/built-in-supported-types.md
@@ -30,6 +30,7 @@ The currently supported basic types are:
 Additionally, PureConfig also handles the following collections and composite Scala structures:
 
 - `Option` for optional values, i.e. values that can or cannot be in the configuration, of types on this list;
+- `Either[A,B]` where `A` and `B` are two other supported types
 - collections implementing the `TraversableOnce` trait, where the type of the elements is on this list;
 - `Map`s from `String` keys to any value type that is on this list;
 - `Map`s from types convertible to `String` to any value type that is on this list (must be configured first - see

--- a/tests/src/test/scala/pureconfig/CollectionConvertersSuite.scala
+++ b/tests/src/test/scala/pureconfig/CollectionConvertersSuite.scala
@@ -59,4 +59,19 @@ class CollectionConvertersSuite extends BaseSuite {
   checkArbitrary[Option[Int]]
 
   checkArbitrary[Array[Int]]
+
+  checkArbitrary[Either[String, List[String]]]
+
+  checkFailures[Either[String, List[String]]](
+    // Wrong object types return errors for both branches
+    ConfigFactory.parseString("{a = b}").root() -> ConfigReaderFailures(
+      ConvertFailure(WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.STRING)), stringConfigOrigin(1), ""),
+      ConvertFailure(WrongType(ConfigValueType.OBJECT, Set(ConfigValueType.LIST)), stringConfigOrigin(1), "")
+    )
+  )
+
+  checkWrite[Either[String, List[String]]](
+    Left[String, List[String]]("foo") -> ConfigValueFactory.fromAnyRef("foo"),
+    Right[String, List[String]](List("a", "b", "c")) -> ConfigValueFactory.fromAnyRef(List("a", "b", "c").asJava)
+  )
 }


### PR DESCRIPTION
Adding support for `Either[A,B]`. For example:

```scala
case class Foobert(
  maybeList: Either[String, List[String]]
)

val x = ConfigSource.string("maybe-list = a").loadOrThrow[Foobert]
assert(x.maybeList.isLeft)
val y = ConfigSource.string("maybe-list = [a, b, c]").loadOrThrow[Foobert]
assert(y.maybeList.isRight)
```