### PR TITLE
Update reference of scala-3-derivation doc in index.md

### DIFF
--- a/docs/docs/docs/index.md
+++ b/docs/docs/docs/index.md
@@ -20,7 +20,7 @@ Users of Scala 3 need to add the following dependency to their `build.sbt`:
 libraryDependencies += "com.github.pureconfig" %% "pureconfig-core" % "@VERSION@"
 ```
 
-While a lot of the documentation will also apply to Scala 3, there is a specific guide for Scala 3's derivation that you can [find here](scala-3-derivation.html).
+While a lot of the documentation will also apply to Scala 3, there is a specific guide for Scala 3's derivation that you can [find here](scala-3-derivation.md).
 
 
 Earlier versions of Scala had bugs which can cause subtle compile-time problems in PureConfig.


### PR DESCRIPTION
Currently the scala-3-derivation link points to an .html file which is non-existent. This pull request updates this reference to point to the correct docs/docs/docs/scala-3-derivation.md markdown documentation file.