### PR TITLE
Adds more config readers and writers for ip4s models

### DIFF
--- a/modules/ip4s/README.md
+++ b/modules/ip4s/README.md
@@ -1,8 +1,17 @@
 
 # Ip4s module for PureConfig
 
-Adds support for [Ip4s](https://github.com/Comcast/ip4s)'s Hostname and Port class to PureConfig. PRs adding support
-for other classes are welcome :)
+Adds support for [Ip4s](https://github.com/Comcast/ip4s)'s models to PureConfig.
+Currently the following models are supported:
+  - `Host`:
+    - `Hostname`
+    - `IpAddress`:
+      - `Ipv4Address`
+      - `Ipv6Address`
+    - `IDN`
+  - `Port`
+
+PRs adding support for other classes are welcome :)
 
 ## Add pureconfig-ip4s to your project
 
@@ -14,15 +23,15 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-ip4s" % "0.17.2"
 
 ## Example
 
-To load an `Hostname` or a `Port` into a configuration, create a class to hold it:
+To load an `Host` or a `Port` into a configuration, create a class to hold it:
 
 ```scala
-import com.comcast.ip4s.{Hostname, Port}
+import com.comcast.ip4s._
 import pureconfig._
 import pureconfig.generic.auto._
 import pureconfig.module.ip4s._
 
-case class MyConfig(hostname: Hostname, port: Port)
+case class MyConfig(host: Host, port: Port)
 ```
 
 We can read a `MyConfig` with the following code:
@@ -30,9 +39,12 @@ We can read a `MyConfig` with the following code:
 ```scala
 val source = ConfigSource.string(
   """{ 
-    |hostname: "0.0.0.0" 
+    |host: "0.0.0.0" 
     |port: 8080 
     |}""".stripMargin)
     
 source.load[MyConfig]
 ```
+
+Note that in the example above, `host` will be loaded as `Ipv4Address` type,
+whereas `host: "pureconfig.github.io"` will become `Hostname` instead.

--- a/modules/ip4s/README.md
+++ b/modules/ip4s/README.md
@@ -23,7 +23,7 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-ip4s" % "0.17.2"
 
 ## Example
 
-To load an `Host` or a `Port` into a configuration, create a class to hold it:
+To load a `Host` or a `Port` into a configuration, create a class to hold it:
 
 ```scala
 import com.comcast.ip4s._

--- a/modules/ip4s/build.sbt
+++ b/modules/ip4s/build.sbt
@@ -4,7 +4,12 @@ name := "pureconfig-ip4s"
 
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
-libraryDependencies ++= Seq("com.comcast" %% "ip4s-core" % "3.2.0")
+val ip4sVersion = "3.2.0"
+
+libraryDependencies ++= Seq(
+  "com.comcast" %% "ip4s-core" % ip4sVersion,
+  "com.comcast" %% "ip4s-test-kit" % ip4sVersion % Test
+)
 
 developers := List(
   Developer("geirolz", "David Geirola", "david.geirolz@gmail.com", url("https://github.com/geirolz"))

--- a/modules/ip4s/docs/README.md
+++ b/modules/ip4s/docs/README.md
@@ -23,7 +23,7 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-ip4s" % "@VERSION@
 
 ## Example
 
-To load an `Host` or a `Port` into a configuration, create a class to hold it:
+To load a `Host` or a `Port` into a configuration, create a class to hold it:
 
 ```scala mdoc:silent
 import com.comcast.ip4s._

--- a/modules/ip4s/docs/README.md
+++ b/modules/ip4s/docs/README.md
@@ -1,8 +1,17 @@
 
 # Ip4s module for PureConfig
 
-Adds support for [Ip4s](https://github.com/Comcast/ip4s)'s Hostname and Port class to PureConfig. PRs adding support
-for other classes are welcome :)
+Adds support for [Ip4s](https://github.com/Comcast/ip4s)'s models to PureConfig.
+Currently the following models are supported:
+  - `Host`:
+    - `Hostname`
+    - `IpAddress`:
+      - `Ipv4Address`
+      - `Ipv6Address`
+    - `IDN`
+  - `Port`
+
+PRs adding support for other classes are welcome :)
 
 ## Add pureconfig-ip4s to your project
 
@@ -14,15 +23,15 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-ip4s" % "@VERSION@
 
 ## Example
 
