### PR TITLE
Set Scala 3 version used in CI to 3.3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - scala: '2.13'
             scala-version: 2.13.13
           - scala: '3'
-            scala-version: 3.3.0
+            scala-version: 3.3.3
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Sets the Scala 3 version used in CI to 3.3.3, which should prevent these fallbacks we've been observing in the CI build:

```
[info] Falling back sttp to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back yaml to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back http4s to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back fs2 to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back cats-effect to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back tests to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back enumeratum to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back http4s022 to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back circe to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back cats to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back core to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back ip4s to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back cats-effect2 to listed 3.3.3 instead of unlisted 3.3.0
[info] Falling back testkit to listed 3.3.3 instead of unlisted 3.3.0
```