### PR TITLE
Avoid multiple calls to `ProductHint#bottom` in derived `ConfigReader`s for Scala 3

### DIFF
--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigReaderDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigReaderDerivation.scala
@@ -80,10 +80,13 @@ trait HintsAwareProductConfigReaderDerivation { self: HintsAwareConfigReaderDeri
 
         val resultTuple = ConfigReader.Result.zipWith(head, tail)((h, t) => widen[h *: t, T](h *: t))
 
-        val usedFields = actions.map(_._2.field).toSet
-        val hintFailures = summon[ProductHint[A]].bottom(objCursor, usedFields).toLeft(())
-
-        ConfigReader.Result.zipWith(resultTuple, hintFailures)((r, _) => r)
+        if (n == 0) {
+          val usedFields = actions.map(_._2.field).toSet
+          val bottomFailures = summon[ProductHint[A]].bottom(objCursor, usedFields).toLeft(())
+          ConfigReader.Result.zipWith(resultTuple, bottomFailures)((r, _) => r)
+        } else {
+          resultTuple
+        }
 
       case _: EmptyTuple =>
         Right(widen[EmptyTuple, T](EmptyTuple))

--- a/modules/generic-scala3/src/test/scala/pureconfig/generic/ProductHintSuite.scala
+++ b/modules/generic-scala3/src/test/scala/pureconfig/generic/ProductHintSuite.scala
@@ -154,19 +154,20 @@ class ProductHintSuite extends BaseSuite {
   it should "disallow unknown keys if specified through a product hint" in {
     given ProductHint[Conf2] = ProductHint(allowUnknownKeys = false)
 
-    case class Conf1(a: Int)
+    case class Conf1(a: Int, c: Int)
     given ConfigReader[Conf1] = deriveReader
-    case class Conf2(a: Int)
+    case class Conf2(a: Int, c: Int)
     given ConfigReader[Conf2] = deriveReader
 
     val conf = ConfigFactory.parseString("""{
       conf {
         a = 1
         b = 2
+        c = 3
       }
     }""")
 
-    conf.getConfig("conf").to[Conf1] shouldBe Right(Conf1(1))
+    conf.getConfig("conf").to[Conf1] shouldBe Right(Conf1(1, 3))
     conf.getConfig("conf").to[Conf2] should failWith(UnknownKey("b"), "b", stringConfigOrigin(4))
   }
 

--- a/modules/generic/src/test/scala/pureconfig/ProductHintSuite.scala
+++ b/modules/generic/src/test/scala/pureconfig/ProductHintSuite.scala
@@ -142,8 +142,8 @@ class ProductHintSuite extends BaseSuite {
 
   it should "disallow unknown keys if specified through a product hint" in {
 
-    case class Conf1(a: Int)
-    case class Conf2(a: Int)
+    case class Conf1(a: Int, c: Int)
+    case class Conf2(a: Int, c: Int)
 
     implicit val productHint = ProductHint[Conf2](allowUnknownKeys = false)
 
@@ -151,10 +151,11 @@ class ProductHintSuite extends BaseSuite {
       conf {
         a = 1
         b = 2
+        c = 3
       }
     }""")
 
-    conf.getConfig("conf").to[Conf1] shouldBe Right(Conf1(1))
+    conf.getConfig("conf").to[Conf1] shouldBe Right(Conf1(1, 3))
     conf.getConfig("conf").to[Conf2] should failWith(UnknownKey("b"), "b", stringConfigOrigin(4))
   }
 


### PR DESCRIPTION
`ProductHint#bottom` is meant to be called only once when producing an instance for a product of type `A` within `ConfigReader#from`. The current code was calling it once per field of the product, resulting in possibly multiple repeated failures. This is problematic for strict derivations, as we get as many `UnknownKey` failures as valid fields in the product being read.