### PR TITLE
Small improvement to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ PureConfig is a Scala library for loading configuration files. It reads [Typesaf
 
 <br clear="right"> <!-- Turn off the wrapping for the logo image. -->
 
+
 ## Why
 
 Loading configurations has always been a tedious and error-prone procedure. A common way to do it

--- a/bundle/docs/README.md
+++ b/bundle/docs/README.md
@@ -12,6 +12,7 @@ PureConfig is a Scala library for loading configuration files. It reads [Typesaf
 
 <br clear="right"> <!-- Turn off the wrapping for the logo image. -->
 
+
 ## Why
 
 Loading configurations has always been a tedious and error-prone procedure. A common way to do it


### PR DESCRIPTION
Typically, there are 2 empty lines before `##`.
Also, after having this merged, I won't have to bother maintainers to approve each run of CI in PRs. E.g. here https://github.com/pureconfig/pureconfig/pull/1486#issuecomment-1575846035