### PR TITLE
Set no cross build for the root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -180,6 +180,9 @@ lazy val lintFlags = forScalaVersions {
 // Use the same Scala 2.12 version in the root project as in subprojects
 scalaVersion := scala212
 
+// Setting no cross build for the aggregating root project so that we can have proper per project exclusions.
+crossScalaVersions := Nil
+
 // do not publish the root project
 publish / skip := true
 


### PR DESCRIPTION
Sets `crossScalaVersions` to `Nil` in the root project so that we can have proper per project exclusions. I stumbled upon this issue due to [this comment](https://github.com/pureconfig/pureconfig/pull/1636#discussion_r1541175731). If we try to set a `scalaVersion` for a specific subproject different from the one in the root project that subproject ends up being included as part of the aggregating project because there's no exclusion taking place in the root project. To verify this, we can try applying the suggestion in that comment and run `++ 2.12.19 -v` which results in the following (notice the inclusion the `pureconfig` - root - project):

```
[info] Switching Scala version on:
[info]     magnolia (2.12.19, 2.13.13)
[info]     sttp (2.12.19, 2.13.13, 3.3.3)
[info]     pekko-http (2.12.19, 2.13.13)
[info]     yaml (2.12.19, 2.13.13, 3.3.3)
[info]     http4s-docs (2.12.18)
[info]     javax-docs (2.12.18)
[info]     generic-base (2.12.19, 2.13.13, 3.3.3)
[info]     bundle (2.12.19, 2.13.13)
[info]     spark-docs (2.12.18)
[info]     hadoop-docs (2.12.18)
[info]     http4s (2.12.19, 2.13.13, 3.3.3)
[info]     fs2 (2.12.19, 2.13.13, 3.3.3)
[info]     scala-xml-docs (2.12.18)
[info]     cats-effect (2.12.19, 2.13.13, 3.3.3)
[info]     akka-docs (2.12.18)
[info]     circe-docs (2.12.18)
[info]     zio-config (2.12.19, 2.13.13)
[info]     squants (2.12.19, 2.13.13)
[info]     akka (2.12.19, 2.13.13)
[info]     enumeratum-docs (2.12.18)
[info]     akka-http-docs (2.12.18)
[info]     docs (2.12.19, 2.13.13)
[info]     tests (2.12.19, 2.13.13, 3.3.3)
[info]     cron4s-docs (2.12.18)
[info]     squants-docs (2.12.18)
[info]     enumeratum (2.12.19, 2.13.13, 3.3.3)
[info]     cats-docs (2.12.18)
[info]     http4s022-docs (2.12.18)
[info]   * pureconfig (2.12.19)
[info]     cats-effect2-docs (2.12.18)
[info]     joda (2.12.19, 2.13.13)
[info]     zio-config-docs (2.12.18)
[info]     fs2-docs (2.12.18)
[info]     generic (2.12.19, 2.13.13)
[info]     cron4s (2.12.19, 2.13.13)
[info]     http4s022 (2.12.19, 2.13.13, 3.3.3)
[info]     pekko-docs (2.12.18)
[info]     bundle-docs (2.12.18)
[info]     javax (2.12.19, 2.13.13)
[info]     akka-http (2.12.19, 2.13.13)
[info]     sttp-docs (2.12.18)
[info]     enum-docs (2.12.18)
[info]     hadoop (2.12.19, 2.13.13)
[info]     spark (2.12.19, 2.13.13)
[info]     ip4s-docs (2.12.18)
[info]     enum (2.12.19, 2.13.13)
[info]     circe (2.12.19, 2.13.13, 3.3.3)
[info]     joda-docs (2.12.18)
[info]     pekko-http-docs (2.12.18)
[info]     pekko (2.12.19, 2.13.13)
[info]     cats-effect-docs (2.12.18)
[info]     magnolia-docs (2.12.18)
[info]     cats (2.12.19, 2.13.13, 3.3.3)
[info]     core (2.12.19, 2.13.13, 3.3.3)
[info]     ip4s (2.12.19, 2.13.13, 3.3.3)
[info]     scala-xml (2.12.19, 2.13.13)
[info]     scalaz-docs (2.12.18)
[info]     scalaz (2.12.19, 2.13.13)
[info]     yaml-docs (2.12.18)
[info]     cats-effect2 (2.12.19, 2.13.13, 3.3.3)
[info]     testkit (2.12.19, 2.13.13, 3.3.3)
[info] Excluding projects:
[info]     generic-scala3 (3.3.3)
```

With this change we get the following (with the `pureconfig` - root - project excluded):

```
[info] Switching Scala version on:
[info]     magnolia (2.12.19, 2.13.13)
[info]     sttp (2.12.19, 2.13.13, 3.3.3)
[info]     pekko-http (2.12.19, 2.13.13)
[info]     yaml (2.12.19, 2.13.13, 3.3.3)
[info]     http4s-docs (2.12.18)
[info]     javax-docs (2.12.18)
[info]     generic-base (2.12.19, 2.13.13, 3.3.3)
[info]     bundle (2.12.19, 2.13.13)
[info]     spark-docs (2.12.18)
[info]     hadoop-docs (2.12.18)
[info]     http4s (2.12.19, 2.13.13, 3.3.3)
[info]     fs2 (2.12.19, 2.13.13, 3.3.3)
[info]     scala-xml-docs (2.12.18)
[info]     cats-effect (2.12.19, 2.13.13, 3.3.3)
[info]     akka-docs (2.12.18)
[info]     circe-docs (2.12.18)
[info]     zio-config (2.12.19, 2.13.13)
[info]     squants (2.12.19, 2.13.13)
[info]     akka (2.12.19, 2.13.13)
[info]     enumeratum-docs (2.12.18)
[info]     akka-http-docs (2.12.18)
[info]     docs (2.12.19, 2.13.13)
[info]     tests (2.12.19, 2.13.13, 3.3.3)
[info]     cron4s-docs (2.12.18)
[info]     squants-docs (2.12.18)
[info]     enumeratum (2.12.19, 2.13.13, 3.3.3)
[info]     cats-docs (2.12.18)
[info]     http4s022-docs (2.12.18)
[info]     cats-effect2-docs (2.12.18)
[info]     joda (2.12.19, 2.13.13)
[info]     zio-config-docs (2.12.18)
[info]     fs2-docs (2.12.18)
[info]     generic (2.12.19, 2.13.13)
[info]     cron4s (2.12.19, 2.13.13)
[info]     http4s022 (2.12.19, 2.13.13, 3.3.3)
[info]     pekko-docs (2.12.18)
[info]     bundle-docs (2.12.18)
[info]     javax (2.12.19, 2.13.13)
[info]     akka-http (2.12.19, 2.13.13)
[info]     sttp-docs (2.12.18)
[info]     enum-docs (2.12.18)
[info]     hadoop (2.12.19, 2.13.13)
[info]     spark (2.12.19, 2.13.13)
[info]     ip4s-docs (2.12.18)
[info]     enum (2.12.19, 2.13.13)
[info]     circe (2.12.19, 2.13.13, 3.3.3)
[info]     joda-docs (2.12.18)
[info]     pekko-http-docs (2.12.18)
[info]     pekko (2.12.19, 2.13.13)
[info]     cats-effect-docs (2.12.18)
[info]     magnolia-docs (2.12.18)
[info]     cats (2.12.19, 2.13.13, 3.3.3)
[info]     core (2.12.19, 2.13.13, 3.3.3)
[info]     ip4s (2.12.19, 2.13.13, 3.3.3)
[info]     scala-xml (2.12.19, 2.13.13)
[info]     scalaz-docs (2.12.18)
[info]     scalaz (2.12.19, 2.13.13)
[info]     yaml-docs (2.12.18)
[info]     cats-effect2 (2.12.19, 2.13.13, 3.3.3)
[info]     testkit (2.12.19, 2.13.13, 3.3.3)
[info] Excluding projects:
[info]   * pureconfig ()
[info]     generic-scala3 (3.3.3)
```