### PR TITLE
Enforce Scala 2 compatible syntax

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,7 +1,6 @@
 rules = [OrganizeImports]
 
 OrganizeImports {
-  targetDialect = Scala2
   coalesceToWildcardImportThreshold = 2147483647 # Int.MaxValue
   expandRelative = false
   groupExplicitlyImportedImplicitsSeparately = false
@@ -10,4 +9,5 @@ OrganizeImports {
   importSelectorsOrder = Ascii
   importsOrder = Ascii
   removeUnused = false
+  targetDialect = Scala2
 }

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,6 +1,7 @@
 rules = [OrganizeImports]
 
 OrganizeImports {
+  targetDialect = Scala2
   coalesceToWildcardImportThreshold = 2147483647 # Int.MaxValue
   expandRelative = false
   groupExplicitlyImportedImplicitsSeparately = false

--- a/build.sbt
+++ b/build.sbt
@@ -172,7 +172,9 @@ lazy val lintFlags = forScalaVersions {
       "-encoding",
       "UTF-8", // arg for -encoding
       "-feature",
-      "-unchecked"
+      "-unchecked",
+      "-old-syntax",
+      "-no-indent"
     )
 
   case (maj, min) => throw new Exception(s"Unknown Scala version $maj.$min")

--- a/core/src/main/scala-3/pureconfig/generic/derivation/EnumConfigWriterDerivation.scala
+++ b/core/src/main/scala-3/pureconfig/generic/derivation/EnumConfigWriterDerivation.scala
@@ -8,7 +8,7 @@ import scala.deriving.Mirror
 import com.typesafe.config.{ConfigValue, ConfigValueFactory}
 
 import pureconfig.error.{CannotConvert, ConfigReaderFailures}
-import pureconfig.generic.derivation.Utils.*
+import pureconfig.generic.derivation.Utils._
 
 type EnumConfigWriter[A] = EnumConfigWriterDerivation.Default.EnumConfigWriter[A]
 

--- a/core/src/main/scala-3/pureconfig/generic/derivation/ProductConfigReaderDerivation.scala
+++ b/core/src/main/scala-3/pureconfig/generic/derivation/ProductConfigReaderDerivation.scala
@@ -5,7 +5,7 @@ package derivation
 import scala.compiletime.ops.int._
 import scala.compiletime.{constValue, constValueTuple, erasedValue, summonFrom, summonInline}
 import scala.deriving.Mirror
-import scala.util.chaining.*
+import scala.util.chaining._
 
 import pureconfig.error.{ConfigReaderFailures, ConvertFailure, KeyNotFound, UnknownKey, WrongSizeList}
 import pureconfig.generic.derivation.Utils._

--- a/modules/generic-scala3/src/test/scala/pureconfig/generic/ProductConvertDerivationSuite.scala
+++ b/modules/generic-scala3/src/test/scala/pureconfig/generic/ProductConvertDerivationSuite.scala
@@ -171,14 +171,16 @@ class ProductConvertDerivationSuite extends BaseSuite {
     ConfigReader[Conf].from(conf) should failWith(KeyNotFound("b"))
 
     locally {
-      given ConfigReader[Int] with ReadsMissingKeys with
+      given ConfigReader[Int] with ReadsMissingKeys with {
         def from(cur: ConfigCursor) =
           cur.asConfigValue.fold(
             _ => Right(42),
-            v =>
+            v => {
               val s = v.render(ConfigRenderOptions.concise)
               cur.scopeFailure(catchReadError(_.toInt)(implicitly)(s))
+            }
           )
+      }
       given ConfigReader[Conf] = deriveReader
 
       ConfigReader[Conf].from(conf).value shouldBe Conf(1, 42)

--- a/modules/generic-scala3/src/test/scala/pureconfig/generic/ProductHintSuite.scala
+++ b/modules/generic-scala3/src/test/scala/pureconfig/generic/ProductHintSuite.scala
@@ -62,9 +62,10 @@ class ProductHintSuite extends BaseSuite {
     case class SampleConf(a: Int, b: String)
 
     val default = deriveReader[SampleConf]
-    val customized =
+    val customized = {
       given ProductHint[SampleConf] = ProductHint(ConfigFieldMapping(_.toUpperCase))
       deriveReader[SampleConf]
+    }
 
     ConfigReader[SampleConf](using default).from(conf).left.value.toList should contain theSameElementsAs Seq(
       ConvertFailure(KeyNotFound("a", Set("A")), stringConfigOrigin(1), ""),

--- a/tests/src/test/scala-3/pureconfig/EnumerationConvertDerivationSuite.scala
+++ b/tests/src/test/scala-3/pureconfig/EnumerationConvertDerivationSuite.scala
@@ -6,9 +6,9 @@ import scala.language.higherKinds
 
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory, ConfigValueType}
 
-import pureconfig.*
+import pureconfig._
 import pureconfig.error.{CannotConvert, WrongType}
-import pureconfig.generic.derivation.*
+import pureconfig.generic.derivation._
 
 class EnumConvertDerivationSuite extends BaseSuite {
   behavior of "EnumConfigConvert"


### PR DESCRIPTION
In past PRs we've been asking contributors to  use Scala 2 compatible syntax. On this PR I'm starting to enforce these choices using scalac and scalafix.

Most PureConfig code is cross-compiled against Scala 2.12, 2.13 and 3 and in those we have no choice but to use syntax compatible with all versions. Some Scala3-only code _could_ technically use the new syntax, but this would create a discrepancy in code style that I'd rather avoid as long as we can (i.e. until Scala 3 drops support for some Scala 2 syntax).