### PR TITLE
Allow Scala 3 `derives` without an import and deprecate direct usage of derivation classes

### DIFF
--- a/core/src/main/scala-2/pureconfig/ReaderDerives.scala
+++ b/core/src/main/scala-2/pureconfig/ReaderDerives.scala
@@ -1,0 +1,5 @@
+package pureconfig
+
+trait ReaderDerives {
+  // `derives` clauses are only supported in Scala 3
+}

--- a/core/src/main/scala-3/pureconfig/ReaderDerives.scala
+++ b/core/src/main/scala-3/pureconfig/ReaderDerives.scala
@@ -2,7 +2,7 @@ package pureconfig
 
 import scala.deriving.Mirror
 
-import pureconfig.generic.derivation.*
+import pureconfig.generic.derivation._
 
 trait ReaderDerives {
   inline def derived[A](using m: Mirror.Of[A]): ConfigReader[A] =

--- a/core/src/main/scala-3/pureconfig/ReaderDerives.scala
+++ b/core/src/main/scala-3/pureconfig/ReaderDerives.scala
@@ -1,0 +1,10 @@
+package pureconfig
+
+import scala.deriving.Mirror
+
+import pureconfig.generic.derivation.*
+
+trait ReaderDerives {
+  inline def derived[A](using m: Mirror.Of[A]): ConfigReader[A] =
+    ConfigReaderDerivation.Default.deriveConfigReader[A]
+}

--- a/core/src/main/scala-3/pureconfig/generic/derivation/ConfigReaderDerivation.scala
+++ b/core/src/main/scala-3/pureconfig/generic/derivation/ConfigReaderDerivation.scala
@@ -5,14 +5,21 @@ package derivation
 import scala.compiletime.summonFrom
 import scala.deriving.Mirror
 
+@deprecated(
+  "Custom derivation is deprecated in pureconfig-core. If you only need the default behavior, please use the default `derives` behavior. If you need configuration please use the `pureconfig-generic-scala3` module instead.",
+  "0.17.7"
+)
 trait ConfigReaderDerivation extends CoproductConfigReaderDerivation with ProductConfigReaderDerivation {
   extension (c: ConfigReader.type) {
     inline def derived[A](using m: Mirror.Of[A]): ConfigReader[A] =
-      inline m match {
-        case given Mirror.ProductOf[A] => derivedProduct
-        case given Mirror.SumOf[A] => derivedSum
-      }
+      deriveConfigReader[A]
   }
+
+  inline def deriveConfigReader[A](using m: Mirror.Of[A]): ConfigReader[A] =
+    inline m match {
+      case given Mirror.ProductOf[A] => derivedProduct
+      case given Mirror.SumOf[A] => derivedSum
+    }
 
   /** Summons a `ConfigReader` for a given type `A`. It first tries to find an existing given instance of
     * `ConfigReader[A]`. If none is found, it tries to derive one using this `ConfigReaderDerivation` instance. This
@@ -24,6 +31,7 @@ trait ConfigReaderDerivation extends CoproductConfigReaderDerivation with Produc
   }
 }
 
+@deprecated("Derivation of ConfigReaders using `derives` is now supported without an import.", "0.17.7")
 object ConfigReaderDerivation {
   object Default
       extends ConfigReaderDerivation
@@ -31,4 +39,5 @@ object ConfigReaderDerivation {
       with ProductConfigReaderDerivation(ConfigFieldMapping(CamelCase, KebabCase))
 }
 
+@deprecated("Derivation of ConfigReaders using `derives` is now supported without an import.", "0.17.7")
 val default = ConfigReaderDerivation.Default

--- a/core/src/main/scala-3/pureconfig/generic/derivation/CoproductConfigReaderDerivation.scala
+++ b/core/src/main/scala-3/pureconfig/generic/derivation/CoproductConfigReaderDerivation.scala
@@ -7,8 +7,12 @@ import scala.deriving.Mirror
 
 import pureconfig.error.{CannotConvert, ConfigReaderFailures}
 import pureconfig.generic.derivation.ConfigReaderDerivation
-import pureconfig.generic.derivation.Utils._
+import pureconfig.generic.derivation.Utils.*
 
+@deprecated(
+  "Custom derivation is deprecated in pureconfig-core. If you only need the default behavior, please use the default `derives` behavior. If you need configuration please use the `pureconfig-generic-scala3` module instead.",
+  "0.17.7"
+)
 trait CoproductConfigReaderDerivation(fieldMapping: ConfigFieldMapping, optionField: String) {
   self: ConfigReaderDerivation =>
   inline def derivedSum[A](using m: Mirror.SumOf[A]): ConfigReader[A] =

--- a/core/src/main/scala-3/pureconfig/generic/derivation/CoproductConfigReaderDerivation.scala
+++ b/core/src/main/scala-3/pureconfig/generic/derivation/CoproductConfigReaderDerivation.scala
@@ -7,7 +7,7 @@ import scala.deriving.Mirror
 
 import pureconfig.error.{CannotConvert, ConfigReaderFailures}
 import pureconfig.generic.derivation.ConfigReaderDerivation
-import pureconfig.generic.derivation.Utils.*
+import pureconfig.generic.derivation.Utils._
 
 @deprecated(
   "Custom derivation is deprecated in pureconfig-core. If you only need the default behavior, please use the default `derives` behavior. If you need configuration please use the `pureconfig-generic-scala3` module instead.",

--- a/core/src/main/scala-3/pureconfig/generic/derivation/EnumConfigReaderDerivation.scala
+++ b/core/src/main/scala-3/pureconfig/generic/derivation/EnumConfigReaderDerivation.scala
@@ -6,7 +6,7 @@ import scala.compiletime.{constValue, erasedValue, error, summonInline}
 import scala.deriving.Mirror
 
 import pureconfig.error.{CannotConvert, ConfigReaderFailures}
-import pureconfig.generic.derivation.Utils._
+import pureconfig.generic.derivation.Utils.*
 
 type EnumConfigReader[A] = EnumConfigReaderDerivation.Default.EnumConfigReader[A]
 

--- a/core/src/main/scala-3/pureconfig/generic/derivation/EnumConfigReaderDerivation.scala
+++ b/core/src/main/scala-3/pureconfig/generic/derivation/EnumConfigReaderDerivation.scala
@@ -6,7 +6,7 @@ import scala.compiletime.{constValue, erasedValue, error, summonInline}
 import scala.deriving.Mirror
 
 import pureconfig.error.{CannotConvert, ConfigReaderFailures}
-import pureconfig.generic.derivation.Utils.*
+import pureconfig.generic.derivation.Utils._
 
 type EnumConfigReader[A] = EnumConfigReaderDerivation.Default.EnumConfigReader[A]
 

--- a/core/src/main/scala-3/pureconfig/generic/derivation/ProductConfigReaderDerivation.scala
+++ b/core/src/main/scala-3/pureconfig/generic/derivation/ProductConfigReaderDerivation.scala
@@ -2,14 +2,18 @@ package pureconfig
 package generic
 package derivation
 
-import scala.compiletime.ops.int._
+import scala.compiletime.ops.int.*
 import scala.compiletime.{constValue, constValueTuple, erasedValue, summonFrom, summonInline}
 import scala.deriving.Mirror
 import scala.util.chaining.*
 
 import pureconfig.error.{ConfigReaderFailures, ConvertFailure, KeyNotFound, UnknownKey, WrongSizeList}
-import pureconfig.generic.derivation.Utils._
+import pureconfig.generic.derivation.Utils.*
 
+@deprecated(
+  "Custom derivation is deprecated in pureconfig-core. If you only need the default behavior, please use the default `derives` behavior. If you need configuration please use the `pureconfig-generic-scala3` module instead.",
+  "0.17.7"
+)
 trait ProductConfigReaderDerivation(fieldMapping: ConfigFieldMapping) { self: ConfigReaderDerivation =>
   inline def derivedProduct[A](using m: Mirror.ProductOf[A]): ConfigReader[A] =
     inline erasedValue[A] match {

--- a/core/src/main/scala-3/pureconfig/generic/derivation/ProductConfigReaderDerivation.scala
+++ b/core/src/main/scala-3/pureconfig/generic/derivation/ProductConfigReaderDerivation.scala
@@ -2,13 +2,13 @@ package pureconfig
 package generic
 package derivation
 
-import scala.compiletime.ops.int.*
+import scala.compiletime.ops.int._
 import scala.compiletime.{constValue, constValueTuple, erasedValue, summonFrom, summonInline}
 import scala.deriving.Mirror
-import scala.util.chaining.*
+import scala.util.chaining._
 
 import pureconfig.error.{ConfigReaderFailures, ConvertFailure, KeyNotFound, UnknownKey, WrongSizeList}
-import pureconfig.generic.derivation.Utils.*
+import pureconfig.generic.derivation.Utils._
 
 @deprecated(
   "Custom derivation is deprecated in pureconfig-core. If you only need the default behavior, please use the default `derives` behavior. If you need configuration please use the `pureconfig-generic-scala3` module instead.",

--- a/core/src/main/scala/pureconfig/ConfigReader.scala
+++ b/core/src/main/scala/pureconfig/ConfigReader.scala
@@ -145,7 +145,12 @@ trait ConfigReader[A] {
 
 /** Provides methods to create [[ConfigReader]] instances.
   */
-object ConfigReader extends BasicReaders with CollectionReaders with ProductReaders with ExportedReaders {
+object ConfigReader
+    extends BasicReaders
+    with CollectionReaders
+    with ProductReaders
+    with ExportedReaders
+    with ReaderDerives {
 
   /** The type of most config PureConfig reading methods.
     *

--- a/tests/src/test/scala-3/pureconfig/CoproductReaderDerivationSuite.scala
+++ b/tests/src/test/scala-3/pureconfig/CoproductReaderDerivationSuite.scala
@@ -4,10 +4,8 @@ import scala.language.higherKinds
 
 import com.typesafe.config.ConfigFactory
 
-import pureconfig._
-import pureconfig.error._
-import pureconfig.generic._
-import pureconfig.generic.derivation.default.derived
+import pureconfig.*
+import pureconfig.error.*
 
 enum AnimalConfig derives ConfigReader {
   case DogConfig(age: Int)

--- a/tests/src/test/scala-3/pureconfig/CoproductReaderDerivationSuite.scala
+++ b/tests/src/test/scala-3/pureconfig/CoproductReaderDerivationSuite.scala
@@ -4,8 +4,8 @@ import scala.language.higherKinds
 
 import com.typesafe.config.ConfigFactory
 
-import pureconfig.*
-import pureconfig.error.*
+import pureconfig._
+import pureconfig.error._
 
 enum AnimalConfig derives ConfigReader {
   case DogConfig(age: Int)

--- a/tests/src/test/scala-3/pureconfig/ProductReaderDerivationSuite.scala
+++ b/tests/src/test/scala-3/pureconfig/ProductReaderDerivationSuite.scala
@@ -6,7 +6,7 @@ import scala.language.higherKinds
 import com.typesafe.config.{ConfigFactory, ConfigRenderOptions, ConfigValueFactory}
 import org.scalacheck.Arbitrary
 
-import pureconfig.*
+import pureconfig._
 import pureconfig.ConfigConvert.catchReadError
 import pureconfig.error.{KeyNotFound, WrongSizeList, WrongType}
 

--- a/tests/src/test/scala-3/pureconfig/ProductReaderDerivationSuite.scala
+++ b/tests/src/test/scala-3/pureconfig/ProductReaderDerivationSuite.scala
@@ -1,5 +1,4 @@
 package pureconfig
-package generic
 
 import scala.collection.JavaConverters.given
 import scala.language.higherKinds
@@ -7,10 +6,9 @@ import scala.language.higherKinds
 import com.typesafe.config.{ConfigFactory, ConfigRenderOptions, ConfigValueFactory}
 import org.scalacheck.Arbitrary
 
+import pureconfig.*
 import pureconfig.ConfigConvert.catchReadError
-import pureconfig._
 import pureconfig.error.{KeyNotFound, WrongSizeList, WrongType}
-import pureconfig.generic.derivation.default.derived
 
 class ProductReaderDerivationSuite extends BaseSuite {
 


### PR DESCRIPTION
When the original Scala 3 derivation was designed, it was built such that users could customize it if they went through the trouble of creating their own derivation object and mixing in `ConfigReaderDerivation` traits to their liking. This resulted in a complex setup of traits using a cake pattern and the need for an explicit import.

`pureconfig-generic-scala3` is a more capable alternative for deriving readers in Scala 3 with support for configuration. Now that we have it, we can simplify the `pureconfig-core` implementation by locking in `derives` behavior to the defaults used by PureConfig. This means that we can make `derives` work without an import and, after a deprecation period, simplify derivation internals.