### PR TITLE
Clear all Scala 2.13 warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val commonSettings = Seq(
 
   Test / scalacOptions ~= { _.filterNot(_.contains("-Ywarn-unused")) },
 
-  Compile / console / scalacOptions --= Seq("-Xfatal-warnings", "-Ywarn-unused-import", "-Ywarn-unused:_,-implicits"),
+  Compile / console / scalacOptions -= "-Ywarn-unused",
   Test / console / scalacOptions := (Compile / console / scalacOptions).value,
 
   scalafmtOnCompile := true,
@@ -145,8 +145,13 @@ lazy val lintFlags = forScalaVersions {
       "UTF-8", // arg for -encoding
       "-feature",
       "-unchecked",
-      "-Yrangepos", // Required by SemanticDB compiler plugin.
-      "-Ywarn-unused:_,-implicits",
+      "-deprecation",
+      // do not create copy constructor for case classes with private fields
+      "-Xsource-features:case-apply-copy-access",
+      "-Xsource:3",
+      // Required by SemanticDB compiler plugin
+      "-Yrangepos",
+      "-Ywarn-unused",
       "-Ywarn-dead-code",
       "-Ywarn-numeric-widen"
     )

--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -183,7 +183,7 @@ trait TypesafeConfigReaders {
       cur.scopeFailure {
         ConvertHelpers.tryToEither {
           Try {
-            val wrapped = cur.asConfigValue.right.get.atKey("_")
+            val wrapped = cur.asConfigValue.toOption.get.atKey("_")
             val bytes = wrapped.getBytes("_").longValue()
             ConfigMemorySize.ofBytes(bytes)
           }

--- a/core/src/main/scala/pureconfig/BasicWriters.scala
+++ b/core/src/main/scala/pureconfig/BasicWriters.scala
@@ -106,19 +106,19 @@ trait NumericWriters {
 trait TypesafeConfigWriters {
 
   implicit val configConfigWriter: ConfigWriter[Config] = new ConfigWriter[Config] {
-    def to(t: Config) = t.root()
+    def to(t: Config): ConfigValue = t.root()
   }
 
   implicit val configObjectConfigWriter: ConfigWriter[ConfigObject] = new ConfigWriter[ConfigObject] {
-    def to(t: ConfigObject) = t
+    def to(t: ConfigObject): ConfigValue = t
   }
 
   implicit val configValueConfigWriter: ConfigWriter[ConfigValue] = new ConfigWriter[ConfigValue] {
-    def to(t: ConfigValue) = t
+    def to(t: ConfigValue): ConfigValue = t
   }
 
   implicit val configListConfigWriter: ConfigWriter[ConfigList] = new ConfigWriter[ConfigList] {
-    def to(t: ConfigList) = t
+    def to(t: ConfigList): ConfigValue = t
   }
 
   implicit val configMemorySizeWriter: ConfigWriter[ConfigMemorySize] = {

--- a/core/src/main/scala/pureconfig/CollectionReaders.scala
+++ b/core/src/main/scala/pureconfig/CollectionReaders.scala
@@ -1,7 +1,6 @@
 package pureconfig
 
 import scala.collection.Factory
-import scala.language.higherKinds
 import scala.reflect.ClassTag
 
 /** A marker trait signaling that a `ConfigReader` accepts missing (undefined) values.
@@ -24,7 +23,7 @@ trait CollectionReaders {
       }
     }
 
-  implicit def traversableReader[A, F[A] <: TraversableOnce[A]](implicit
+  implicit def traversableReader[A, F[A] <: IterableOnce[A]](implicit
       configConvert: ConfigReader[A],
       cbf: Factory[A, F[A]]
   ): ConfigReader[F[A]] =

--- a/core/src/main/scala/pureconfig/CollectionWriters.scala
+++ b/core/src/main/scala/pureconfig/CollectionWriters.scala
@@ -1,7 +1,6 @@
 package pureconfig
 
-import scala.collection.JavaConverters._
-import scala.language.higherKinds
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config._
 
@@ -29,20 +28,20 @@ trait CollectionWriters {
       def toOpt(t: Option[A]): Option[ConfigValue] = t.map(conv.to)
     }
 
-  implicit def traversableWriter[A, F[A] <: TraversableOnce[A]](implicit
+  implicit def traversableWriter[A, F[A] <: IterableOnce[A]](implicit
       configConvert: ConfigWriter[A]
   ): ConfigWriter[F[A]] =
     new ConfigWriter[F[A]] {
 
       override def to(ts: F[A]): ConfigValue = {
-        ConfigValueFactory.fromIterable(ts.toList.map(configConvert.to).asJava)
+        ConfigValueFactory.fromIterable(ts.iterator.to(List).map(configConvert.to).asJava)
       }
     }
 
   implicit def mapWriter[A](implicit configConvert: ConfigWriter[A]): ConfigWriter[Map[String, A]] =
     new ConfigWriter[Map[String, A]] {
       override def to(keyVals: Map[String, A]): ConfigValue = {
-        ConfigValueFactory.fromMap(keyVals.mapValues(configConvert.to).toMap.asJava)
+        ConfigValueFactory.fromMap(keyVals.view.mapValues(configConvert.to).toMap.asJava)
       }
     }
 

--- a/core/src/main/scala/pureconfig/ConfigCursor.scala
+++ b/core/src/main/scala/pureconfig/ConfigCursor.scala
@@ -1,6 +1,6 @@
 package pureconfig
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 import com.typesafe.config.ConfigValueType._
@@ -337,7 +337,7 @@ object ConfigCursor {
         Right(ConfigValueFactory.fromAnyRef(configValue.unwrapped.toString))
 
       case (ConfigValueType.OBJECT, ConfigValueType.LIST) =>
-        val obj = configValue.asInstanceOf[ConfigObject].asScala.toIterator
+        val obj = configValue.asInstanceOf[ConfigObject].asScala.iterator
         val ll = obj.flatMap { case (str, v) => Try(str.toInt).toOption.map(_ -> v) }.toList
 
         ll match {

--- a/core/src/main/scala/pureconfig/ConfigSource.scala
+++ b/core/src/main/scala/pureconfig/ConfigSource.scala
@@ -318,7 +318,7 @@ object ConfigSource {
   private[pureconfig] def fromCursor(cur: ConfigCursor): ConfigSource =
     new ConfigSource {
       def value(): Result[ConfigValue] = cur.asConfigValue
-      override def cursor() = Right(cur)
+      override def cursor(): Result[ConfigCursor] = Right(cur)
     }
 
   /** Creates a `ConfigSource` from a `FluentConfigCursor`.
@@ -331,7 +331,7 @@ object ConfigSource {
   private[pureconfig] def fromCursor(cur: FluentConfigCursor): ConfigSource =
     new ConfigSource {
       def value(): Result[ConfigValue] = cur.cursor.flatMap(_.asConfigValue)
-      override def cursor() = cur.cursor
-      override def fluentCursor() = cur
+      override def cursor(): Result[ConfigCursor] = cur.cursor
+      override def fluentCursor(): FluentConfigCursor = cur
     }
 }

--- a/core/src/main/scala/pureconfig/DurationUtils.scala
+++ b/core/src/main/scala/pureconfig/DurationUtils.scala
@@ -49,7 +49,7 @@ private[pureconfig] object DurationUtils {
   // "ms milli millisecond" -> List("ms", "milli", "millis", "millisecond", "milliseconds")
   private[this] def words(s: String) = (s.trim split "\\s+").toList
   private[this] def expandLabels(labels: String): List[String] = {
-    val hd :: rest = words(labels)
+    val hd :: rest = words(labels): @unchecked
     hd :: rest.flatMap(s => List(s, s + "s"))
   }
 

--- a/core/src/main/scala/pureconfig/NamingConvention.scala
+++ b/core/src/main/scala/pureconfig/NamingConvention.scala
@@ -1,5 +1,7 @@
 package pureconfig
 
+import scala.collection.immutable.ArraySeq
+
 trait NamingConvention {
   def toTokens(s: String): Seq[String]
   def fromTokens(l: Seq[String]): String
@@ -7,7 +9,7 @@ trait NamingConvention {
 
 trait CapitalizedWordsNamingConvention extends NamingConvention {
   def toTokens(s: String): Seq[String] = {
-    CapitalizedWordsNamingConvention.wordBreakPattern.split(s).map(_.toLowerCase)
+    ArraySeq.unsafeWrapArray(CapitalizedWordsNamingConvention.wordBreakPattern.split(s)).map(_.toLowerCase)
   }
 }
 
@@ -40,7 +42,7 @@ object PascalCase extends CapitalizedWordsNamingConvention {
 
 class StringDelimitedNamingConvention(d: String) extends NamingConvention {
   def toTokens(s: String): Seq[String] =
-    s.split(d).map(_.toLowerCase)
+    ArraySeq.unsafeWrapArray(s.split(d)).map(_.toLowerCase)
 
   def fromTokens(l: Seq[String]): String =
     l.map(_.toLowerCase).mkString(d)

--- a/core/src/main/scala/pureconfig/backend/PathUtil.scala
+++ b/core/src/main/scala/pureconfig/backend/PathUtil.scala
@@ -1,6 +1,6 @@
 package pureconfig.backend
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.ConfigUtil
 

--- a/core/src/main/scala/pureconfig/configurable/package.scala
+++ b/core/src/main/scala/pureconfig/configurable/package.scala
@@ -3,7 +3,7 @@ package pureconfig
 import java.time._
 import java.time.format.DateTimeFormatter
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
 import com.typesafe.config.ConfigValueFactory

--- a/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
+++ b/core/src/main/scala/pureconfig/error/ConfigReaderFailure.scala
@@ -93,7 +93,7 @@ trait CannotRead extends ConfigReaderFailure {
       case None => s"Unable to read $sourceType $sourceName."
     }
 
-  def origin = None
+  def origin: Option[ConfigOrigin] = None
 }
 
 /** A failure occurred due to the inability to read a requested file.

--- a/docs/docs/docs/built-in-supported-types.md
+++ b/docs/docs/docs/built-in-supported-types.md
@@ -30,7 +30,7 @@ The currently supported basic types are:
 Additionally, PureConfig also handles the following collections and composite Scala structures:
 
 - `Option` for optional values, i.e. values that can or cannot be in the configuration, of types on this list;
-- collections implementing the `TraversableOnce` trait, where the type of the elements is on this list;
+- collections implementing the `IterableOnce` trait, where the type of the elements is on this list;
 - `Map`s from `String` keys to any value type that is on this list;
 - `Map`s from types convertible to `String` to any value type that is on this list (must be configured first - see
   [Configurable Converters](configurable-converters.html));

--- a/docs/docs/docs/complex-types.md
+++ b/docs/docs/docs/complex-types.md
@@ -70,10 +70,11 @@ final case class Class2Dummy(id: String, value: Int) extends IdentifiableDummy {
 // change the coproduct hint to tell PureConfig that the type value specified
 // is the name of the class without the "Dummy" suffix because we want the type to
 // be the one of the new types, not the mirroring types
-implicit val identifiableCoproductHint = new FieldCoproductHint[IdentifiableDummy]("type") {
-  override protected def fieldValue(name: String): String =
-    name.take(name.length - "Dummy".length).toLowerCase
-}
+implicit val identifiableCoproductHint: FieldCoproductHint[IdentifiableDummy] =
+  new FieldCoproductHint[IdentifiableDummy]("type") {
+    override protected def fieldValue(name: String): String =
+      name.take(name.length - "Dummy".length).toLowerCase
+  }
 
 // we tell PureConfig that to read Identifiable, it has to read IdentifiableDummy first
 // and then maps it to Identifiable
@@ -108,7 +109,7 @@ def extractByType(typ: String, objCur: ConfigObjectCursor): ConfigReader.Result[
       s"type has value $t instead of class1 or class2"))
 }
 
-implicit val identifiableConfigReader2 = ConfigReader.fromCursor { cur =>
+implicit val identifiableConfigReader2: ConfigReader[Identifiable] = ConfigReader.fromCursor { cur =>
   for {
     objCur <- cur.asObjectCursor
     typeCur <- objCur.atKey("type")
@@ -149,7 +150,7 @@ import shapeless.labelled._
 // create the singleton idw for the field id
 val idw = Witness(Symbol("id"))
 
-implicit val class1Generic = new LabelledGeneric[Class1] {
+implicit val class1Generic: LabelledGeneric[Class1] = new LabelledGeneric[Class1] {
   // the generic representation of Class1 is the field id of type String
   override type Repr = FieldType[idw.T, String] :: HNil
 
@@ -161,7 +162,7 @@ implicit val class1Generic = new LabelledGeneric[Class1] {
 // create the singleton valuew for the field value
 val valuew = Witness(Symbol("value"))
 
-implicit val class2Generic = new LabelledGeneric[Class2] {
+implicit val class2Generic: LabelledGeneric[Class2] = new LabelledGeneric[Class2] {
   // the generic representation of Class2 is the fields id of type String and value of type Int
   override type Repr = FieldType[idw.T, String] :: FieldType[valuew.T, Int] :: HNil
 
@@ -175,12 +176,12 @@ implicit val class2Generic = new LabelledGeneric[Class2] {
 The second item is trivial because neither `Class1` nor `Class2` have default values for fields:
 
 ```scala mdoc:silent
-implicit val class1Default = new Default.AsOptions[Class1] {
+implicit val class1Default: Default.AsOptions[Class1] = new Default.AsOptions[Class1] {
   override type Out = Option[String] :: HNil
   override def apply(): Out = None :: HNil
 }
 
-implicit val class2Default = new Default.AsOptions[Class2] {
+implicit val class2Default: Default.AsOptions[Class2] = new Default.AsOptions[Class2] {
   override type Out = Option[String] :: Option[Int] :: HNil
   override def apply(): Out = None :: None :: HNil
 }
@@ -194,7 +195,7 @@ as a sealed family of `Class1` and `Class2`, or a coproduct of them if you want:
 val class1w = Witness(Symbol("Class1"))
 val class2w = Witness(Symbol("Class2"))
 
-implicit val identifiableGeneric = new LabelledGeneric[Identifiable] {
+implicit val identifiableGeneric: LabelledGeneric[Identifiable] = new LabelledGeneric[Identifiable] {
   override type Repr =
     FieldType[class1w.T, Class1] :+:
     FieldType[class2w.T, Class2] :+:

--- a/docs/docs/docs/config-cursors.md
+++ b/docs/docs/docs/config-cursors.md
@@ -49,7 +49,7 @@ def firstNameOf(name: String): String =
 def lastNamesOf(name: String): Array[String] =
   name.dropWhile(_ != ' ').drop(1).split(" ")
 
-implicit val personReader = ConfigReader.fromCursor[Person] { cur =>
+implicit val personReader: ConfigReader[Person] = ConfigReader.fromCursor[Person] { cur =>
   for {
     objCur <- cur.asObjectCursor      // 1
     nameCur <- objCur.atKey("name")   // 2

--- a/docs/docs/docs/config-writers.md
+++ b/docs/docs/docs/config-writers.md
@@ -50,7 +50,8 @@ class MyInt(value: Int) {
   override def toString: String = s"MyInt($value)"
 }
 
-implicit val myIntWriter = ConfigWriter[Int].contramap[MyInt](_.getValue)
+implicit val myIntWriter: ConfigWriter[MyInt] =
+  ConfigWriter[Int].contramap[MyInt](_.getValue)
 ```
 
 ```scala mdoc
@@ -60,12 +61,18 @@ ConfigWriter[MyInt].to(new MyInt(1))
 Finally, if you need both the reading and the writing part for a custom type, you can implement a `ConfigConvert`:
 
 ```scala mdoc:silent
-implicit val myIntConvert = ConfigConvert[Int].xmap[MyInt](new MyInt(_), _.getValue)
+class MyInt2(value: Int) {
+  def getValue: Int = value
+  override def toString: String = s"MyInt2($value)"
+}
+
+implicit val myIntConvert: ConfigConvert[MyInt2] =
+  ConfigConvert[Int].xmap[MyInt2](new MyInt2(_), _.getValue)
 ```
 
 ```scala mdoc
-val conf = ConfigWriter[MyInt].to(new MyInt(1))
-ConfigReader[MyInt].from(conf)
+val conf = ConfigWriter[MyInt2].to(new MyInt2(1))
+ConfigReader[MyInt2].from(conf)
 ```
 
 A `ConfigConvert` implements both the `ConfigReader` and `ConfigWriter` interfaces and can be used everywhere one of

--- a/docs/docs/docs/configurable-converters.md
+++ b/docs/docs/docs/configurable-converters.md
@@ -24,8 +24,8 @@ import pureconfig.generic.auto._
 
 case class Conf(date: LocalDate, intMap: Map[Int, Int])
 
-implicit val localDateConvert = localDateConfigConvert(DateTimeFormatter.ISO_DATE)
-implicit val intMapReader = genericMapReader[Int, Int](catchReadError(_.toInt))
+implicit val localDateConvert: ConfigConvert[LocalDate] = localDateConfigConvert(DateTimeFormatter.ISO_DATE)
+implicit val intMapReader: ConfigReader[Map[Int, Int]] = genericMapReader[Int, Int](catchReadError(_.toInt))
 ```
 
 Then load the configuration:

--- a/docs/docs/docs/error-handling.md
+++ b/docs/docs/docs/error-handling.md
@@ -52,7 +52,7 @@ case class PositiveInt(value: Int) {
   require(value >= 0)
 }
 
-implicit val positiveIntReader = ConfigReader.fromCursor[PositiveInt] { cur =>
+implicit val positiveIntReader: ConfigReader[PositiveInt] = ConfigReader.fromCursor[PositiveInt] { cur =>
   cur.asString.flatMap { str =>
     Try(str.toInt) match {
       case Success(n) if n >= 0 => Right(PositiveInt(n))

--- a/docs/docs/docs/non-automatic-derivation.md
+++ b/docs/docs/docs/non-automatic-derivation.md
@@ -66,7 +66,7 @@ val conf = ConfigFactory.parseString("{ name: John, surname: Doe }")
 ```scala mdoc:silent
 import pureconfig.generic.semiauto._
 
-implicit val personReader = deriveReader[Person]
+implicit val personReader: ConfigReader[Person] = deriveReader
 ```
 
 We are now ready to read `Person` configs:
@@ -86,21 +86,21 @@ sealed trait Occupation extends Product with Serializable
 object Occupation {
   case class Employed(job: String) extends Occupation
   object Employed {
-    implicit val employedReader = deriveReader[Employed]
+    implicit val employedReader: ConfigReader[Employed] = deriveReader
   }
   case object Unemployed extends Occupation {
-    implicit val unemployedReader = deriveReader[Unemployed.type]
+    implicit val unemployedReader: ConfigReader[Unemployed.type] = deriveReader
   }
   case object Student extends Occupation {
-    implicit val studentReader = deriveReader[Student.type]
+    implicit val studentReader: ConfigReader[Student.type] = deriveReader
   }
-  implicit val occupationReader = deriveReader[Occupation]
+  implicit val occupationReader: ConfigReader[Occupation] = deriveReader
 }
 
 case class WorkingPerson(name: String, surname: String, occupation: Occupation)
 
 object WorkingPerson {
-  implicit val workingPersonReader = deriveReader[WorkingPerson]
+  implicit val workingPersonReader: ConfigReader[WorkingPerson] = deriveReader
 }
 ```
 
@@ -126,7 +126,8 @@ val conf = ConfigFactory.parseString("{ name: John, surname: Doe }")
 ```scala mdoc:silent
 import pureconfig._
 
-implicit val personReader = ConfigReader.forProduct2("name", "surname")(Person(_, _))
+implicit val personReader: ConfigReader[Person] =
+  ConfigReader.forProduct2("name", "surname")(Person(_, _))
 ```
 
 ```scala mdoc

--- a/docs/docs/docs/overriding-behavior-for-case-classes.md
+++ b/docs/docs/docs/overriding-behavior-for-case-classes.md
@@ -45,7 +45,7 @@ import pureconfig.generic.ProductHint
 
 case class SampleConf(foo: Int, bar: String)
 
-implicit val productHint = ProductHint[SampleConf](new ConfigFieldMapping {
+implicit val productHint: ProductHint[SampleConf] = ProductHint[SampleConf](new ConfigFieldMapping {
   def apply(fieldName: String) = fieldName.toUpperCase
 })
 ```
@@ -74,7 +74,7 @@ can make sure the following implicit is in scope before loading or writing
 configuration files:
 
 ```scala mdoc:silent
-implicit def hint[A] = ProductHint[A](ConfigFieldMapping(CamelCase, CamelCase))
+implicit def hint[A]: ProductHint[A] = ProductHint[A](ConfigFieldMapping(CamelCase, CamelCase))
 ```
 
 ### Default field values
@@ -115,8 +115,8 @@ ConfigSource.string("{ where: Texas, how-long: 3 hours }").load[Holiday]
 A `ProductHint` can make the conversion fail if a key is missing from the
 config regardless of whether a default value exists or not:
 
-```scala mdoc:silent
-implicit val hint = ProductHint[Holiday](useDefaultArgs = false)
+```scala mdoc:silent:nest
+implicit val hint: ProductHint[Holiday] = ProductHint[Holiday](useDefaultArgs = false)
 ```
 
 ```scala mdoc
@@ -146,9 +146,11 @@ ConfigSource.string("{ wher: Texas, how-long: 21 days }").load[Holiday]
 With a `ProductHint`, one can tell the converter to fail if an unknown key is
 found:
 
-```scala mdoc
-implicit val hint = ProductHint[Holiday](allowUnknownKeys = false)
+```scala mdoc:silent:nest
+implicit val hint: ProductHint[Holiday] = ProductHint[Holiday](allowUnknownKeys = false)
+```
 
+```scala mdoc
 ConfigSource.string("{ wher: Texas, how-long: 21 days }").load[Holiday]
 ```
 
@@ -181,7 +183,7 @@ available `ConfigReader` for that type with a [cursor](config-cursors.html) to a
 Under this setup:
 
 ```scala mdoc:silent
-implicit val maybeIntReader = new ConfigReader[Int] with ReadsMissingKeys {
+implicit val maybeIntReader: ConfigReader[Int] = new ConfigReader[Int] with ReadsMissingKeys {
   override def from(cur: ConfigCursor) =
     if (cur.isUndefined) Right(42) else ConfigReader[Int].from(cur)
 }

--- a/docs/docs/docs/overriding-behavior-for-sealed-families.md
+++ b/docs/docs/docs/overriding-behavior-for-sealed-families.md
@@ -35,10 +35,10 @@ of a case class option, we can use another field.
 
 First, define a `CoproductHint` in implicit scope:
 
-```scala mdoc:silent
+```scala mdoc:silent:nest
 import pureconfig.generic.FieldCoproductHint
 
-implicit val animalConfHint = new FieldCoproductHint[AnimalConf]("kind")
+implicit val animalConfHint: FieldCoproductHint[AnimalConf] = new FieldCoproductHint[AnimalConf]("kind")
 ```
 
 Then load the config:
@@ -51,7 +51,7 @@ ConfigSource.string("{ kind: dog-conf, age: 4 }").load[AnimalConf]
 way. First, define a new `FieldCoproductHint` in implicit scope:
 
 ```scala mdoc:nest:silent
-implicit val animalConfHint = new FieldCoproductHint[AnimalConf]("type") {
+implicit val animalConfHint: FieldCoproductHint[AnimalConf] = new FieldCoproductHint[AnimalConf]("type") {
   override def fieldValue(name: String) = name.dropRight("Conf".length)
 }
 ```

--- a/docs/docs/docs/overriding-behavior-for-types.md
+++ b/docs/docs/docs/overriding-behavior-for-types.md
@@ -14,7 +14,6 @@ For instance, the default behavior of PureConfig for `String` is to return the s
 ```scala mdoc:silent
 import com.typesafe.config.ConfigValueFactory
 import pureconfig._
-import pureconfig.generic.auto._
 ```
 
 ```scala mdoc
@@ -24,10 +23,11 @@ ConfigReader[String].from(ConfigValueFactory.fromAnyRef("FooBar"))
 Now let's say that we want to override this behavior such that `String`s are always read lower case. We can define a
 custom `ConfigReader` instance for `String`:
 
-```scala mdoc:silent
+```scala mdoc:silent:nest
 import pureconfig.ConvertHelpers._
 
-implicit val overrideStrReader = ConfigReader.fromString[String](catchReadError(_.toLowerCase))
+implicit val overrideStrReader: ConfigReader[String] =
+  ConfigReader.fromString[String](catchReadError(_.toLowerCase))
 ```
 
 PureConfig will now use the custom `overrideStrReader` instance:

--- a/docs/docs/docs/supporting-new-types.md
+++ b/docs/docs/docs/supporting-new-types.md
@@ -37,7 +37,7 @@ For the `MyInt` type above, we could create a `ConfigReader[MyInt]` by mapping t
 this:
 
 ```scala mdoc:silent
-implicit val myIntReader = ConfigReader[Int].map(n => new MyInt(n))
+implicit val myIntReader: ConfigReader[MyInt] = ConfigReader[Int].map(n => new MyInt(n))
 ```
 
 Note that the `ConfigReader[Int]` expression "summons" an existing implicit instance, being syntactic sugar for `implicitly[ConfigReader[Int]]`. This is usually the easiest way to create a `ConfigReader` for simple types. See
@@ -46,7 +46,7 @@ Note that the `ConfigReader[Int]` expression "summons" an existing implicit inst
 As an example for the second approach, we could read the required integer by parsing it from a string form like this:
 
 ```scala mdoc:nest:silent
-implicit val myIntReader = ConfigReader.fromString[MyInt](
+implicit val myIntReader: ConfigReader[MyInt] = ConfigReader.fromString[MyInt](
   ConvertHelpers.catchReadError(s => new MyInt(s.toInt)))
 ```
 
@@ -57,7 +57,7 @@ The `fromString` factory method allows users to easily read data from string rep
 Finally, we could simply implement the `ConfigReader` interface by hand:
 
 ```scala mdoc:nest:silent
-implicit val myIntReader = new ConfigReader[MyInt] {
+implicit val myIntReader: ConfigReader[MyInt] = new ConfigReader[MyInt] {
   def from(cur: ConfigCursor) = cur.asString.map(s => new MyInt(s.toInt))
 }
 ```

--- a/modules/akka/src/test/scala/pureconfig/module/akka/AkkaSuite.scala
+++ b/modules/akka/src/test/scala/pureconfig/module/akka/AkkaSuite.scala
@@ -6,6 +6,7 @@ import akka.actor.ActorPath
 import akka.util.Timeout
 
 import pureconfig.BaseSuite
+import pureconfig.error.CannotConvert
 import pureconfig.syntax._
 
 class AkkaSuite extends BaseSuite {
@@ -22,6 +23,6 @@ class AkkaSuite extends BaseSuite {
   }
 
   it should "not load invalid ActorPath" in {
-    configString("this is this the path you're looking for").to[ActorPath] should be('left)
+    configString("this is this the path you're looking for").to[ActorPath].isLeft shouldBe true
   }
 }

--- a/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/package.scala
+++ b/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/package.scala
@@ -4,7 +4,6 @@ import java.io.OutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 
-import scala.language.higherKinds
 import scala.reflect.ClassTag
 
 import cats.data.{EitherT, NonEmptyList}

--- a/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/syntax/package.scala
+++ b/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/syntax/package.scala
@@ -1,6 +1,5 @@
 package pureconfig.module.catseffect
 
-import scala.language.higherKinds
 import scala.reflect.ClassTag
 
 import cats.effect.Sync

--- a/modules/cats-effect2/src/main/scala/pureconfig/module/catseffect2/package.scala
+++ b/modules/cats-effect2/src/main/scala/pureconfig/module/catseffect2/package.scala
@@ -4,7 +4,6 @@ import java.io.OutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 
-import scala.language.higherKinds
 import scala.reflect.ClassTag
 
 import cats.data.EitherT

--- a/modules/cats-effect2/src/main/scala/pureconfig/module/catseffect2/syntax/package.scala
+++ b/modules/cats-effect2/src/main/scala/pureconfig/module/catseffect2/syntax/package.scala
@@ -1,6 +1,5 @@
 package pureconfig.module.catseffect2
 
-import scala.language.higherKinds
 import scala.reflect.ClassTag
 
 import cats.effect.{Blocker, ContextShift, Sync}

--- a/modules/cats/src/main/scala/pureconfig/module/cats/package.scala
+++ b/modules/cats/src/main/scala/pureconfig/module/cats/package.scala
@@ -1,7 +1,6 @@
 package pureconfig.module
 
 import scala.collection.immutable.{SortedMap, SortedSet}
-import scala.language.higherKinds
 import scala.reflect.ClassTag
 
 import _root_.cats.data._
@@ -43,12 +42,12 @@ package object cats {
   implicit def nonEmptyMapWriter[A, B](implicit writer: ConfigWriter[Map[A, B]]): ConfigWriter[NonEmptyMap[A, B]] =
     writer.contramap(_.toSortedMap)
 
-  // For emptiable foldables not covered by TraversableOnce reader/writer, e.g. Chain.
-  implicit def lowPriorityNonReducibleReader[A, F[_]: Foldable: Alternative](implicit
+  // For emptiable foldables not covered by IterableOnce reader/writer, e.g. Chain.
+  implicit def lowPriorityNonReducibleReader[A, F[_]: Alternative](implicit
       reader: ConfigReader[List[A]]
   ): Exported[ConfigReader[F[A]]] =
     Exported(reader.map(to => (to foldRight Alternative[F].empty[A])(_.pure[F] <+> _)))
-  implicit def lowPriorityNonReducibleWriter[A, F[_]: Foldable: Alternative](implicit
+  implicit def lowPriorityNonReducibleWriter[A, F[_]: Foldable](implicit
       writer: ConfigWriter[List[A]]
   ): Exported[ConfigWriter[F[A]]] =
     Exported(writer.contramap(_.toList))

--- a/modules/cats/src/test/scala/pureconfig/module/cats/arbitrary/package.scala
+++ b/modules/cats/src/test/scala/pureconfig/module/cats/arbitrary/package.scala
@@ -1,6 +1,6 @@
 package pureconfig.module.cats
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{Config, ConfigValue, ConfigValueFactory}
 import org.scalacheck.Arbitrary.{arbitrary => arb}

--- a/modules/circe/src/main/scala/pureconfig/module/circe/package.scala
+++ b/modules/circe/src/main/scala/pureconfig/module/circe/package.scala
@@ -1,6 +1,6 @@
 package pureconfig.module
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config._
 import io.circe._
@@ -28,7 +28,7 @@ package object circe {
         Json.fromValues(iter)
       }
       case ConfigValueType.OBJECT => {
-        val jsonMap = cv.asInstanceOf[ConfigObject].asScala.mapValues(cvToJson _).toMap
+        val jsonMap = cv.asInstanceOf[ConfigObject].asScala.view.mapValues(cvToJson _).toMap
         val jsonObj = JsonObject.fromMap(jsonMap)
         Json.fromJsonObject(jsonObj)
       }

--- a/modules/enum/src/main/scala/pureconfig/module/enum/package.scala
+++ b/modules/enum/src/main/scala/pureconfig/module/enum/package.scala
@@ -8,7 +8,7 @@ import pureconfig.ConfigConvert
 import pureconfig.ConfigConvert.viaNonEmptyString
 import pureconfig.error.CannotConvert
 
-package object enum {
+package object `enum` {
   implicit def enumConfigConvert[A](implicit e: Enum[A], ct: ClassTag[A]): ConfigConvert[A] = {
     viaNonEmptyString(
       s => e.decode(s).left.map(failure => CannotConvert(s, ct.runtimeClass.getSimpleName, failure.toString)),

--- a/modules/fs2/src/main/scala/pureconfig/module/fs2/package.scala
+++ b/modules/fs2/src/main/scala/pureconfig/module/fs2/package.scala
@@ -2,7 +2,6 @@ package pureconfig.module
 
 import java.nio.charset.StandardCharsets.UTF_8
 
-import scala.language.higherKinds
 import scala.reflect.ClassTag
 
 import _root_.fs2.{Stream, text}

--- a/modules/generic-scala3/src/test/scala/pureconfig/generic/EnumDerivationSuite.scala
+++ b/modules/generic-scala3/src/test/scala/pureconfig/generic/EnumDerivationSuite.scala
@@ -3,7 +3,6 @@ package generic
 
 import scala.compiletime.testing.{typeCheckErrors, typeChecks}
 import scala.deriving.Mirror
-import scala.language.higherKinds
 
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory, ConfigValueType}
 

--- a/modules/generic-scala3/src/test/scala/pureconfig/generic/ProductConvertDerivationSuite.scala
+++ b/modules/generic-scala3/src/test/scala/pureconfig/generic/ProductConvertDerivationSuite.scala
@@ -3,7 +3,6 @@ package generic
 
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters.given
-import scala.language.higherKinds
 
 import com.typesafe.config.{ConfigFactory, ConfigRenderOptions, ConfigValueFactory}
 import org.scalacheck.Arbitrary

--- a/modules/generic/src/main/scala/pureconfig/generic/DerivedConfigReader.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/DerivedConfigReader.scala
@@ -1,5 +1,7 @@
 package pureconfig.generic
 
+import scala.annotation.unused
+
 import shapeless._
 
 import pureconfig._
@@ -17,7 +19,6 @@ object DerivedConfigReader extends DerivedConfigReader1 {
 
   implicit def anyValReader[A, Wrapped](implicit
       ev: A <:< AnyVal,
-      generic: Generic[A],
       unwrapped: Unwrapped.Aux[A, Wrapped],
       reader: ConfigReader[Wrapped]
   ): DerivedConfigReader[A] =
@@ -27,7 +28,8 @@ object DerivedConfigReader extends DerivedConfigReader1 {
         reader.from(value).map(unwrapped.wrap)
     }
 
-  implicit def tupleReader[A: IsTuple, Repr <: HList, LabelledRepr <: HList, DefaultRepr <: HList](implicit
+  implicit def tupleReader[A, Repr <: HList, LabelledRepr <: HList, DefaultRepr <: HList](implicit
+      @unused("Needed to disambiguate from anyValReader") isTuple: IsTuple[A],
       g: Generic.Aux[A, Repr],
       gcr: SeqShapedReader[Repr],
       lg: LabelledGeneric.Aux[A, LabelledRepr],
@@ -51,12 +53,12 @@ object DerivedConfigReader extends DerivedConfigReader1 {
       }
     }
 
-  private[pureconfig] def tupleAsListReader[A: IsTuple, Repr <: HList](
+  private[pureconfig] def tupleAsListReader[A, Repr <: HList](
       cur: ConfigListCursor
   )(implicit gen: Generic.Aux[A, Repr], cr: SeqShapedReader[Repr]): ConfigReader.Result[A] =
     cr.from(cur).map(gen.from)
 
-  private[pureconfig] def tupleAsObjectReader[A: IsTuple, Repr <: HList, DefaultRepr <: HList](
+  private[pureconfig] def tupleAsObjectReader[A, Repr <: HList, DefaultRepr <: HList](
       cur: ConfigObjectCursor
   )(implicit
       gen: LabelledGeneric.Aux[A, Repr],

--- a/modules/generic/src/main/scala/pureconfig/generic/DerivedConfigWriter.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/DerivedConfigWriter.scala
@@ -1,5 +1,7 @@
 package pureconfig.generic
 
+import scala.annotation.unused
+
 import com.typesafe.config._
 import shapeless._
 
@@ -16,7 +18,6 @@ object DerivedConfigWriter extends DerivedConfigWriter1 {
 
   implicit def anyValWriter[A, Wrapped](implicit
       ev: A <:< AnyVal,
-      generic: Generic[A],
       unwrapped: Unwrapped.Aux[A, Wrapped],
       writer: ConfigWriter[Wrapped]
   ): DerivedConfigWriter[A] =
@@ -24,7 +25,8 @@ object DerivedConfigWriter extends DerivedConfigWriter1 {
       override def to(t: A): ConfigValue = writer.to(unwrapped.unwrap(t))
     }
 
-  implicit def tupleWriter[A: IsTuple, Repr](implicit
+  implicit def tupleWriter[A, Repr](implicit
+      @unused("Needed to disambiguate from anyValWriter") isTuple: IsTuple[A],
       gen: Generic.Aux[A, Repr],
       cc: SeqShapedWriter[Repr]
   ): DerivedConfigWriter[A] =

--- a/modules/generic/src/main/scala/pureconfig/generic/EnumerationConfigWriterBuilder.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/EnumerationConfigWriterBuilder.scala
@@ -1,5 +1,7 @@
 package pureconfig.generic
 
+import scala.annotation.unused
+
 import com.typesafe.config.{ConfigValue, ConfigValueFactory}
 import shapeless._
 import shapeless.labelled._
@@ -28,7 +30,7 @@ object EnumerationConfigWriterBuilder {
 
   implicit def deriveEnumerationWriterBuilderCCons[K <: Symbol, H, T <: Coproduct](implicit
       vName: Witness.Aux[K],
-      hGen: LabelledGeneric.Aux[H, HNil],
+      @unused("Needed to disallow non-case objects and classes") hGen: LabelledGeneric.Aux[H, HNil],
       tWriterBuilder: EnumerationConfigWriterBuilder[T]
   ): EnumerationConfigWriterBuilder[FieldType[K, H] :+: T] =
     new EnumerationConfigWriterBuilder[FieldType[K, H] :+: T] {

--- a/modules/generic/src/main/scala/pureconfig/generic/MapShapedWriter.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/MapShapedWriter.scala
@@ -1,6 +1,6 @@
 package pureconfig.generic
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{ConfigFactory, ConfigObject, ConfigValue}
 import shapeless._

--- a/modules/generic/src/main/scala/pureconfig/generic/SeqShapedWriter.scala
+++ b/modules/generic/src/main/scala/pureconfig/generic/SeqShapedWriter.scala
@@ -1,6 +1,6 @@
 package pureconfig.generic
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{ConfigList, ConfigValue, ConfigValueFactory}
 import shapeless._

--- a/modules/generic/src/test/scala/pureconfig/CoproductConvertersSuite.scala
+++ b/modules/generic/src/test/scala/pureconfig/CoproductConvertersSuite.scala
@@ -14,7 +14,7 @@ class CoproductConvertersSuite extends BaseSuite {
   val genCatConfig: Gen[CatConfig] = Arbitrary.arbInt.arbitrary.map(CatConfig.apply)
   val genDogConfig: Gen[DogConfig] = Arbitrary.arbInt.arbitrary.map(DogConfig.apply)
   val genAnimalConfig: Gen[AnimalConfig] = Gen.oneOf(genBirdConfig, genCatConfig, genDogConfig)
-  implicit val arbAnimalConfig = Arbitrary(genAnimalConfig)
+  implicit val arbAnimalConfig: Arbitrary[AnimalConfig] = Arbitrary(genAnimalConfig)
 
   checkArbitrary[AnimalConfig]
 

--- a/modules/generic/src/test/scala/pureconfig/HListConvertersSuite.scala
+++ b/modules/generic/src/test/scala/pureconfig/HListConvertersSuite.scala
@@ -1,6 +1,6 @@
 package pureconfig
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.ConfigValueFactory
 import org.scalacheck.{Arbitrary, Gen}

--- a/modules/generic/src/test/scala/pureconfig/ProductHintSuite.scala
+++ b/modules/generic/src/test/scala/pureconfig/ProductHintSuite.scala
@@ -1,6 +1,6 @@
 package pureconfig
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{ConfigFactory, ConfigObject, ConfigValueType}
 

--- a/modules/generic/src/test/scala/pureconfig/TupleConvertersSuite.scala
+++ b/modules/generic/src/test/scala/pureconfig/TupleConvertersSuite.scala
@@ -1,6 +1,6 @@
 package pureconfig
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{ConfigValueFactory, ConfigValueType}
 import org.scalacheck.Arbitrary

--- a/modules/generic/src/test/scala/pureconfig/ValueClassSuite.scala
+++ b/modules/generic/src/test/scala/pureconfig/ValueClassSuite.scala
@@ -25,7 +25,7 @@ trait Read[A] {
 object Read {
   def apply[A](implicit readT: Read[A]): Read[A] = readT
 
-  implicit val badReadString = new Read[String] {
+  implicit val badReadString: Read[String] = new Read[String] {
     override def read(str: String): String = ""
   }
 }

--- a/modules/ip4s/src/test/scala/pureconfig/module/ip4s/Ip4sTest.scala
+++ b/modules/ip4s/src/test/scala/pureconfig/module/ip4s/Ip4sTest.scala
@@ -16,7 +16,8 @@ import pureconfig.syntax._
 class Ip4sTest extends BaseSuite with Inside with LoneElement {
   // By default `minSuccessfull` set to 10 in `ScalaCheckDrivenPropertyChecks`.
   // It is way too small for tests to be robust and reliable. Set to 100, which is used by default in ScalaCheck.
-  implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
 
   // This generator is missing from `com.comcast.ip4s.Arbitraries` for some reason.
   private val hostGenerator: Gen[Host] =

--- a/modules/joda/src/test/scala/pureconfig/module/joda/arbitrary/package.scala
+++ b/modules/joda/src/test/scala/pureconfig/module/joda/arbitrary/package.scala
@@ -1,6 +1,6 @@
 package pureconfig.module.joda
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.joda.time._
 import org.scalacheck.{Arbitrary, Gen}

--- a/modules/magnolia/README.md
+++ b/modules/magnolia/README.md
@@ -23,7 +23,6 @@ The only thing needed to use Magnolia-based derivation is to replace the `pureco
 ```scala
 import pureconfig._
 import pureconfig.module.magnolia.auto.reader._
-import scala.language.higherKinds
 
 sealed trait MyAdt
 case class AdtA(a: String) extends MyAdt
@@ -73,5 +72,4 @@ certain types, writing configs and using semi-auto derivation. Please refer to t
 
 ## Differences in Behavior
 
-- Value classes that are not case classes are not supported (other value classes have the same reading behavior);
-- The Scala compiler may emit a warning unless `scala.language.higherKinds` is imported.
+- Value classes that are not case classes are not supported (other value classes have the same reading behavior).

--- a/modules/magnolia/docs/README.md
+++ b/modules/magnolia/docs/README.md
@@ -23,7 +23,6 @@ The only thing needed to use Magnolia-based derivation is to replace the `pureco
 ```scala mdoc:silent:reset-object
 import pureconfig._
 import pureconfig.module.magnolia.auto.reader._
-import scala.language.higherKinds
 
 sealed trait MyAdt
 case class AdtA(a: String) extends MyAdt
@@ -63,5 +62,4 @@ certain types, writing configs and using semi-auto derivation. Please refer to t
 
 ## Differences in Behavior
 
-- Value classes that are not case classes are not supported (other value classes have the same reading behavior);
-- The Scala compiler may emit a warning unless `scala.language.higherKinds` is imported.
+- Value classes that are not case classes are not supported (other value classes have the same reading behavior).

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/EnumerationConfigReaderBuilder.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/EnumerationConfigReaderBuilder.scala
@@ -59,5 +59,5 @@ object EnumerationConfigReaderBuilder {
         }
     }
 
-  implicit def export[A]: EnumerationConfigReaderBuilder[A] = macro Magnolia.gen[A]
+  implicit def `export`[A]: EnumerationConfigReaderBuilder[A] = macro Magnolia.gen[A]
 }

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/EnumerationConfigWriterBuilder.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/EnumerationConfigWriterBuilder.scala
@@ -37,5 +37,5 @@ object EnumerationConfigWriterBuilder {
         }
     }
 
-  implicit def export[A]: EnumerationConfigWriterBuilder[A] = macro Magnolia.gen[A]
+  implicit def `export`[A]: EnumerationConfigWriterBuilder[A] = macro Magnolia.gen[A]
 }

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/ExportedMagnolia.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/ExportedMagnolia.scala
@@ -1,6 +1,5 @@
 package pureconfig.module.magnolia
 
-import scala.language.higherKinds
 import scala.reflect.macros.whitebox
 
 import magnolia1.Magnolia

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/MagnoliaConfigWriter.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/MagnoliaConfigWriter.scala
@@ -1,7 +1,6 @@
 package pureconfig.module.magnolia
 
-import scala.collection.JavaConverters._
-import scala.reflect.ClassTag
+import scala.jdk.CollectionConverters._
 
 import _root_.magnolia1._
 import com.typesafe.config.{ConfigValue, ConfigValueFactory}
@@ -46,7 +45,7 @@ object MagnoliaConfigWriter {
         ctx.parameters.map { param => param.typeclass.to(param.dereference(a)) }.head
     }
 
-  def split[A: ClassTag](ctx: SealedTrait[ConfigWriter, A])(implicit hint: CoproductHint[A]): ConfigWriter[A] =
+  def split[A](ctx: SealedTrait[ConfigWriter, A])(implicit hint: CoproductHint[A]): ConfigWriter[A] =
     new ConfigWriter[A] {
       def to(a: A): ConfigValue =
         ctx.split(a) { subtype =>

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/auto/writer.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/auto/writer.scala
@@ -1,7 +1,6 @@
 package pureconfig.module.magnolia.auto
 
 import scala.language.experimental.macros
-import scala.reflect.ClassTag
 
 import magnolia1._
 
@@ -18,7 +17,7 @@ object writer {
   def join[A: ProductHint](ctx: CaseClass[ConfigWriter, A]): ConfigWriter[A] =
     MagnoliaConfigWriter.join(ctx)
 
-  def split[A: ClassTag: CoproductHint](ctx: SealedTrait[ConfigWriter, A]): ConfigWriter[A] =
+  def split[A: CoproductHint](ctx: SealedTrait[ConfigWriter, A]): ConfigWriter[A] =
     MagnoliaConfigWriter.split(ctx)
 
   implicit def exportWriter[A]: Exported[ConfigWriter[A]] = macro ExportedMagnolia.exportedMagnolia[ConfigWriter, A]

--- a/modules/magnolia/src/main/scala/pureconfig/module/magnolia/semiauto/writer.scala
+++ b/modules/magnolia/src/main/scala/pureconfig/module/magnolia/semiauto/writer.scala
@@ -1,7 +1,6 @@
 package pureconfig.module.magnolia.semiauto
 
 import scala.language.experimental.macros
-import scala.reflect.ClassTag
 
 import magnolia1._
 
@@ -18,7 +17,7 @@ object writer {
   def join[A: ProductHint](ctx: CaseClass[ConfigWriter, A]): ConfigWriter[A] =
     MagnoliaConfigWriter.join(ctx)
 
-  def split[A: ClassTag: CoproductHint](ctx: SealedTrait[ConfigWriter, A]): ConfigWriter[A] =
+  def split[A: CoproductHint](ctx: SealedTrait[ConfigWriter, A]): ConfigWriter[A] =
     MagnoliaConfigWriter.split(ctx)
 
   def deriveWriter[A]: ConfigWriter[A] = macro Magnolia.gen[A]

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/CoproductConvertersSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/CoproductConvertersSuite.scala
@@ -1,7 +1,5 @@
 package pureconfig.module.magnolia
 
-import scala.language.higherKinds
-
 import com.typesafe.config.{ConfigFactory, ConfigObject, ConfigValueFactory}
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -26,7 +24,7 @@ class CoproductConvertersSuite extends BaseSuite {
   val genCatConfig: Gen[CatConfig] = Arbitrary.arbInt.arbitrary.map(CatConfig.apply)
   val genDogConfig: Gen[DogConfig] = Arbitrary.arbInt.arbitrary.map(DogConfig.apply)
   val genAnimalConfig: Gen[AnimalConfig] = Gen.oneOf(genBirdConfig, genCatConfig, genDogConfig)
-  implicit val arbAnimalConfig = Arbitrary(genAnimalConfig)
+  implicit val arbAnimalConfig: Arbitrary[AnimalConfig] = Arbitrary(genAnimalConfig)
 
   checkArbitrary[AnimalConfig]
 

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/CoproductHintSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/CoproductHintSuite.scala
@@ -1,7 +1,5 @@
 package pureconfig.module.magnolia
 
-import scala.language.higherKinds
-
 import com.typesafe.config._
 
 import pureconfig._

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/DerivationModesSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/DerivationModesSuite.scala
@@ -1,7 +1,5 @@
 package pureconfig.module.magnolia
 
-import scala.language.higherKinds
-
 import com.typesafe.config.ConfigFactory
 import shapeless.test.illTyped
 

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/EnumerationsSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/EnumerationsSuite.scala
@@ -1,7 +1,5 @@
 package pureconfig.module.magnolia
 
-import scala.language.higherKinds
-
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory, ConfigValueType}
 import shapeless.test.illTyped
 

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/ProductHintSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/ProductHintSuite.scala
@@ -1,7 +1,6 @@
 package pureconfig.module.magnolia
 
-import scala.collection.JavaConverters._
-import scala.language.higherKinds
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{ConfigFactory, ConfigObject, ConfigValueType}
 

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/TupleConvertersSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/TupleConvertersSuite.scala
@@ -1,7 +1,6 @@
 package pureconfig.module.magnolia
 
-import scala.collection.JavaConverters._
-import scala.language.higherKinds
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{ConfigValueFactory, ConfigValueType}
 import org.scalacheck.Arbitrary

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/ValueClassSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/ValueClassSuite.scala
@@ -1,7 +1,5 @@
 package pureconfig.module.magnolia
 
-import scala.language.higherKinds
-
 import shapeless.test.illTyped
 
 import pureconfig._
@@ -30,7 +28,7 @@ trait Read[A] {
 object Read {
   def apply[A](implicit readT: Read[A]): Read[A] = readT
 
-  implicit val badReadString = new Read[String] {
+  implicit val badReadString: Read[String] = new Read[String] {
     override def read(str: String): String = ""
   }
 }

--- a/modules/scalaz/build.sbt
+++ b/modules/scalaz/build.sbt
@@ -5,8 +5,6 @@ libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-scalacheck-binding" % "7.3.8" % "test"
 )
 
-mdocScalacOptions += "-Ypartial-unification"
-
 developers := List(
   Developer("ChernikovP", "Pavel Chernikov", "chernikov.pavel92@gmail.com", url("https://github.com/ChernikovP"))
 )

--- a/modules/scalaz/src/test/scala/pureconfig/module/scalaz/arbitrary/package.scala
+++ b/modules/scalaz/src/test/scala/pureconfig/module/scalaz/arbitrary/package.scala
@@ -1,6 +1,6 @@
 package pureconfig.module.scalaz
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{ConfigValue, ConfigValueFactory}
 import org.scalacheck.Arbitrary.{arbitrary => arb}

--- a/modules/yaml/src/main/scala/pureconfig/module/yaml/YamlConfigSource.scala
+++ b/modules/yaml/src/main/scala/pureconfig/module/yaml/YamlConfigSource.scala
@@ -5,7 +5,7 @@ import java.net.{URI, URL}
 import java.nio.file.{Files, Path, Paths}
 import java.util.Base64
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 import scala.util.control.NonFatal
 

--- a/modules/yaml/src/main/scala/pureconfig/module/yaml/error/NonStringKeyFound.scala
+++ b/modules/yaml/src/main/scala/pureconfig/module/yaml/error/NonStringKeyFound.scala
@@ -1,8 +1,10 @@
 package pureconfig.module.yaml.error
 
+import com.typesafe.config.ConfigOrigin
+
 import pureconfig.error.ConfigReaderFailure
 
 case class NonStringKeyFound(value: String, keyType: String) extends ConfigReaderFailure {
   def description = s"Cannot read YAML key '$value' (with type $keyType). PureConfig only supports string keys."
-  def origin = None
+  def origin: Option[ConfigOrigin] = None
 }

--- a/modules/yaml/src/main/scala/pureconfig/module/yaml/error/UnsupportedYamlType.scala
+++ b/modules/yaml/src/main/scala/pureconfig/module/yaml/error/UnsupportedYamlType.scala
@@ -1,8 +1,10 @@
 package pureconfig.module.yaml.error
 
+import com.typesafe.config.ConfigOrigin
+
 import pureconfig.error.ConfigReaderFailure
 
 case class UnsupportedYamlType(value: String, keyType: String) extends ConfigReaderFailure {
   def description = s"Cannot read YAML value '$value' (with unsupported type $keyType)."
-  def origin = None
+  def origin: Option[ConfigOrigin] = None
 }

--- a/modules/zio-config/src/test/scala/pureconfig/module/zioconfig/ZioConfigSuite.scala
+++ b/modules/zio-config/src/test/scala/pureconfig/module/zioconfig/ZioConfigSuite.scala
@@ -1,7 +1,5 @@
 package pureconfig.module.zioconfig
 
-import scala.language.higherKinds
-
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.scalacheck.Arbitrary
 import zio.config.ConfigDescriptor._

--- a/testkit/src/main/scala/pureconfig/ConfigConvertChecks.scala
+++ b/testkit/src/main/scala/pureconfig/ConfigConvertChecks.scala
@@ -86,7 +86,7 @@ trait ConfigConvertChecks { this: AnyFlatSpec with Matchers with ScalaCheckDrive
   /** For each pair of value of type `A` and `ConfigValue`, check that `ConfigWriter[A].to` successfully converts the
     * former into the latter. Useful to test specific values
     */
-  def checkWrite[A: Equality](
+  def checkWrite[A](
       valuesToReprs: (A, ConfigValue)*
   )(implicit cw: ConfigWriter[A], tpe: TypeStringCompat[A]): Unit =
     for ((value, repr) <- valuesToReprs) {
@@ -96,7 +96,7 @@ trait ConfigConvertChecks { this: AnyFlatSpec with Matchers with ScalaCheckDrive
     }
 
   /** Similar to [[checkWrite]] but work on ConfigValues of type String */
-  def checkWriteString[A: ConfigWriter: TypeStringCompat: Equality](valuesToStrs: (A, String)*): Unit =
+  def checkWriteString[A: ConfigWriter: TypeStringCompat](valuesToStrs: (A, String)*): Unit =
     checkWrite[A](valuesToStrs.map { case (a, s) => a -> ConfigValueFactory.fromAnyRef(s) }: _*)
 
   /** For each pair of value of type `A` and `ConfigValue`, check that `ConfigReader[A].from` successfully converts the

--- a/testkit/src/main/scala/pureconfig/arbitrary/package.scala
+++ b/testkit/src/main/scala/pureconfig/arbitrary/package.scala
@@ -21,7 +21,7 @@ package object arbitrary {
   implicit val arbFiniteDuration: Arbitrary[FiniteDuration] = Arbitrary(genFiniteDuration)
   implicit val arbInstant: Arbitrary[Instant] = Arbitrary(genInstant)
   implicit val arbPeriod: Arbitrary[Period] = Arbitrary(genPeriod)
-  implicit val arbChronoUnit: Arbitrary[ChronoUnit] = Arbitrary(Gen.oneOf(ChronoUnit.values()))
+  implicit val arbChronoUnit: Arbitrary[ChronoUnit] = Arbitrary(Gen.oneOf(ChronoUnit.values().toSeq))
   implicit val arbYear: Arbitrary[Year] = Arbitrary(genYear)
   implicit val arbUUID: Arbitrary[UUID] = Arbitrary(Gen.uuid)
   implicit val arbPath: Arbitrary[Path] = Arbitrary(genPath)

--- a/testkit/src/main/scala/pureconfig/gen/package.scala
+++ b/testkit/src/main/scala/pureconfig/gen/package.scala
@@ -6,8 +6,8 @@ import java.nio.file.{Path, Paths}
 import java.time._
 import java.time.{Duration => JavaDuration}
 
-import scala.collection.JavaConverters._
 import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.jdk.CollectionConverters._
 
 import org.scalacheck.{Arbitrary, Gen}
 

--- a/tests/src/test/scala-3/pureconfig/CoproductReaderDerivationSuite.scala
+++ b/tests/src/test/scala-3/pureconfig/CoproductReaderDerivationSuite.scala
@@ -1,7 +1,5 @@
 package pureconfig
 
-import scala.language.higherKinds
-
 import com.typesafe.config.ConfigFactory
 
 import pureconfig._

--- a/tests/src/test/scala-3/pureconfig/EnumerationConvertDerivationSuite.scala
+++ b/tests/src/test/scala-3/pureconfig/EnumerationConvertDerivationSuite.scala
@@ -2,7 +2,6 @@ package pureconfig
 
 import scala.compiletime.testing.{typeCheckErrors, typeChecks}
 import scala.deriving.Mirror
-import scala.language.higherKinds
 
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory, ConfigValueType}
 

--- a/tests/src/test/scala-3/pureconfig/ProductReaderDerivationSuite.scala
+++ b/tests/src/test/scala-3/pureconfig/ProductReaderDerivationSuite.scala
@@ -1,7 +1,6 @@
 package pureconfig
 
 import scala.collection.JavaConverters.given
-import scala.language.higherKinds
 
 import com.typesafe.config.{ConfigFactory, ConfigRenderOptions, ConfigValueFactory}
 import org.scalacheck.Arbitrary

--- a/tests/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/tests/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -9,8 +9,8 @@ import java.time.{Duration => JavaDuration, _}
 import java.util.UUID
 import java.util.regex.Pattern
 
-import scala.collection.JavaConverters._
 import scala.concurrent.duration.{Duration, FiniteDuration, _}
+import scala.jdk.CollectionConverters._
 import scala.util.matching.Regex
 
 import com.typesafe.config._
@@ -21,7 +21,8 @@ import pureconfig.equality._
 import pureconfig.error._
 
 class BasicConvertersSuite extends BaseSuite {
-  implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
 
   behavior of "ConfigConvert"
 

--- a/tests/src/test/scala/pureconfig/CollectionConvertersSuite.scala
+++ b/tests/src/test/scala/pureconfig/CollectionConvertersSuite.scala
@@ -1,14 +1,15 @@
 package pureconfig
 
-import scala.collection.JavaConverters._
 import scala.collection.immutable.{HashSet, ListSet, Queue, TreeSet}
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory, ConfigValueType}
 
 import pureconfig.error.{ConfigReaderFailures, ConvertFailure, WrongType}
 
 class CollectionConvertersSuite extends BaseSuite {
-  implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
 
   behavior of "ConfigConvert"
 
@@ -50,7 +51,7 @@ class CollectionConvertersSuite extends BaseSuite {
   checkArbitrary[Set[Double]]
   checkRead[Set[Int]](ConfigValueFactory.fromMap(Map("1" -> 4, "2" -> 5, "3" -> 6).asJava) -> Set(4, 5, 6))
 
-  checkArbitrary[Stream[String]]
+  checkArbitrary[LazyList[String]]
 
   checkArbitrary[TreeSet[Int]]
 

--- a/tests/src/test/scala/pureconfig/ConfigConvertSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigConvertSuite.scala
@@ -7,7 +7,8 @@ import pureconfig.ConfigConvertSuite._
 import pureconfig.error.{CannotConvert, ExceptionThrown, WrongType}
 
 class ConfigConvertSuite extends BaseSuite {
-  implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
 
   val intConvert = ConfigConvert[Int]
 

--- a/tests/src/test/scala/pureconfig/ConfigCursorSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigCursorSuite.scala
@@ -209,7 +209,7 @@ class ConfigCursorSuite extends BaseSuite {
   behavior of "ConfigListCursor"
 
   def listCursor(confStr: String, pathElems: List[String] = defaultPath): ConfigListCursor =
-    cursor(confStr, pathElems).asListCursor.right.get
+    cursor(confStr, pathElems).asListCursor.toOption.get
 
   it should "have correct isEmpty and size methods" in {
     listCursor("[1, 2]").isEmpty shouldBe false
@@ -250,7 +250,7 @@ class ConfigCursorSuite extends BaseSuite {
   behavior of "ConfigObjectCursor"
 
   def objCursor(confStr: String, pathElems: List[String] = defaultPath): ConfigObjectCursor =
-    cursor(confStr, pathElems).asObjectCursor.right.get
+    cursor(confStr, pathElems).asObjectCursor.toOption.get
 
   it should "have correct isEmpty and size methods" in {
     objCursor("{ a: 1, b: 2 }").isEmpty shouldBe false

--- a/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigReaderSuite.scala
@@ -6,7 +6,8 @@ import org.scalacheck.{Arbitrary, Gen}
 import pureconfig.error._
 
 class ConfigReaderSuite extends BaseSuite {
-  implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
 
   val intReader = ConfigReader[Int]
   val strReader = ConfigReader[String]

--- a/tests/src/test/scala/pureconfig/ConfigWriterSuite.scala
+++ b/tests/src/test/scala/pureconfig/ConfigWriterSuite.scala
@@ -3,7 +3,8 @@ package pureconfig
 import com.typesafe.config.{ConfigFactory, ConfigValue}
 
 class ConfigWriterSuite extends BaseSuite {
-  implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
 
   val intWriter = ConfigWriter[Int]
 

--- a/tests/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
+++ b/tests/src/test/scala/pureconfig/configurable/ConfigurableSuite.scala
@@ -12,7 +12,8 @@ import pureconfig.syntax._
 import pureconfig.{BaseSuite, ConfigConvert, ConfigReader, ConfigWriter}
 
 class ConfigurableSuite extends BaseSuite {
-  implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 100)
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
 
   behavior of "configurable converters"
 


### PR DESCRIPTION
We couldn't fix a lot of these warnings before due to the need to keep source code compatible with Scala 2.12. Now that we dropped Scala 2.12, it's time to clean up code.

Besides fixing existing warnings, on this PR I'm also modifying some scalac options to issue more of them (e.g. adding `-deprecation`, removing `-Ywarn-unused:-implicits` in favor of explicit `@unused` annotations, `-Xsource:3` to warn about behavioral differences with Scala 3).

I fixed all `-Xsource:3` issues in mdoc snippets as well (as they're being flagged as errors), but I haven't fixed all warnings there as code simplicity and conciseness is generally more important for documentation.