### PR TITLE
Add some utility methods to simplify creating `ConfigReader` instances manually

### DIFF
--- a/core/src/main/scala/pureconfig/ConfigCursor.scala
+++ b/core/src/main/scala/pureconfig/ConfigCursor.scala
@@ -467,6 +467,32 @@ case class ConfigObjectCursor(objValue: ConfigObject, pathElems: List[String]) e
     }
   }
 
+  /** Returns a value at a given key.
+    *
+    * @param key
+    *   the key of the config for which a value should be returned
+    * @tparam A
+    *   the type of the value (a ConfigReader instance for this type must be in scope)
+    * @return
+    *   a `Right` with the value at `key` if such a config exists, a `Left` with a list of failures otherwise.
+    */
+  def getAtKey[A: ConfigReader](key: String): ConfigReader.Result[A] =
+    atKey(key).flatMap(ConfigReader[A].from(_))
+
+  /** Returns a value at a given key or the default value if the key is missing.
+    *
+    * @param key
+    *   the key of the config for which a value should be returned
+    * @param default
+    *   the default value to return if the key is missing
+    * @tparam A
+    *   the type of the value (a ConfigReader instance for this type must be in scope)
+    * @return
+    *   the value at `key` if such a value exists, `default` otherwise.
+    */
+  def getAtKeyOr[A: ConfigReader](key: String, default: => A): ConfigReader.Result[A] =
+    ConfigReader[Option[A]].from(atKeyOrUndefined(key)).map(_.getOrElse(default))
+
   /** Returns a cursor to the config at a given key. A missing key will return a cursor to an undefined value.
     *
     * @param key

--- a/tests/src/test/scala/pureconfig/ConfigCursorSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigCursorSuite.scala
@@ -275,6 +275,17 @@ class ConfigCursorSuite extends BaseSuite {
     objCursor("{ a: 1, b: 2 }").atKeyOrUndefined("c").isUndefined shouldBe true
   }
 
+  it should "allow access to value at a given key" in {
+    objCursor("{ a: 1, b: 2 }").getAtKey[Int]("a") shouldBe Right(1)
+    objCursor("{ a: 1, b: 2 }")
+      .getAtKey[Int]("c") should failWith(KeyNotFound("c", Set()), defaultPathStr, stringConfigOrigin(1))
+  }
+
+  it should "allow access to value at a given key in a safe way" in {
+    objCursor("{ a: 1, b: 2 }").getAtKeyOr[Int]("a", 5) shouldBe Right(1)
+    objCursor("{ a: 1, b: 2 }").getAtKeyOr[Int]("c", 4) shouldBe Right(4)
+  }
+
   it should "provide a correct withoutKey method" in {
     objCursor("{ a: 1, b: 2 }").withoutKey("a") shouldBe objCursor("{ b: 2 }")
     objCursor("{ a: 1, b: 2 }").withoutKey("c") shouldBe objCursor("{ a: 1, b: 2 }")


### PR DESCRIPTION
This PR adds a few utilities to `ConfigReader` & `ConfigObjectCursor` to simplify the process of creating a `ConfigReader` instance manually:

```scala
implicit val MyConfigConfigReader: ConfigReader[MyConfig] = ConfigReader.discriminator(
  "always" ->
    (_ => Right(MyConfig)),
  "never" ->
    (_ => Right(MyConfig)),
  "sometimes" -> { cursor =>
    (
      cursor.getAtKey[Int]("one"),
      cursor.getAtKey[Double]("two"),
      cursor.getAtKeyOr[Boolean]("three", true),
      cursor.getAtKeyOr[Boolean]("four", true),
    ).mapN(MyConfig.apply)
  }
)
```