-To load an `Hostname` or a `Port` into a configuration, create a class to hold it:
+To load an `Host` or a `Port` into a configuration, create a class to hold it:
 
 ```scala mdoc:silent
-import com.comcast.ip4s.{Hostname, Port}
+import com.comcast.ip4s._
 import pureconfig._
 import pureconfig.generic.auto._
 import pureconfig.module.ip4s._
 
-case class MyConfig(hostname: Hostname, port: Port)
+case class MyConfig(host: Host, port: Port)
 ```
 
 We can read a `MyConfig` with the following code:
@@ -30,9 +39,12 @@ We can read a `MyConfig` with the following code:
 ```scala mdoc:silent
 val source = ConfigSource.string(
   """{ 
-    |hostname: "0.0.0.0" 
+    |host: "0.0.0.0" 
     |port: 8080 
     |}""".stripMargin)
     
 source.load[MyConfig]
 ```
+
+Note that in the example above, `host` will be loaded as `Ipv4Address` type,
+whereas `host: "pureconfig.github.io"` will become `Hostname` instead.

--- a/modules/ip4s/src/main/scala/pureconfig/module/ip4s/package.scala
+++ b/modules/ip4s/src/main/scala/pureconfig/module/ip4s/package.scala
@@ -1,31 +1,58 @@
 package pureconfig.module
 
-import com.comcast.ip4s.{Hostname, Port}
+import com.comcast.ip4s._
 
 import pureconfig.error.CannotConvert
 import pureconfig.{ConfigReader, ConfigWriter}
 
 package object ip4s {
 
+  private def mkConfigReader[From, To](f: From => Option[To])(
+      cname: String,
+      uname: String
+  )(implicit From: ConfigReader[From]): ConfigReader[To] = From.emap { from =>
+    f(from).toRight(CannotConvert(from.toString, cname, s"Invalid $uname"))
+  }
+
+  implicit val hostWriter: ConfigWriter[Host] =
+    ConfigWriter[String].contramap(_.toString)
+
+  implicit val hostReader: ConfigReader[Host] =
+    mkConfigReader[String, Host](Host.fromString)("Host", "host")
+
+  implicit val ipAddressWriter: ConfigWriter[IpAddress] =
+    ConfigWriter[String].contramap(_.toString)
+
+  implicit val ipAddressReader: ConfigReader[IpAddress] =
+    mkConfigReader[String, IpAddress](IpAddress.fromString)("IpAddress", "IP address")
+
+  implicit val ipv4AddressWriter: ConfigWriter[Ipv4Address] =
+    ConfigWriter[String].contramap(_.toString)
+
+  implicit val ipv4AddressReader: ConfigReader[Ipv4Address] =
+    mkConfigReader[String, Ipv4Address](Ipv4Address.fromString)("Ipv4Address", "IPv4 address")
+
+  implicit val ipv6AddressWriter: ConfigWriter[Ipv6Address] =
+    ConfigWriter[String].contramap(_.toString)
+
+  implicit val ipv6AddressReader: ConfigReader[Ipv6Address] =
+    mkConfigReader[String, Ipv6Address](Ipv6Address.fromString)("Ipv6Address", "IPv6 address")
+
   implicit val hostnameWriter: ConfigWriter[Hostname] =
     ConfigWriter[String].contramap(_.toString)
 
   implicit val hostnameReader: ConfigReader[Hostname] =
-    ConfigReader.fromString(str =>
-      Hostname.fromString(str) match {
-        case Some(hostname) => Right(hostname)
-        case None => Left(CannotConvert(str, "Hostname", "Invalid hostname"))
-      }
-    )
+    mkConfigReader[String, Hostname](Hostname.fromString)("Hostname", "hostname")
+
+  implicit val idnWriter: ConfigWriter[IDN] =
+    ConfigWriter[String].contramap(_.toString)
+
+  implicit val idnReader: ConfigReader[IDN] =
+    mkConfigReader[String, IDN](IDN.fromString)("IDN", "IDN")
 
   implicit val portWriter: ConfigWriter[Port] =
     ConfigWriter[Int].contramap(_.value)
 
   implicit val portReader: ConfigReader[Port] =
-    ConfigReader[Int].emap(str =>
-      Port.fromInt(str) match {
-        case Some(port) => Right(port)
-        case None => Left(CannotConvert(str.toString, "Port", "Invalid port"))
-      }
-    )
+    mkConfigReader[Int, Port](Port.fromInt)("Port", "port")
 }

