### PR TITLE
Add support for some of the components of http4s's Uri class

### DIFF
--- a/modules/http4s/README.md
+++ b/modules/http4s/README.md
@@ -1,8 +1,16 @@
 
 # Http4s module for PureConfig
 
-Adds support for [Http4s](http://http4s.org/)'s Uri class to PureConfig. PRs adding support
+Adds support for [Http4s](http://http4s.org/)'s `Uri` class to PureConfig. PRs adding support
 for other classes are welcome :)
+
+Support is also provided for some of the components of a `Uri`:
+
+* `Uri.Scheme`
+* `Uri.Path`
+* `Uri.Host`
+    * `Uri.Ipv4Address`
+    * `Uri.Ipv6Address`
 
 ## Add pureconfig-http4s to your project
 
@@ -14,7 +22,7 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-http4s" % "0.17.2"
 
 ## Example
 
-To load an `Uri` into a configuration, create a class to hold it:
+To load a `Uri` or one of `Uri`'s components into a configuration, create a class to hold it:
 
 ```scala
 import org.http4s.Uri
@@ -23,15 +31,29 @@ import pureconfig._
 import pureconfig.generic.auto._
 import pureconfig.module.http4s._
 
-case class MyConfig(uri: Uri)
+case class MyConfig(
+    uri: Uri,
+    scheme: Uri.Scheme,
+    host: Uri.Host,
+    path: Uri.Path,
+    ipAddress1: Uri.Ipv4Address,
+    ipAddress2: Uri.Ipv6Address
+)
 ```
 
 We can read a `MyConfig` with the following code:
 
 ```scala
-val conf = parseString("""{ uri: "http://http4s.org/" }""")
-// conf: com.typesafe.config.Config = Config(SimpleConfigObject({"uri":"http://http4s.org/"}))
+val conf = parseString("""{
+    uri: "http://http4s.org/",
+    scheme: "https",
+    host: "www.foo.com",
+    path: "relative/path/to/resource.txt",
+    ip-address-1: "192.168.1.1",
+    ip-address-2: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
+}""")
+// conf: com.typesafe.config.Config = Config(SimpleConfigObject({"host":"www.foo.com","ip-address-1":"192.168.1.1","ip-address-2":"2001:db8:85a3:8d3:1319:8a2e:370:7344","path":"relative/path/to/resource.txt","scheme":"https","uri":"http://http4s.org/"}))
 
 ConfigSource.fromConfig(conf).load[MyConfig]
-// res0: ConfigReader.Result[MyConfig] = Right(MyConfig(http://http4s.org/))
+// res0: ConfigReader.Result[MyConfig] = Right(MyConfig(http://http4s.org/,Scheme(https),www.foo.com,relative/path/to/resource.txt,Ipv4Address(192.168.1.1),[2001:db8:85a3:8d3:1319:8a2e:370:7344]))
 ```

--- a/modules/http4s/docs/README.md
+++ b/modules/http4s/docs/README.md
@@ -1,8 +1,16 @@
 
 # Http4s module for PureConfig
 
-Adds support for [Http4s](http://http4s.org/)'s Uri class to PureConfig. PRs adding support
+Adds support for [Http4s](http://http4s.org/)'s `Uri` class to PureConfig. PRs adding support
 for other classes are welcome :)
+
+Support is also provided for some of the components of a `Uri`:
+
+* `Uri.Scheme`
+* `Uri.Path`
+* `Uri.Host`
+    * `Uri.Ipv4Address`
+    * `Uri.Ipv6Address`
 
 ## Add pureconfig-http4s to your project
 
@@ -14,7 +22,7 @@ libraryDependencies += "com.github.pureconfig" %% "pureconfig-http4s" % "@VERSIO
 
 ## Example
 
-To load an `Uri` into a configuration, create a class to hold it:
+To load a `Uri` or one of `Uri`'s components into a configuration, create a class to hold it:
 
 ```scala mdoc:silent
 import org.http4s.Uri
@@ -23,13 +31,27 @@ import pureconfig._
 import pureconfig.generic.auto._
 import pureconfig.module.http4s._
 
-case class MyConfig(uri: Uri)
+case class MyConfig(
+    uri: Uri,
+    scheme: Uri.Scheme,
+    host: Uri.Host,
+    path: Uri.Path,
+    ipAddress1: Uri.Ipv4Address,
+    ipAddress2: Uri.Ipv6Address
+)
 ```
 
 We can read a `MyConfig` with the following code:
 
 ```scala mdoc:to-string
-val conf = parseString("""{ uri: "http://http4s.org/" }""")
+val conf = parseString("""{
+    uri: "http://http4s.org/",
+    scheme: "https",
+    host: "www.foo.com",
+    path: "relative/path/to/resource.txt",
+    ip-address-1: "192.168.1.1",
+    ip-address-2: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
+}""")
 
 ConfigSource.fromConfig(conf).load[MyConfig]
 ```

--- a/modules/http4s/src/main/scala/pureconfig/module/http4s/package.scala
+++ b/modules/http4s/src/main/scala/pureconfig/module/http4s/package.scala
@@ -1,16 +1,55 @@
 package pureconfig.module
 
-import org.http4s.Uri
+import scala.reflect.ClassTag
+
+import org.http4s.{ParseResult, Uri}
 
 import pureconfig.error.CannotConvert
 import pureconfig.{ConfigReader, ConfigWriter}
 
 package object http4s {
+  private def mkConfigReader[A](f: String => ParseResult[A])(implicit ct: ClassTag[A]): ConfigReader[A] =
+    ConfigReader.fromString { str =>
+      val className = ct.runtimeClass.getSimpleName()
+      f(str).fold(
+        err => Left(CannotConvert(str, className, err.sanitized)),
+        value => Right(value)
+      )
+    }
 
   implicit val uriReader: ConfigReader[Uri] =
-    ConfigReader.fromString(str =>
-      Uri.fromString(str).fold(err => Left(CannotConvert(str, "Uri", err.sanitized)), uri => Right(uri))
-    )
+    mkConfigReader[Uri](Uri.fromString)
 
-  implicit val uriWriter: ConfigWriter[Uri] = ConfigWriter[String].contramap(_.renderString)
+  implicit val uriWriter: ConfigWriter[Uri] =
+    ConfigWriter[String].contramap(_.renderString)
+
+  implicit val uriSchemeReader: ConfigReader[Uri.Scheme] =
+    mkConfigReader[Uri.Scheme](Uri.Scheme.fromString)
+
+  implicit val uriSchemeWriter: ConfigWriter[Uri.Scheme] =
+    ConfigWriter[String].contramap(_.value)
+
+  implicit val uriPathReader: ConfigReader[Uri.Path] =
+    ConfigReader.stringConfigReader.map(Uri.Path.unsafeFromString) // .fromString is deprecated
+
+  implicit val uriPathWriter: ConfigWriter[Uri.Path] =
+    ConfigWriter[String].contramap(_.renderString)
+
+  implicit val uriHostReader: ConfigReader[Uri.Host] =
+    mkConfigReader[Uri.Host](Uri.Host.fromString)
+
+  implicit val uriHostWriter: ConfigWriter[Uri.Host] =
+    ConfigWriter[String].contramap(_.renderString)
+
+  implicit val uriIpv4AddressReader: ConfigReader[Uri.Ipv4Address] =
+    mkConfigReader[Uri.Ipv4Address](Uri.Ipv4Address.fromString)
+
+  implicit val uriIpv4AddressWriter: ConfigWriter[Uri.Ipv4Address] =
+    ConfigWriter[String].contramap(_.renderString)
+
+  implicit val uriIpv6AddressReader: ConfigReader[Uri.Ipv6Address] =
+    mkConfigReader[Uri.Ipv6Address](Uri.Ipv6Address.fromString)
+
+  implicit val uriIpv6AddressWriter: ConfigWriter[Uri.Ipv6Address] =
+    ConfigWriter[String].contramap(_.value) // Uses .value so that we can round-trip as Ipv6Address
 }

--- a/modules/http4s/src/test/scala/pureconfig/module/http4s/Http4sTest.scala
+++ b/modules/http4s/src/test/scala/pureconfig/module/http4s/Http4sTest.scala
@@ -20,6 +20,64 @@ class Http4sTest extends BaseSuite {
     )
   }
 
+  "reading a uri scheme" should "parse the scheme" in {
+    configString("https").to[Uri.Scheme].value shouldEqual Uri.Scheme.https
+    configString("http").to[Uri.Scheme].value shouldEqual Uri.Scheme.http
+    configString("mongodb").to[Uri.Scheme].value shouldEqual Uri.Scheme.unsafeFromString("mongodb")
+  }
+
+  "reading an invalid uri scheme" should "get a CannotConvert error" in {
+    configString("\\\\").to[Uri.Scheme].left.value shouldEqual ConfigReaderFailures(
+      ConvertFailure(CannotConvert("\\", "Scheme", "Invalid scheme"), stringConfigOrigin(1), "")
+    )
+  }
+
+  "reading a uri path" should "parse the path" in {
+    configString("/path").to[Uri.Path].value shouldEqual Uri.Path.unsafeFromString("/path")
+    configString("/path/with/lots/of/segments").to[Uri.Path].value shouldEqual Uri.Path.unsafeFromString(
+      "/path/with/lots/of/segments"
+    )
+    configString("relative/path").to[Uri.Path].value shouldEqual Uri.Path.unsafeFromString("relative/path")
+  }
+
+  "reading a uri host" should "parse the host" in {
+    configString("localhost").to[Uri.Host].value shouldEqual Uri.Host.unsafeFromString("localhost")
+    configString("192.168.1.1").to[Uri.Host].value shouldEqual Uri.Host.unsafeFromString("192.168.1.1")
+    configString("www.foo.com").to[Uri.Host].value shouldEqual Uri.Host.unsafeFromString("www.foo.com")
+    configString("[2001:db8:85a3:8d3:1319:8a2e:370:7344]").to[Uri.Host].value shouldEqual Uri.Host.unsafeFromString(
+      "[2001:db8:85a3:8d3:1319:8a2e:370:7344]"
+    )
+  }
+
+  "reading an invalid uri host" should "get a CannotConvert error" in {
+    configString(":/?#[]@").to[Uri.Host].left.value shouldEqual ConfigReaderFailures(
+      ConvertFailure(CannotConvert(":/?#[]@", "Host", "Invalid host"), stringConfigOrigin(1), "")
+    )
+  }
+
+  "reading an ipv4 address" should "parse the address" in {
+    configString("192.168.1.1").to[Uri.Ipv4Address].value shouldEqual Uri.Ipv4Address.unsafeFromString("192.168.1.1")
+  }
+
+  "reading an invalid ipv4 address" should "get a CannotConvert error" in {
+    configString(":/?#[]@").to[Uri.Ipv4Address].left.value shouldEqual ConfigReaderFailures(
+      ConvertFailure(CannotConvert(":/?#[]@", "Ipv4Address", "Invalid IPv4 Address"), stringConfigOrigin(1), "")
+    )
+  }
+
+  "reading an ipv6 address" should "parse the address" in {
+    configString("2001:db8:85a3:8d3:1319:8a2e:370:7344").to[Uri.Ipv6Address].value shouldEqual Uri.Ipv6Address
+      .unsafeFromString(
+        "2001:db8:85a3:8d3:1319:8a2e:370:7344"
+      )
+  }
+
+  "reading an invalid ipv6 address" should "get a CannotConvert error" in {
+    configString(":/?#[]@").to[Uri.Ipv6Address].left.value shouldEqual ConfigReaderFailures(
+      ConvertFailure(CannotConvert(":/?#[]@", "Ipv6Address", "Invalid IPv6 address"), stringConfigOrigin(1), "")
+    )
+  }
+
   "Uri ConfigReader and ConfigWriter" should "be able to round-trip reading/writing of Uri" in {
     val expectedComplexUri =
       Uri.unsafeFromString(
@@ -28,5 +86,35 @@ class Http4sTest extends BaseSuite {
 
     val configValue = ConfigWriter[Uri].to(expectedComplexUri)
     configValue.to[Uri].value shouldEqual expectedComplexUri
+  }
+
+  "Uri.Scheme ConfigReader and ConfigWriter" should "be able to round-trip reading/writing of Uri.Scheme" in {
+    val expectedScheme = Uri.Scheme.unsafeFromString("mongodb")
+    val configValue = ConfigWriter[Uri.Scheme].to(expectedScheme)
+    configValue.to[Uri.Scheme].value shouldEqual expectedScheme
+  }
+
+  "Uri.Path ConfigReader and ConfigWriter" should "be able to round-trip reading/writing of Uri.Path" in {
+    val expectedPath = Uri.Path.unsafeFromString("relative/path/to/resource.txt")
+    val configValue = ConfigWriter[Uri.Path].to(expectedPath)
+    configValue.to[Uri.Path].value shouldEqual expectedPath
+  }
+
+  "Uri.Host ConfigReader and ConfigWriter" should "be able to round-trip reading/writing of Uri.Host" in {
+    val expectedHost = Uri.Host.unsafeFromString("[2001:db8:85a3:8d3:1319:8a2e:370:7344]")
+    val configValue = ConfigWriter[Uri.Host].to(expectedHost)
+    configValue.to[Uri.Host].value shouldEqual expectedHost
+  }
+
+  "Uri.Ipv4Address ConfigReader and ConfigWriter" should "be able to round-trip reading/writing of Uri.Ipv4Address" in {
+    val expectedHost = Uri.Ipv4Address.unsafeFromString("192.168.1.1")
+    val configValue = ConfigWriter[Uri.Ipv4Address].to(expectedHost)
+    configValue.to[Uri.Ipv4Address].value shouldEqual expectedHost
+  }
+
+  "Uri.Ipv6Address ConfigReader and ConfigWriter" should "be able to round-trip reading/writing of Uri.Ipv6Address" in {
+    val expectedHost = Uri.Ipv6Address.unsafeFromString("2001:db8:85a3:8d3:1319:8a2e:370:7344")
+    val configValue = ConfigWriter[Uri.Ipv6Address].to(expectedHost)
+    configValue.to[Uri.Ipv6Address].value shouldEqual expectedHost
   }
 }


### PR DESCRIPTION
This PR adds support for some of the components of a http4s `Uri` to the `pureconfig-http4s` module.

* `Uri.Scheme`
* `Uri.Path`
* `Uri.Host` and its subtypes `Uri.Ipv4Address` and `Uri.Ipv6Address`