### PR TITLE
fix CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 0.17.7 (Jun 9, 2024)
 
 - New features
-  - Added support for Scala 3 derivation of `ConfigWriter` and `ConfigConvert` using a `derives` clause.
+  - Added support for Scala 3 derivation of `EnumConfigWriter` and `EnumConfigConvert` using a `derives` clause.
   - Added a new `pureconfig-generic-scala3` module, a drop-in replacement of Scala 2's `pureconfig-generic` for semiauto derivation in Scala 3. It supports most of the types supported in `pureconfig-generic` and accepts product and coproduct hints.
 
 ### 0.17.6 (Feb 22, 2024)


### PR DESCRIPTION
@ruippeixotog I'm afraid we don't support general derivation of `ConfigWriter` and `ConfigConvert` using `derives` clause just yet! We do have it for enums though.

If we want to support the `derives` clause we need to either reconsider [this](https://github.com/pureconfig/pureconfig/pull/1636#discussion_r1580104314) approach or reimplement the `ConfigWriter` and `ConfigConvert`  derivation in core without hints. 