### PR TITLE
Remove installation of libxslt-dev from CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,7 @@ jobs:
           ruby-version: 3.2
 
       - name: Install dependencies
-        run: >
-          sudo apt install libxslt-dev &&
-          gem install jekyll:4.3.2 html-proofer:5.0.7
+        run: gem install jekyll:4.3.2 html-proofer:5.0.7
 
       - name: Build website
         run: sbt makeMicrosite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           ruby-version: 3.2
 
       - name: Install dependencies
-        run: gem install jekyll:4.3.2 html-proofer:5.0.7
+        run: gem install 'jekyll:~>4' html-proofer:5.0.7
 
       - name: Build website
         run: sbt makeMicrosite
@@ -115,7 +115,7 @@ jobs:
           ruby-version: 3.2
 
       - name: Install dependencies
-        run: gem install jekyll:4.3.2
+        run: gem install 'jekyll:~>4'
 
       - name: Build and compare website
         id: diff_website


### PR DESCRIPTION
It looks like at some point in time the PureConfig website required libxslt-dev to build. However, that no longer seems to be the case. Seeing as it is failing the installation in recent builds (https://github.com/pureconfig/pureconfig/actions/runs/14014181748/job/39247022750), we might as well remove it.

Incidentally, this also doesn't pin on a specific Jekyll 4.x version, as that seems to be what's [recommended by sbt-microsites](https://47degrees.github.io/sbt-microsites/docs/getting-started/#continuous-integration---travis).