### PR TITLE
Update magnolia to 1.1.3

### DIFF
--- a/modules/magnolia/build.sbt
+++ b/modules/magnolia/build.sbt
@@ -5,7 +5,7 @@ name := "pureconfig-magnolia"
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(
-  "com.softwaremill.magnolia1_2" %% "magnolia" % "1.1.2",
+  "com.softwaremill.magnolia1_2" %% "magnolia" % "1.1.3",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
   // We're using shapeless for illTyped in tests.
   "com.chuusai" %% "shapeless" % "2.3.10" % Test


### PR DESCRIPTION
Update to magnolia 1.1.3 which fixes compile-time memory leaks in large projects https://github.com/softwaremill/magnolia/releases/tag/scala2-v1.1.3