### PR TITLE
Remove sass gem from CI setup steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,12 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
 
       - name: Install dependencies
         run: >
           sudo apt install libxslt-dev &&
-          gem install sass jekyll:4.3.1 html-proofer:5.0.3
+          gem install jekyll:4.3.2 html-proofer:5.0.7
 
       - name: Build website
         run: sbt makeMicrosite
@@ -114,10 +114,10 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
 
       - name: Install dependencies
-        run: gem install sass jekyll:4.3.1
+        run: gem install jekyll:4.3.2
 
       - name: Build and compare website
         id: diff_website


### PR DESCRIPTION
CI jobs are all failing because "sass from sass-embedded conflicts with installed executable from sass", e.g. [this job](https://github.com/pureconfig/pureconfig/actions/runs/5217381536/jobs/9446955287?pr=1514). It seems [Jekyll now comes with sass bundled](https://jekyllrb.com/docs/configuration/sass/), so we don't need it anymore. 