### PR TITLE
Clean up dependency definitions

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,4 +4,4 @@ name := "pureconfig-core"
 
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
-libraryDependencies += Dependencies.typesafeConfig
+libraryDependencies += "com.typesafe" % "config" % "1.4.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,30 +8,13 @@ object Dependencies {
     val scala213 = "2.13.10"
     val scala3 = "3.3.0"
 
-    val typesafeConfig = "1.4.2"
-
-    // can't use 3.2.11+ on Scala 2.12 because it pulls in scala-xml 2.
-    // See https://github.com/scoverage/sbt-scoverage/issues/439
-    val scalaTest212 = "3.2.16"
-    val scalaTestPlusScalaCheck212 = "3.2.10.0"
-    val scalaTest = "3.2.12"
-    val scalaTestPlusScalaCheck = "3.2.11.0"
-
+    val scalaTest = "3.2.16"
+    val scalaTestPlusScalaCheck = "3.2.16.0"
     val scalaCheck = "1.17.0"
   }
 
-  val typesafeConfig = "com.typesafe" % "config" % Version.typesafeConfig
-
   // testing libraries
-  val scalaTest = forScalaVersions {
-    case (2, 12) => "org.scalatest" %% "scalatest" % Version.scalaTest212
-    case _ => "org.scalatest" %% "scalatest" % Version.scalaTest
-  }
-
-  val scalaTestPlusScalaCheck = forScalaVersions {
-    case (2, 12) => "org.scalatestplus" %% "scalacheck-1-15" % Version.scalaTestPlusScalaCheck212
-    case _ => "org.scalatestplus" %% "scalacheck-1-15" % Version.scalaTestPlusScalaCheck
-  }
-
+  val scalaTest = "org.scalatest" %% "scalatest" % Version.scalaTest
+  val scalaTestPlusScalaCheck = "org.scalatestplus" %% "scalacheck-1-17" % Version.scalaTestPlusScalaCheck
   val scalaCheck = "org.scalacheck" %% "scalacheck" % Version.scalaCheck
 }

--- a/testkit/build.sbt
+++ b/testkit/build.sbt
@@ -5,9 +5,9 @@ name := "pureconfig-testkit"
 crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq(
-  Dependencies.scalaTest.value,
+  Dependencies.scalaTest,
   Dependencies.scalaCheck,
-  Dependencies.scalaTestPlusScalaCheck.value
+  Dependencies.scalaTestPlusScalaCheck
 )
 
 // This is to avoid a warning due to the intransitive dependency of scalaTestPlusScalaCheck.


### PR DESCRIPTION
https://github.com/scoverage/sbt-scoverage/issues/439 is fixed now, so it's safe now to use the latest scalatest version with every Scala major version.

I also inlined Typesafe config SBT entry in `core` as it should only really be included there.

Supersedes #1500. Failures on website CI jobs are due to #1515.