### PR TITLE
pureconfig-magnolia: Update magnolia to softwaremill.magnolia1_2 to avoid memory leak in old magnolia version

### DIFF
--- a/modules/magnolia/build.sbt
+++ b/modules/magnolia/build.sbt
@@ -5,7 +5,7 @@ name := "pureconfig-magnolia"
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(
-  "com.propensive" %% "magnolia" % "0.17.0",
+  "com.softwaremill.magnolia1_2" %% "magnolia" % "1.1.2",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
   // We're using shapeless for illTyped in tests.
   "com.chuusai" %% "shapeless" % "2.3.10" % Test

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/EnumerationConfigReaderBuilder.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/EnumerationConfigReaderBuilder.scala
@@ -3,7 +3,7 @@ package pureconfig.module.magnolia
 import scala.language.experimental.macros
 import scala.reflect.ClassTag
 
-import magnolia._
+import magnolia1._
 
 import pureconfig.ConfigReader.Result
 import pureconfig.error.CannotConvert
@@ -23,7 +23,7 @@ private[magnolia] trait EnumerationConfigReaderBuilder[A] {
 object EnumerationConfigReaderBuilder {
   type Typeclass[A] = EnumerationConfigReaderBuilder[A]
 
-  def combine[A](
+  def join[A](
       ctx: CaseClass[EnumerationConfigReaderBuilder, A]
   )(implicit ct: ClassTag[A]): EnumerationConfigReaderBuilder[A] =
     new EnumerationConfigReaderBuilder[A] {
@@ -44,7 +44,7 @@ object EnumerationConfigReaderBuilder {
         }
     }
 
-  def dispatch[A](ctx: SealedTrait[EnumerationConfigReaderBuilder, A]): EnumerationConfigReaderBuilder[A] =
+  def split[A](ctx: SealedTrait[EnumerationConfigReaderBuilder, A]): EnumerationConfigReaderBuilder[A] =
     new EnumerationConfigReaderBuilder[A] {
       def build(transformName: String => String): ConfigReader[A] =
         new ConfigReader[A] {

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/EnumerationConfigWriterBuilder.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/EnumerationConfigWriterBuilder.scala
@@ -3,7 +3,7 @@ package pureconfig.module.magnolia
 import scala.language.experimental.macros
 
 import com.typesafe.config.{ConfigValue, ConfigValueFactory}
-import magnolia._
+import magnolia1._
 
 import pureconfig.ConfigWriter
 
@@ -20,7 +20,7 @@ private[magnolia] trait EnumerationConfigWriterBuilder[A] {
 object EnumerationConfigWriterBuilder {
   type Typeclass[A] = EnumerationConfigWriterBuilder[A]
 
-  def combine[A](ctx: CaseClass[EnumerationConfigWriterBuilder, A]): EnumerationConfigWriterBuilder[A] =
+  def join[A](ctx: CaseClass[EnumerationConfigWriterBuilder, A]): EnumerationConfigWriterBuilder[A] =
     new EnumerationConfigWriterBuilder[A] {
       def build(transformName: String => String): ConfigWriter[A] =
         new ConfigWriter[A] {
@@ -28,12 +28,12 @@ object EnumerationConfigWriterBuilder {
         }
     }
 
-  def dispatch[A](ctx: SealedTrait[EnumerationConfigWriterBuilder, A]): EnumerationConfigWriterBuilder[A] =
+  def split[A](ctx: SealedTrait[EnumerationConfigWriterBuilder, A]): EnumerationConfigWriterBuilder[A] =
     new EnumerationConfigWriterBuilder[A] {
       def build(transformName: String => String): ConfigWriter[A] =
         new ConfigWriter[A] {
           def to(a: A): ConfigValue =
-            ctx.dispatch(a)(subtype => subtype.typeclass.build(transformName).to(subtype.cast(a)))
+            ctx.split(a)(subtype => subtype.typeclass.build(transformName).to(subtype.cast(a)))
         }
     }
 

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/ExportedMagnolia.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/ExportedMagnolia.scala
@@ -3,7 +3,7 @@ package pureconfig.module.magnolia
 import scala.language.higherKinds
 import scala.reflect.macros.whitebox
 
-import magnolia.Magnolia
+import magnolia1.Magnolia
 
 import pureconfig.Exported
 

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/auto/reader.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/auto/reader.scala
@@ -2,7 +2,7 @@ package pureconfig.module.magnolia.auto
 
 import scala.language.experimental.macros
 
-import magnolia._
+import magnolia1._
 
 import pureconfig.generic.{CoproductHint, ProductHint}
 import pureconfig.module.magnolia.{ExportedMagnolia, MagnoliaConfigReader}
@@ -14,11 +14,11 @@ import pureconfig.{ConfigReader, Exported}
 object reader {
   type Typeclass[A] = ConfigReader[A]
 
-  def combine[A: ProductHint](ctx: CaseClass[ConfigReader, A]): ConfigReader[A] =
-    MagnoliaConfigReader.combine(ctx)
+  def join[A: ProductHint](ctx: CaseClass[ConfigReader, A]): ConfigReader[A] =
+    MagnoliaConfigReader.join(ctx)
 
-  def dispatch[A: CoproductHint](ctx: SealedTrait[ConfigReader, A]): ConfigReader[A] =
-    MagnoliaConfigReader.dispatch(ctx)
+  def split[A: CoproductHint](ctx: SealedTrait[ConfigReader, A]): ConfigReader[A] =
+    MagnoliaConfigReader.split(ctx)
 
   implicit def exportReader[A]: Exported[ConfigReader[A]] = macro ExportedMagnolia.exportedMagnolia[ConfigReader, A]
 }

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/auto/writer.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/auto/writer.scala
@@ -3,7 +3,7 @@ package pureconfig.module.magnolia.auto
 import scala.language.experimental.macros
 import scala.reflect.ClassTag
 
-import magnolia._
+import magnolia1._
 
 import pureconfig.generic.{CoproductHint, ProductHint}
 import pureconfig.module.magnolia.{ExportedMagnolia, MagnoliaConfigWriter}
@@ -15,11 +15,11 @@ import pureconfig.{ConfigWriter, Exported}
 object writer {
   type Typeclass[A] = ConfigWriter[A]
 
-  def combine[A: ProductHint](ctx: CaseClass[ConfigWriter, A]): ConfigWriter[A] =
-    MagnoliaConfigWriter.combine(ctx)
+  def join[A: ProductHint](ctx: CaseClass[ConfigWriter, A]): ConfigWriter[A] =
+    MagnoliaConfigWriter.join(ctx)
 
-  def dispatch[A: ClassTag: CoproductHint](ctx: SealedTrait[ConfigWriter, A]): ConfigWriter[A] =
-    MagnoliaConfigWriter.dispatch(ctx)
+  def split[A: ClassTag: CoproductHint](ctx: SealedTrait[ConfigWriter, A]): ConfigWriter[A] =
+    MagnoliaConfigWriter.split(ctx)
 
   implicit def exportWriter[A]: Exported[ConfigWriter[A]] = macro ExportedMagnolia.exportedMagnolia[ConfigWriter, A]
 }

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/semiauto/reader.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/semiauto/reader.scala
@@ -2,7 +2,7 @@ package pureconfig.module.magnolia.semiauto
 
 import scala.language.experimental.macros
 
-import magnolia._
+import magnolia1.{CaseClass, Magnolia, SealedTrait}
 
 import pureconfig.generic.{CoproductHint, ProductHint}
 import pureconfig.module.magnolia.{EnumerationConfigReaderBuilder, MagnoliaConfigReader}
@@ -14,11 +14,11 @@ import pureconfig.{ConfigFieldMapping, ConfigReader, KebabCase, PascalCase}
 object reader {
   type Typeclass[A] = ConfigReader[A]
 
-  def combine[A: ProductHint](ctx: CaseClass[ConfigReader, A]): ConfigReader[A] =
-    MagnoliaConfigReader.combine(ctx)
+  def join[A: ProductHint](ctx: CaseClass[ConfigReader, A]): ConfigReader[A] =
+    MagnoliaConfigReader.join(ctx)
 
-  def dispatch[A: CoproductHint](ctx: SealedTrait[ConfigReader, A]): ConfigReader[A] =
-    MagnoliaConfigReader.dispatch(ctx)
+  def split[A: CoproductHint](ctx: SealedTrait[ConfigReader, A]): ConfigReader[A] =
+    MagnoliaConfigReader.split(ctx)
 
   def deriveReader[A]: ConfigReader[A] = macro Magnolia.gen[A]
 

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/semiauto/writer.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/semiauto/writer.scala
@@ -3,7 +3,7 @@ package pureconfig.module.magnolia.semiauto
 import scala.language.experimental.macros
 import scala.reflect.ClassTag
 
-import magnolia._
+import magnolia1._
 
 import pureconfig.generic.{CoproductHint, ProductHint}
 import pureconfig.module.magnolia.{EnumerationConfigWriterBuilder, MagnoliaConfigWriter}
@@ -15,11 +15,11 @@ import pureconfig.{ConfigFieldMapping, ConfigWriter, KebabCase, PascalCase}
 object writer {
   type Typeclass[A] = ConfigWriter[A]
 
-  def combine[A: ProductHint](ctx: CaseClass[ConfigWriter, A]): ConfigWriter[A] =
-    MagnoliaConfigWriter.combine(ctx)
+  def join[A: ProductHint](ctx: CaseClass[ConfigWriter, A]): ConfigWriter[A] =
+    MagnoliaConfigWriter.join(ctx)
 
-  def dispatch[A: ClassTag: CoproductHint](ctx: SealedTrait[ConfigWriter, A]): ConfigWriter[A] =
-    MagnoliaConfigWriter.dispatch(ctx)
+  def split[A: ClassTag: CoproductHint](ctx: SealedTrait[ConfigWriter, A]): ConfigWriter[A] =
+    MagnoliaConfigWriter.split(ctx)
 
   def deriveWriter[A]: ConfigWriter[A] = macro Magnolia.gen[A]
 


### PR DESCRIPTION
Details: https://github.com/softwaremill/magnolia/issues/216#issuecomment-1372933573

Projects using pureconfig-magnolia cause IntelliJ compile server to run out of memory, but the leak seems to happen on old magnolia versions only.