### PR TITLE
Prepare publishing to Sonatype Central Portal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,11 @@ lazy val commonSettings = Seq(
 
   publishMavenStyle := true,
   Test / publishArtifact := false,
-  publishTo := sonatypePublishToBundle.value,
+  publishTo := {
+    val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
+    if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
+    else localStaging.value
+  },
   // format: on
 )
 
@@ -194,7 +198,7 @@ releaseProcess := Seq[ReleaseStep](
   commitReleaseVersion,
   tagRelease,
   releaseStepCommandAndRemaining("+publishSigned"),
-  releaseStepCommand("sonatypeBundleRelease"),
+  releaseStepCommand("sonaRelease"),
   setNextVersion,
   commitNextVersion,
   pushChanges

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,6 @@ addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.7.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
 
 libraryDependencies += "org.slf4j" % "slf4j-simple" % "2.0.17"
 


### PR DESCRIPTION
This prepares the publishing settings so that we can start pushing artifacts to [Sonatype Central Portal](https://central.sonatype.com/). I have already migrated the com.github.pureconfig namespace to the Central Portal and published a snapshot of PureConfig there. sbt-sonatype has been removed since [sbt 1.11.0](https://github.com/sbt/sbt/releases/tag/v1.11.0) already supports central repository publishing.

I have used similar settings to publish [a test project of mine](https://github.com/jcazevedo/sonatype-central-scala/blob/main/build.sbt) to the Central Portal. Note that publishers need to generate [a user token](https://central.sonatype.com/account) and use that instead of the existing username and password.