### PR TITLE
Minor release fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,11 +114,6 @@ lazy val commonSettings = Seq(
   publishMavenStyle := true,
   Test / publishArtifact := false,
   publishTo := sonatypePublishToBundle.value,
-
-  // Publish only for Scala 3.1 (the oldest Scala 3 version we support), not for any other later version. See
-  // https://scala-lang.org/blog/2021/10/21/scala-3.1.0-released.html#compatibility-notice for details about binary
-  // compatibility.
-  publish / skip := forScalaVersions { case (3, x) if x > 1 => true; case _ => false }.value
   // format: on
 )
 

--- a/scripts/update_website.sh
+++ b/scripts/update_website.sh
@@ -6,7 +6,7 @@ set -e
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 WEBSITE_REPO="git@github.com:pureconfig/pureconfig.github.io.git"
-WEBSITE_DIR=$(realpath "docs/target/website")
+WEBSITE_DIR="docs/target/website"
 
 VERSION=$(sed -E 's/ThisBuild \/ version := "([^"]+)"/\1/' < version.sbt)
 COMMIT_MESSAGE="Update website for version $VERSION"


### PR DESCRIPTION
* Removes an old SBT setting that is currently preventing Scala 3 versions to be published;
* Remove a `realpath` call from the website script that is causing the script to fail on clean checkouts.