--- a/modules/ip4s/src/main/scala/pureconfig/module/ip4s/package.scala
+++ b/modules/ip4s/src/main/scala/pureconfig/module/ip4s/package.scala
@@ -1,5 +1,7 @@
 package pureconfig.module
 
+import scala.reflect.ClassTag
+
 import com.comcast.ip4s._
 
 import pureconfig.error.CannotConvert
@@ -7,52 +9,55 @@ import pureconfig.{ConfigReader, ConfigWriter}
 
 package object ip4s {
 
-  private def mkConfigReader[From, To](f: From => Option[To])(
-      cname: String,
-      uname: String
-  )(implicit From: ConfigReader[From]): ConfigReader[To] = From.emap { from =>
-    f(from).toRight(CannotConvert(from.toString, cname, s"Invalid $uname"))
-  }
+  private def mkConfigReader[From, To](
+      f: From => Option[To]
+  )(implicit From: ConfigReader[From], ToCTag: ClassTag[To]): ConfigReader[To] =
+    From.emap { from =>
+      f(from).toRight {
+        val cname = ToCTag.runtimeClass.getSimpleName()
+        CannotConvert(from.toString, cname, s"Invalid $cname")
+      }
+    }
 
   implicit val hostWriter: ConfigWriter[Host] =
     ConfigWriter[String].contramap(_.toString)
 
   implicit val hostReader: ConfigReader[Host] =
-    mkConfigReader[String, Host](Host.fromString)("Host", "host")
+    mkConfigReader[String, Host](Host.fromString)
 
   implicit val ipAddressWriter: ConfigWriter[IpAddress] =
     ConfigWriter[String].contramap(_.toString)
 
   implicit val ipAddressReader: ConfigReader[IpAddress] =
-    mkConfigReader[String, IpAddress](IpAddress.fromString)("IpAddress", "IP address")
+    mkConfigReader[String, IpAddress](IpAddress.fromString)
 
   implicit val ipv4AddressWriter: ConfigWriter[Ipv4Address] =
     ConfigWriter[String].contramap(_.toString)
 
   implicit val ipv4AddressReader: ConfigReader[Ipv4Address] =
-    mkConfigReader[String, Ipv4Address](Ipv4Address.fromString)("Ipv4Address", "IPv4 address")
+    mkConfigReader[String, Ipv4Address](Ipv4Address.fromString)
 
   implicit val ipv6AddressWriter: ConfigWriter[Ipv6Address] =
     ConfigWriter[String].contramap(_.toString)
 
   implicit val ipv6AddressReader: ConfigReader[Ipv6Address] =
-    mkConfigReader[String, Ipv6Address](Ipv6Address.fromString)("Ipv6Address", "IPv6 address")
+    mkConfigReader[String, Ipv6Address](Ipv6Address.fromString)
 
   implicit val hostnameWriter: ConfigWriter[Hostname] =
     ConfigWriter[String].contramap(_.toString)
 
   implicit val hostnameReader: ConfigReader[Hostname] =
-    mkConfigReader[String, Hostname](Hostname.fromString)("Hostname", "hostname")
+    mkConfigReader[String, Hostname](Hostname.fromString)
 
   implicit val idnWriter: ConfigWriter[IDN] =
     ConfigWriter[String].contramap(_.toString)
 
   implicit val idnReader: ConfigReader[IDN] =
-    mkConfigReader[String, IDN](IDN.fromString)("IDN", "IDN")
+    mkConfigReader[String, IDN](IDN.fromString)
 
   implicit val portWriter: ConfigWriter[Port] =
     ConfigWriter[Int].contramap(_.value)
 
   implicit val portReader: ConfigReader[Port] =
-    mkConfigReader[Int, Port](Port.fromInt)("Port", "port")
+    mkConfigReader[Int, Port](Port.fromInt)
 }


### PR DESCRIPTION
This PR fills in the whole hierarchy of `Host` with all its descendants:

- `Host` (_added_)
    - `Hostname` (existing)
    - `IpAddress` (_added_)
        - `Ipv4Address` (_added_)
        - `Ipv6Address` (_added_)
    - `IDN` (_added_)
