### PR TITLE
Rid of deprecated URL constructor

### DIFF
--- a/core/src/main/scala/pureconfig/BasicReaders.scala
+++ b/core/src/main/scala/pureconfig/BasicReaders.scala
@@ -75,7 +75,8 @@ trait JavaEnumReader {
   */
 trait UriAndPathReaders {
 
-  implicit val urlConfigReader: ConfigReader[URL] = ConfigReader.fromNonEmptyString[URL](catchReadError(new URL(_)))
+  implicit val urlConfigReader: ConfigReader[URL] =
+    ConfigReader.fromNonEmptyString[URL](catchReadError(new URI(_).toURL()))
   implicit val uuidConfigReader: ConfigReader[UUID] =
     ConfigReader.fromNonEmptyString[UUID](catchReadError(UUID.fromString))
   implicit val pathConfigReader: ConfigReader[Path] = ConfigReader.fromString[Path](catchReadError(Paths.get(_)))

--- a/tests/src/test/scala/pureconfig/BasicConvertersSuite.scala
+++ b/tests/src/test/scala/pureconfig/BasicConvertersSuite.scala
@@ -162,7 +162,7 @@ class BasicConvertersSuite extends BaseSuite {
   checkReadWriteString[Regex]("(a|b)" -> new Regex("(a|b)"))
   checkFailure[Regex, CannotConvert](ConfigValueFactory.fromAnyRef("(a|b")) // missing closing ')'
 
-  checkReadWriteString[URL]("http://host/path?with=query&param" -> new URL("http://host/path?with=query&param"))
+  checkReadWriteString[URL]("http://host/path?with=query&param" -> new URI("http://host/path?with=query&param").toURL())
 
   checkReadWriteString[URI]("http://host/path?with=query&param" -> new URI("http://host/path?with=query&param"))
 


### PR DESCRIPTION
`java.net.URL` constructors are [officially deprecated](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/net/URL.html#constructor-summary) since JDK 20.
The recommended way to create `URL` is via `URI`:
```
new URI("https://github.com").toURL()
```
