### PR TITLE
cross-compile modules for Scala 3

### DIFF
--- a/modules/cron4s/build.sbt
+++ b/modules/cron4s/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies.Version._
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies += "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.7.0"
 

--- a/modules/hadoop/build.sbt
+++ b/modules/hadoop/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies.Version._
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq("org.apache.hadoop" % "hadoop-common" % "3.4.0" % "provided")
 mdocLibraryDependencies ++= Seq("org.apache.hadoop" % "hadoop-common" % "3.4.0")

--- a/modules/javax/build.sbt
+++ b/modules/javax/build.sbt
@@ -1,5 +1,5 @@
 import Dependencies.Version._
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala3)
 
 developers := List(Developer("derekmorr", "Derek Morr", "morr.derek@gmail.com", url("https://github.com/derekmorr")))

--- a/modules/joda/build.sbt
+++ b/modules/joda/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies.Version._
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq("joda-time" % "joda-time" % "2.12.7", "org.joda" % "joda-convert" % "2.2.3")
 

--- a/modules/pekko-http/build.sbt
+++ b/modules/pekko-http/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies.Version._
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq(
   "org.apache.pekko" %% "pekko-actor" % "1.0.3" % "provided",

--- a/modules/pekko/build.sbt
+++ b/modules/pekko/build.sbt
@@ -1,5 +1,5 @@
 import Dependencies.Version._
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq("org.apache.pekko" %% "pekko-actor" % "1.0.3")

--- a/modules/pekko/src/test/scala/pureconfig/module/pekko/PekkoSuite.scala
+++ b/modules/pekko/src/test/scala/pureconfig/module/pekko/PekkoSuite.scala
@@ -22,6 +22,6 @@ class PekkoSuite extends BaseSuite {
   }
 
   it should "not load invalid ActorPath" in {
-    configString("this is this the path you're looking for").to[ActorPath] should be('left)
+    configString("this is this the path you're looking for").to[ActorPath].isLeft shouldBe true
   }
 }

--- a/modules/scala-xml/build.sbt
+++ b/modules/scala-xml/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies.Version._
 import Utilities._
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala3)
 
 // Scala 2.12 depends on an old version of scala-xml
 libraryDependencies ++= forScalaVersions {

--- a/modules/scala-xml/src/test/scala/pureconfig/module/scalaxml/ScalaXMLSuite.scala
+++ b/modules/scala-xml/src/test/scala/pureconfig/module/scalaxml/ScalaXMLSuite.scala
@@ -18,6 +18,6 @@ class ScalaXMLSuite extends BaseSuite {
   }
 
   it should "return an error when reading invalid XML" in {
-    configValue("<people>").to[Elem] shouldBe 'left
+    configValue("<people>").to[Elem].isLeft shouldBe true
   }
 }

--- a/modules/squants/build.sbt
+++ b/modules/squants/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies.Version._
 
-crossScalaVersions := Seq(scala212, scala213)
+crossScalaVersions := Seq(scala212, scala213, scala3)
 
 libraryDependencies ++= Seq("org.typelevel" %% "squants" % "1.8.3")
 

--- a/modules/squants/src/main/scala/pureconfig/module/squants/package.scala
+++ b/modules/squants/src/main/scala/pureconfig/module/squants/package.scala
@@ -12,6 +12,7 @@ import _root_.squants.space._
 import _root_.squants.thermal._
 import _root_.squants.time._
 
