### PR TITLE
Use JDK 11 in GitHub Actions to fix mdoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [adopt@1.8]
+        jdk: [adopt@1.11]
         scala: ['2.12', '2.13', '3']
         include:
           - scala: '2.12'
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Scala
-        uses: olafurpg/setup-scala@v13
+        uses: olafurpg/setup-scala@v14
         with:
           java-version: ${{ matrix.jdk }}
 
@@ -72,9 +72,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Scala
-        uses: olafurpg/setup-scala@v10
+        uses: olafurpg/setup-scala@v14
         with:
-          java-version: adopt@1.8
+          java-version: adopt@1.11
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -107,9 +107,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Scala
-        uses: olafurpg/setup-scala@v10
+        uses: olafurpg/setup-scala@v14
         with:
-          java-version: adopt@1.8
+          java-version: adopt@1.11
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/bundle/docs/README.md
+++ b/bundle/docs/README.md
@@ -37,6 +37,14 @@ To use PureConfig in an existing SBT project with Scala 2.12 or a later version,
 libraryDependencies += "com.github.pureconfig" %% "pureconfig" % "@VERSION@"
 ```
 
+For Scala 3, add the following dependency to your `build.sbt`:
+
+```scala
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-core" % "@VERSION@"
+```
+
+While a lot of the documentation will also apply to Scala 3, there is a specific guide for Scala 3's derivation that you can [find here](scala-3-derivation.html).
+
 For a full example of `build.sbt` you can have a look at this [build.sbt](https://github.com/pureconfig/pureconfig/blob/master/example/build.sbt).
 
 Earlier versions of Scala had bugs which can cause subtle compile-time problems in PureConfig.


### PR DESCRIPTION
Our CI check for mdoc consistency has been inactive as sbt-mdoc has been silently failing due to a JVM version incompatibility:

```
info: Compiling 1 file to /home/runner/work/pureconfig/pureconfig/modules/zio-config
info: Compiling 1 file to /home/runner/work/pureconfig/pureconfig/modules/scalaz
info: Compiling 1 file to /home/runner/work/pureconfig/pureconfig/modules/circe
Exception in thread "sbt-bg-threads-3" java.lang.UnsupportedClassVersionError: com/vladsch/flexmark/util/data/DataHolder has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
	at java.net.URLClassLoader.access$[100](https://github.com/pureconfig/pureconfig/actions/runs/10829901041/job/30361846600?pr=1709#step:12:101)(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at sbt.internal.ManagedClassLoader.findClass(ManagedClassLoader.java:103)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at mdoc.internal.cli.MainOps.handleMarkdown(MainOps.scala:94)
	at mdoc.internal.cli.MainOps.handleFile(MainOps.scala:122)
	at mdoc.internal.cli.MainOps.$anonfun$generateCompleteSite$1(MainOps.scala:168)
	at scala.collection.LinearSeqOptimized.foldLeft(LinearSeqOptimized.scala:126)
	at scala.collection.LinearSeqOptimized.foldLeft$(LinearSeqOptimized.scala:122)
(...)
```

This allowed generated markdown files to deviate from mdoc sources (e.g. `bundle/docs/README.md` and `README.md`), leading to confusion in PRs like #1703 and #1709.

On this PR I'm fixing mdoc by bumping the JDK used in GitHub Actions to 1.11 and fixing out-of-sync docs accordingly.