### PR TITLE
Ignore StackOverflow URLs when checking PureConfig website

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           --no-check-external-hash
           --swap-urls "https\://github\.com/pureconfig/pureconfig/tree/master:file\://$(pwd)"
           --ignore-urls "/search.maven.org/"
+          --ignore-urls "/stackoverflow.com/"
           docs/target/site
 
   diff_website:


### PR DESCRIPTION
The latest dependency PRs have all been failing CI because htmlproofer can't fetch a StackOverflow link in the website. This has been the case for a while, so it doesn't seem transient - SO likely implemented anti-scraping measures affecting GitHub Actions.

The SO question still seems relevant, so I think we should just exclude stackoverflow.com from liveness checks in CI.
