### PR TITLE
Stop checking hashes of external links in website

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Verify website
         run: >
           htmlproofer
-          --allow-hash-href
+          --no-check-external-hash
           --swap-urls "https\://github\.com/pureconfig/pureconfig/tree/master:file\://$(pwd)"
           --ignore-urls "/search.maven.org/"
           docs/target/site


### PR DESCRIPTION
It looks like GitHub's recent revamp of Markdown rendering caused our website checker to start failing (see CI signals in other PRs).

The reason seems to be that while GitHub processes correctly links with anchors like https://github.com/lightbend/config/blob/master/HOCON.md#hocon-human-optimized-config-object-notation, these aren't represented anymore using HTML (probably handled via Javascript?).

As there are no way to ignore specific URLs or domains, I'm disabling hash checking in CI.