### PR TITLE
Add missing () in pure to prevent compiler warning.

### DIFF
--- a/modules/cats-effect/README.md
+++ b/modules/cats-effect/README.md
@@ -27,7 +27,7 @@ import cats.effect.unsafe.implicits._
 case class MyConfig(somefield: Int, anotherfield: String)
 
 def load: IO[MyConfig] = {
-  ConfigSource.file(somePath).loadF[IO, MyConfig]
+  ConfigSource.file(somePath).loadF[IO, MyConfig]()
 }
 ```
 

--- a/modules/cats-effect/docs/README.md
+++ b/modules/cats-effect/docs/README.md
@@ -35,7 +35,7 @@ import cats.effect.unsafe.implicits._
 case class MyConfig(somefield: Int, anotherfield: String)
 
 def load: IO[MyConfig] = {
-  ConfigSource.file(somePath).loadF[IO, MyConfig]
+  ConfigSource.file(somePath).loadF[IO, MyConfig]()
 }
 ```
 


### PR DESCRIPTION
Compiler warning: "Auto-application to `()` is deprecated."