+import pureconfig.ConfigConvert
 import pureconfig.ConfigConvert._
 
 /** Provides [[ConfigConvert]] instances for Squants [[_root_.squants.Dimension]].
@@ -27,140 +28,140 @@ import pureconfig.ConfigConvert._
 package object squants {
 
   // electro
-  implicit val capacitanceConfigConvert =
+  implicit val capacitanceConfigConvert: ConfigConvert[Capacitance] =
     viaNonEmptyStringTry[Capacitance](Capacitance.apply, _.toString)
-  implicit val conductivityConfigConvert =
+  implicit val conductivityConfigConvert: ConfigConvert[Conductivity] =
     viaNonEmptyStringTry[Conductivity](Conductivity.apply, _.toString)
-  implicit val electricChargeConfigConvert =
+  implicit val electricChargeConfigConvert: ConfigConvert[ElectricCharge] =
     viaNonEmptyStringTry[ElectricCharge](ElectricCharge.apply, _.toString)
-  implicit val electricCurrentConfigConvert =
+  implicit val electricCurrentConfigConvert: ConfigConvert[ElectricCurrent] =
     viaNonEmptyStringTry[ElectricCurrent](ElectricCurrent.apply, _.toString)
-  implicit val electricPotentialConfigConvert =
+  implicit val electricPotentialConfigConvert: ConfigConvert[ElectricPotential] =
     viaNonEmptyStringTry[ElectricPotential](ElectricPotential.apply, _.toString)
-  implicit val electricalConductanceConfigConvert =
+  implicit val electricalConductanceConfigConvert: ConfigConvert[ElectricalConductance] =
     viaNonEmptyStringTry[ElectricalConductance](ElectricalConductance.apply, _.toString)
-  implicit val electricalResistanceConfigConvert =
+  implicit val electricalResistanceConfigConvert: ConfigConvert[ElectricalResistance] =
     viaNonEmptyStringTry[ElectricalResistance](ElectricalResistance.apply, _.toString)
-  implicit val inductanceConfigConvert =
+  implicit val inductanceConfigConvert: ConfigConvert[Inductance] =
     viaNonEmptyStringTry[Inductance](Inductance.apply, _.toString)
-  implicit val magneticFluxConfigConvert =
+  implicit val magneticFluxConfigConvert: ConfigConvert[MagneticFlux] =
     viaNonEmptyStringTry[MagneticFlux](MagneticFlux.apply, _.toString)
-  implicit val magneticFluxDensityConfigConvert =
+  implicit val magneticFluxDensityConfigConvert: ConfigConvert[MagneticFluxDensity] =
     viaNonEmptyStringTry[MagneticFluxDensity](MagneticFluxDensity.apply, _.toString)
-  implicit val resistivityConfigConvert =
+  implicit val resistivityConfigConvert: ConfigConvert[Resistivity] =
     viaNonEmptyStringTry[Resistivity](Resistivity.apply, _.toString)
 
   // energy
-  implicit val energyConfigConvert =
+  implicit val energyConfigConvert: ConfigConvert[Energy] =
     viaNonEmptyStringTry[Energy](Energy.apply, _.toString)
-  implicit val energyDensityConfigConvert =
+  implicit val energyDensityConfigConvert: ConfigConvert[EnergyDensity] =
     viaNonEmptyStringTry[EnergyDensity](EnergyDensity.apply, _.toString)
-  implicit val powerConfigConvert =
+  implicit val powerConfigConvert: ConfigConvert[Power] =
     viaNonEmptyStringTry[Power](Power.apply, _.toString)
-  implicit val powerRampConfigConvert =
+  implicit val powerRampConfigConvert: ConfigConvert[PowerRamp] =
     viaNonEmptyStringTry[PowerRamp](PowerRamp.apply, _.toString)
-  implicit val SpecificEnergyConfigConvert =
+  implicit val SpecificEnergyConfigConvert: ConfigConvert[SpecificEnergy] =
     viaNonEmptyStringTry[SpecificEnergy](SpecificEnergy.apply, _.toString)
 
   // information
-  implicit val informationConfigConvert =
+  implicit val informationConfigConvert: ConfigConvert[Information] =
     viaNonEmptyStringTry[Information](Information.apply, _.toString)
-  implicit val dataRateConfigConvert =
+  implicit val dataRateConfigConvert: ConfigConvert[DataRate] =
     viaNonEmptyStringTry[DataRate](DataRate.apply, _.toString)
 
   // market
   // Using own string representation due to https://github.com/typelevel/squants/issues/321
-  implicit def moneyDensityConfigConvert(implicit mc: MoneyContext) =
+  implicit def moneyDensityConfigConvert(implicit mc: MoneyContext): ConfigConvert[Money] =
     viaNonEmptyStringTry[Money](Money.apply, { m => m.amount.underlying.toPlainString + " " + m.currency.code })
 
   // mass
-  implicit val areaDensityConfigConvert =
+  implicit val areaDensityConfigConvert: ConfigConvert[AreaDensity] =
     viaNonEmptyStringTry[AreaDensity](AreaDensity.apply, _.toString)
-  implicit val chemicalAmountConfigConvert =
+  implicit val chemicalAmountConfigConvert: ConfigConvert[ChemicalAmount] =
     viaNonEmptyStringTry[ChemicalAmount](ChemicalAmount.apply, _.toString)
-  implicit val densityConfigConvert =
+  implicit val densityConfigConvert: ConfigConvert[Density] =
     viaNonEmptyStringTry[Density](Density.apply, _.toString)
-  implicit val massConfigConvert =
+  implicit val massConfigConvert: ConfigConvert[Mass] =
     viaNonEmptyStringTry[Mass](Mass.apply, _.toString)
-  implicit val momentOfInertiaConfigConvert =
+  implicit val momentOfInertiaConfigConvert: ConfigConvert[MomentOfInertia] =
     viaNonEmptyStringTry[MomentOfInertia](MomentOfInertia.apply, _.toString)
 
   // motion
-  implicit val accelerationConfigConvert =
+  implicit val accelerationConfigConvert: ConfigConvert[Acceleration] =
     viaNonEmptyStringTry[Acceleration](Acceleration.apply, _.toString)
-  implicit val angularAccelerationConfigConvert =
+  implicit val angularAccelerationConfigConvert: ConfigConvert[AngularAcceleration] =
     viaNonEmptyStringTry[AngularAcceleration](AngularAcceleration.apply, _.toString)
-  implicit val angularVelocityConfigConvert =
+  implicit val angularVelocityConfigConvert: ConfigConvert[AngularVelocity] =
     viaNonEmptyStringTry[AngularVelocity](AngularVelocity.apply, _.toString)
-  implicit val forceConfigConvert =
+  implicit val forceConfigConvert: ConfigConvert[Force] =
     viaNonEmptyStringTry[Force](Force.apply, _.toString)
-  implicit val jerkConfigConvert =
+  implicit val jerkConfigConvert: ConfigConvert[Jerk] =
     viaNonEmptyStringTry[Jerk](Jerk.apply, _.toString)
-  implicit val massFlowConfigConvert =
+  implicit val massFlowConfigConvert: ConfigConvert[MassFlow] =
     viaNonEmptyStringTry[MassFlow](MassFlow.apply, _.toString)
-  implicit val momentumConfigConvert =
+  implicit val momentumConfigConvert: ConfigConvert[Momentum] =
     viaNonEmptyStringTry[Momentum](Momentum.apply, _.toString)
-  implicit val pressureConfigConvert =
+  implicit val pressureConfigConvert: ConfigConvert[Pressure] =
     viaNonEmptyStringTry[Pressure](Pressure.apply, _.toString)
-  implicit val pressureChangeConfigConvert =
+  implicit val pressureChangeConfigConvert: ConfigConvert[PressureChange] =
     viaNonEmptyStringTry[PressureChange](PressureChange.apply, _.toString)
-  implicit val torqueConfigConvert =
+  implicit val torqueConfigConvert: ConfigConvert[Torque] =
     viaNonEmptyStringTry[Torque](Torque.apply, _.toString)
-  implicit val velocityConfigConvert =
+  implicit val velocityConfigConvert: ConfigConvert[Velocity] =
     viaNonEmptyStringTry[Velocity](Velocity.apply, _.toString)
-  implicit val volumeFlowConfigConvert =
+  implicit val volumeFlowConfigConvert: ConfigConvert[VolumeFlow] =
     viaNonEmptyStringTry[VolumeFlow](VolumeFlow.apply, _.toString)
-  implicit val yankConfigConvert =
+  implicit val yankConfigConvert: ConfigConvert[Yank] =
     viaNonEmptyStringTry[Yank](Yank.apply, _.toString)
 
   // photo
-  implicit val illuminanceConfigConvert =
+  implicit val illuminanceConfigConvert: ConfigConvert[Illuminance] =
     viaNonEmptyStringTry[Illuminance](Illuminance.apply, _.toString)
-  implicit val luminanceConfigConvert =
+  implicit val luminanceConfigConvert: ConfigConvert[Luminance] =
     viaNonEmptyStringTry[Luminance](Luminance.apply, _.toString)
-  implicit val luminousEnergyConfigConvert =
+  implicit val luminousEnergyConfigConvert: ConfigConvert[LuminousEnergy] =
     viaNonEmptyStringTry[LuminousEnergy](LuminousEnergy.apply, _.toString)
-  implicit val luminousExposureConfigConvert =
+  implicit val luminousExposureConfigConvert: ConfigConvert[LuminousExposure] =
     viaNonEmptyStringTry[LuminousExposure](LuminousExposure.apply, _.toString)
-  implicit val luminousFluxConfigConvert =
+  implicit val luminousFluxConfigConvert: ConfigConvert[LuminousFlux] =
     viaNonEmptyStringTry[LuminousFlux](LuminousFlux.apply, _.toString)
-  implicit val luminousIntensityConfigConvert =
+  implicit val luminousIntensityConfigConvert: ConfigConvert[LuminousIntensity] =
     viaNonEmptyStringTry[LuminousIntensity](LuminousIntensity.apply, _.toString)
 
   // radio
-  implicit val irradianceConfigConvert =
+  implicit val irradianceConfigConvert: ConfigConvert[Irradiance] =
     viaNonEmptyStringTry[Irradiance](Irradiance.apply, _.toString)
-  implicit val radianceConfigConvert =
+  implicit val radianceConfigConvert: ConfigConvert[Radiance] =
     viaNonEmptyStringTry[Radiance](Radiance.apply, _.toString)
-  implicit val spectralIntensityConfigConvert =
+  implicit val spectralIntensityConfigConvert: ConfigConvert[SpectralIntensity] =
     viaNonEmptyStringTry[SpectralIntensity](SpectralIntensity.apply, _.toString)
-  implicit val spectralIrradianceConfigConvert =
+  implicit val spectralIrradianceConfigConvert: ConfigConvert[SpectralIrradiance] =
     viaNonEmptyStringTry[SpectralIrradiance](SpectralIrradiance.apply, _.toString)
-  implicit val spectralPowerConfigConvert =
+  implicit val spectralPowerConfigConvert: ConfigConvert[SpectralPower] =
     viaNonEmptyStringTry[SpectralPower](SpectralPower.apply, _.toString)
 
   // space
-  implicit val angleConfigConvert =
+  implicit val angleConfigConvert: ConfigConvert[Angle] =
     viaNonEmptyStringTry[Angle](Angle.apply, _.toString)
-  implicit val areaConfigConvert =
+  implicit val areaConfigConvert: ConfigConvert[Area] =
     viaNonEmptyStringTry[Area](Area.apply, _.toString)
-  implicit val lengthConfigConvert =
+  implicit val lengthConfigConvert: ConfigConvert[Length] =
     viaNonEmptyStringTry[Length](Length.apply, _.toString)
-  implicit val solidAngleConfigConvert =
+  implicit val solidAngleConfigConvert: ConfigConvert[SolidAngle] =
     viaNonEmptyStringTry[SolidAngle](SolidAngle.apply, _.toString)
-  implicit val volumeConfigConvert =
+  implicit val volumeConfigConvert: ConfigConvert[Volume] =
     viaNonEmptyStringTry[Volume](Volume.apply, _.toString)
 
   // thermal
-  implicit val temperatureConfigConvert =
+  implicit val temperatureConfigConvert: ConfigConvert[Temperature] =
     viaNonEmptyStringTry[Temperature](Temperature.apply, _.toString)
-  implicit val thermalCapacityConfigConvert =
+  implicit val thermalCapacityConfigConvert: ConfigConvert[ThermalCapacity] =
     viaNonEmptyStringTry[ThermalCapacity](ThermalCapacity.apply, _.toString)
 
   // time
-  implicit val frequencyConfigConvert =
+  implicit val frequencyConfigConvert: ConfigConvert[Frequency] =
     viaNonEmptyStringTry[Frequency](Frequency.apply, _.toString)
-  implicit val timeConfigConvert =
+  implicit val timeConfigConvert: ConfigConvert[Time] =
     viaNonEmptyStringTry[Time](Time.apply, _.toString)
 
 }

--- a/modules/squants/src/test/scala/pureconfig/module/squants/SquantsConvertTest.scala
+++ b/modules/squants/src/test/scala/pureconfig/module/squants/SquantsConvertTest.scala
@@ -1,6 +1,6 @@
 package pureconfig.module.squants
 
-import scala.reflect.runtime.universe._
+import scala.reflect.ClassTag
 
 import _root_.squants._
 import _root_.squants.market._
@@ -81,7 +81,7 @@ class SquantsConvertTest extends BaseSuite {
 
   def checkDimension[T <: Quantity[T]](
       dim: Dimension[T]
-  )(implicit tag: TypeTag[T], cc: ConfigConvert[T]): Unit = {
+  )(implicit tag: ClassTag[T], cc: ConfigConvert[T]): Unit = {
     implicit val arbitrary = quantityAbitrary(dim)
     checkArbitrary[T]
   }


### PR DESCRIPTION
Cross-compiling `cron4s`, `hadoop`, `javax`, `joda`, `pekko-http`, `pekko`, `scala-xml` and `squants` modules for Scala 3