### PR TITLE
Fix project name of http4s022 module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ def genericModule(proj: Project) = proj
   .dependsOn(core)
   .dependsOn(testkit % "test")
   .settings(commonSettings)
+  .settings(name := s"pureconfig-${baseDirectory.value.getName}")
 
 def module(proj: Project) = genericModule(proj)
   .enablePlugins(ModuleMdocPlugin)

--- a/modules/akka-http/build.sbt
+++ b/modules/akka-http/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-akka-http"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(

--- a/modules/akka/build.sbt
+++ b/modules/akka/build.sbt
@@ -1,6 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-akka"
 
 crossScalaVersions := Seq(scala212, scala213)
 

--- a/modules/akka/build.sbt
+++ b/modules/akka/build.sbt
@@ -1,6 +1,5 @@
 import Dependencies.Version._
 
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("com.typesafe.akka" %% "akka-actor" % "2.6.20")

--- a/modules/cats-effect/build.sbt
+++ b/modules/cats-effect/build.sbt
@@ -1,8 +1,6 @@
 import Dependencies.Version._
 import Utilities._
 
-name := "pureconfig-cats-effect"
-
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq(

--- a/modules/cats-effect2/build.sbt
+++ b/modules/cats-effect2/build.sbt
@@ -1,8 +1,6 @@
 import Dependencies.Version._
 import Utilities._
 
-name := "pureconfig-cats-effect2"
-
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq(

--- a/modules/cats/build.sbt
+++ b/modules/cats/build.sbt
@@ -1,8 +1,6 @@
 import Dependencies.Version._
 import Utilities._
 
-name := "pureconfig-cats"
-
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq(

--- a/modules/circe/build.sbt
+++ b/modules/circe/build.sbt
@@ -1,8 +1,6 @@
 import Dependencies.Version._
 import Utilities._
 
-name := "pureconfig-circe"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(

--- a/modules/cron4s/build.sbt
+++ b/modules/cron4s/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-cron4s"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies += "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.6.1"

--- a/modules/enum/build.sbt
+++ b/modules/enum/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-enum"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("org.julienrf" %% "enum" % "3.1")

--- a/modules/enumeratum/build.sbt
+++ b/modules/enumeratum/build.sbt
@@ -1,8 +1,6 @@
 import Dependencies.Version._
 import Utilities.forScalaVersions
 
-name := "pureconfig-enumeratum"
-
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq("com.beachape" %% "enumeratum" % "1.7.2")

--- a/modules/fs2/build.sbt
+++ b/modules/fs2/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-fs2"
-
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq(

--- a/modules/generic-base/build.sbt
+++ b/modules/generic-base/build.sbt
@@ -1,5 +1,3 @@
 import Dependencies.Version._
 
-name := "pureconfig-generic-base"
-
 crossScalaVersions := Seq(scala212, scala213)

--- a/modules/generic/build.sbt
+++ b/modules/generic/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-generic"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(

--- a/modules/hadoop/build.sbt
+++ b/modules/hadoop/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-hadoop"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("org.apache.hadoop" % "hadoop-common" % "3.3.5" % "provided")

--- a/modules/http4s/build.sbt
+++ b/modules/http4s/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-http4s"
-
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq("org.http4s" %% "http4s-core" % "0.23.18")

--- a/modules/http4s022/build.sbt
+++ b/modules/http4s022/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies.Version._
 
-name := "pureconfig-http4s"
+name := "pureconfig-http4s022"
 
 crossScalaVersions := Seq(scala212, scala213, scala3)
 

--- a/modules/http4s022/build.sbt
+++ b/modules/http4s022/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-http4s022"
-
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq("org.http4s" %% "http4s-core" % "0.22.15")

--- a/modules/ip4s/build.sbt
+++ b/modules/ip4s/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-ip4s"
-
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
 val ip4sVersion = "3.3.0"

--- a/modules/javax/build.sbt
+++ b/modules/javax/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-javax"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 developers := List(Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr")))

--- a/modules/joda/build.sbt
+++ b/modules/joda/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-joda"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("joda-time" % "joda-time" % "2.12.5", "org.joda" % "joda-convert" % "2.2.3")

--- a/modules/magnolia/build.sbt
+++ b/modules/magnolia/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-magnolia"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(

--- a/modules/scala-xml/build.sbt
+++ b/modules/scala-xml/build.sbt
@@ -1,8 +1,6 @@
 import Dependencies.Version._
 import Utilities._
 
-name := "pureconfig-scala-xml"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 // Scala 2.12 depends on an old version of scala-xml

--- a/modules/scalaz/build.sbt
+++ b/modules/scalaz/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-scalaz"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(

--- a/modules/spark/build.sbt
+++ b/modules/spark/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-spark"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("org.apache.spark" %% "spark-sql" % "3.4.0" % "provided")

--- a/modules/squants/build.sbt
+++ b/modules/squants/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-squants"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("org.typelevel" %% "squants" % "1.8.3")

--- a/modules/sttp/build.sbt
+++ b/modules/sttp/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-sttp"
-
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq(

--- a/modules/yaml/build.sbt
+++ b/modules/yaml/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-yaml"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq("org.yaml" % "snakeyaml" % "2.0")

--- a/modules/zio-config/build.sbt
+++ b/modules/zio-config/build.sbt
@@ -1,7 +1,5 @@
 import Dependencies.Version._
 
-name := "pureconfig-zio-config"
-
 crossScalaVersions := Seq(scala212, scala213)
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
When this module was created as a copy of http4s, the project name should have been updated as well. Having two subprojects with the same name caused published artifacts to override one another, leading to issues like #1489.

Running `sbt name` on master and on this branch and computing the diff shows that the only affected module was http4s022, as expected:

```diff
26c26
< [info] 	pureconfig-http4s
---
> [info] 	pureconfig-http4s022
```