### PR TITLE
Generate `Automatic-Module-Name` attribute

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,18 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
+lazy val javaModuleName = settingKey[String]("Java Module name")
+lazy val publishSettingAutomaticModuleName = Seq(
+  packageOptions += Package.ManifestAttributes("Automatic-Module-Name" -> javaModuleName.value)
+)
+
 lazy val core = (project in file("core"))
   .enablePlugins(BoilerplatePlugin)
-  .settings(commonSettings)
+  .settings(
+    commonSettings,
+    javaModuleName := "pureconfig.core",
+    publishSettingAutomaticModuleName
+  )
 
 lazy val testkit = (project in file("testkit"))
   .settings(commonSettings)
@@ -44,6 +53,7 @@ def genericModule(proj: Project) = proj
   .dependsOn(testkit % "test")
   .settings(commonSettings)
   .settings(name := s"pureconfig-${baseDirectory.value.getName}")
+  .settings(Seq(javaModuleName := s"${name.value.replace("-", ".")}") ++ publishSettingAutomaticModuleName)
 
 def module(proj: Project) = genericModule(proj)
   .enablePlugins(ModuleMdocPlugin)

--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -75,7 +75,8 @@ trait JavaEnumReader {
   */
 trait UriAndPathReaders {
 
-  implicit val urlConfigReader: ConfigReader[URL] = ConfigReader.fromNonEmptyString[URL](catchReadError(new URL(_)))
+  implicit val urlConfigReader: ConfigReader[URL] =
+    ConfigReader.fromNonEmptyString[URL](catchReadError(new URI(_).toURL()))
   implicit val uuidConfigReader: ConfigReader[UUID] =
     ConfigReader.fromNonEmptyString[UUID](catchReadError(UUID.fromString))
   implicit val pathConfigReader: ConfigReader[Path] = ConfigReader.fromString[Path](catchReadError(Paths.get(_)))


### PR DESCRIPTION
It is currently impossible to define `pureconfig` on a module path. This is because Java fails to automatically infer Module name from jar's containing invalid characters (e.g. `_` or `-` in `_2.13` cross version). It's a common problem with Scala artifacts.

This change adds `Automatic-Module-Name` attribute to MANIFEST that contains a valid Java identifier that can be used to define appropriate module dependencies.

Also fixed a warning that was stopping the compilation for those who are on JDK 20 already.