### PR TITLE
Fix semiauto derivation

### DIFF
--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/AnyValDerivationMacros.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/AnyValDerivationMacros.scala
@@ -10,9 +10,8 @@ private[scala3] object AnyValDerivationMacros {
 
   /** Derive a `ConfigReader` for a value class. Can only be called after checking that `A` is a value class.
     */
-  inline def unsafeDeriveAnyValReader[A](using inline df: DerivationFlow): ConfigReader[A] = ${
-    deriveAnyValReaderImpl[A]('df)
-  }
+  inline def unsafeDeriveAnyValReader[A](using inline df: DerivationFlow): ConfigReader[A] =
+    ${ deriveAnyValReaderImpl[A]('df) }
 
   private def deriveAnyValReaderImpl[A: Type](df: Expr[DerivationFlow])(using Quotes): Expr[ConfigReader[A]] = {
     import quotes.reflect._
@@ -39,9 +38,10 @@ private[scala3] object AnyValDerivationMacros {
 
   /** Derive a `ConfigWriter` for a value class. Can only be called after checking that `A` is a value class.
     */
-  inline def unsafeDeriveAnyValWriter[A]: ConfigWriter[A] = ${ deriveAnyValWriterImpl[A] }
+  inline def unsafeDeriveAnyValWriter[A](using inline df: DerivationFlow): ConfigWriter[A] =
+    ${ deriveAnyValWriterImpl[A]('df) }
 
-  private def deriveAnyValWriterImpl[A: Type](using Quotes): Expr[ConfigWriter[A]] = {
+  private def deriveAnyValWriterImpl[A: Type](df: Expr[DerivationFlow])(using Quotes): Expr[ConfigWriter[A]] = {
     import quotes.reflect._
 
     val wrapperTypeRepr = TypeRepr.of[A]
@@ -59,7 +59,7 @@ private[scala3] object AnyValDerivationMacros {
             .asExprOf[t]
 
         '{
-          HintsAwareConfigWriterDerivation.summonConfigWriter[t].contramap[A](a => ${ unwrap('a) })
+          HintsAwareConfigWriterDerivation.summonConfigWriter[t](using $df).contramap[A](a => ${ unwrap('a) })
         }
     }
   }

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/AnyValDerivationMacros.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/AnyValDerivationMacros.scala
@@ -10,9 +10,11 @@ private[scala3] object AnyValDerivationMacros {
 
   /** Derive a `ConfigReader` for a value class. Can only be called after checking that `A` is a value class.
     */
-  inline def unsafeDeriveAnyValReader[A]: ConfigReader[A] = ${ deriveAnyValReaderImpl[A] }
+  inline def unsafeDeriveAnyValReader[A](using inline df: DerivationFlow): ConfigReader[A] = ${
+    deriveAnyValReaderImpl[A]('df)
+  }
 
-  private def deriveAnyValReaderImpl[A: Type](using Quotes): Expr[ConfigReader[A]] = {
+  private def deriveAnyValReaderImpl[A: Type](df: Expr[DerivationFlow])(using Quotes): Expr[ConfigReader[A]] = {
     import quotes.reflect._
 
     val wrapperTypeRepr = TypeRepr.of[A]
@@ -30,7 +32,7 @@ private[scala3] object AnyValDerivationMacros {
             .asExprOf[A]
 
         '{
-          HintsAwareConfigReaderDerivation.summonConfigReader[t].map(a => ${ wrap('a) })
+          HintsAwareConfigReaderDerivation.summonConfigReader[t](using $df).map(a => ${ wrap('a) })
         }
     }
   }

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
@@ -1,14 +1,14 @@
 package pureconfig.generic.scala3
 
 /** Context of macro derivation.
- *
- * An instance of this class is intended to be passed as an inline parameter, with the compiler knowing the precise values of all
- * fields
- *
- * @param allowAutoSum
- * If true, auto derivation of enums and sealed traits is currently allowed, because we are deriving an instance for a
- *   top-level union
- */
+  *
+  * An instance of this class is intended to be passed as an inline parameter, with the compiler knowing the precise
+  * values of all fields
+  *
+  * @param allowAutoSum
+  *   If true, auto derivation of enums and sealed traits is currently allowed, because we are deriving an instance for
+  *   a top-level union
+  */
 class DerivationFlow(val allowAutoSum: Boolean)
 
 object DerivationFlow {

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
@@ -5,11 +5,9 @@ package pureconfig.generic.scala3
   * Instance of this class is intended to be passed as an inline paramter, with compiler knowing precise values of all
   * fields
   *
-  * @param auto
-  *   if true, full auto derivation is allowed
   * @param allowAutoSum
-  *   if true, auto derivation if enums and sealed traits is currently allowed, either because auto = true or we are
-  *   deriving an instance for a top-level union, that was requested in the derivation macro
+  *   if true, auto derivation of enums and sealed traits is currently allowed, becausewe are deriving an instance for a
+  *   top-level union
   */
 class DerivationFlow(val allowAutoSum: Boolean)
 

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
@@ -1,14 +1,14 @@
 package pureconfig.generic.scala3
 
 /** Context of macro derivation.
-  *
-  * Instance of this class is intended to be passed as an inline paramter, with compiler knowing precise values of all
-  * fields
-  *
-  * @param allowAutoSum
-  *   if true, auto derivation of enums and sealed traits is currently allowed, becausewe are deriving an instance for a
-  *   top-level union
-  */
+ *
+ * An instance of this class is intended to be passed as an inline parameter, with the compiler knowing the precise values of all
+ * fields
+ *
+ * @param allowAutoSum
+ * If true, auto derivation of enums and sealed traits is currently allowed, because we are deriving an instance for a
+ *   top-level union
+ */
 class DerivationFlow(val allowAutoSum: Boolean)
 
 object DerivationFlow {

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
@@ -1,9 +1,12 @@
 package pureconfig.generic.scala3
 
-class DerivationFlow(val fallthroughUnions: Boolean) {
-  inline def noFallthoughUnions: DerivationFlow = DerivationFlow(fallthroughUnions = false)
-}
+class DerivationFlow(val auto: Boolean, val allowAutoUnion: Boolean)
 
 object DerivationFlow {
-  inline def default = DerivationFlow(fallthroughUnions = true)
+  inline def auto = DerivationFlow(auto = true, allowAutoUnion = true)
+  inline def semiauto = DerivationFlow(auto = false, allowAutoUnion = true)
+  extension (inline df: DerivationFlow) {
+    inline def throughProduct: DerivationFlow =
+      DerivationFlow(auto = df.auto, allowAutoUnion = df.auto)
+  }
 }

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
@@ -1,6 +1,9 @@
 package pureconfig.generic.scala3
 
-/** Context of macro derivation
+/** Context of macro derivation.
+  *
+  * Instance of this class is intended to be passed as an inline paramter, with compiler knowing precise values of all
+  * fields
   *
   * @param auto
   *   if true, full auto derivation is allowed

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
@@ -11,13 +11,11 @@ package pureconfig.generic.scala3
   *   if true, auto derivation if enums and sealed traits is currently allowed, either because auto = true or we are
   *   deriving an instance for a top-level union, that was requested in the derivation macro
   */
-class DerivationFlow(val auto: Boolean, val allowAutoSum: Boolean)
+class DerivationFlow(val allowAutoSum: Boolean)
 
 object DerivationFlow {
-  inline def auto = DerivationFlow(auto = true, allowAutoSum = true)
-  inline def semiauto = DerivationFlow(auto = false, allowAutoSum = true)
+  inline def default = DerivationFlow(allowAutoSum = true)
   extension (inline df: DerivationFlow) {
-    inline def throughProduct: DerivationFlow =
-      DerivationFlow(auto = df.auto, allowAutoSum = df.auto)
+    inline def throughProduct: DerivationFlow = DerivationFlow(allowAutoSum = false)
   }
 }

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
@@ -4,17 +4,17 @@ package pureconfig.generic.scala3
   *
   * @param auto
   *   if true, full auto derivation is allowed
-  * @param allowAutoUnion
+  * @param allowAutoSum
   *   if true, auto derivation if enums and sealed traits is currently allowed, either because auto = true or we are
   *   deriving an instance for a top-level union, that was requested in the derivation macro
   */
-class DerivationFlow(val auto: Boolean, val allowAutoUnion: Boolean)
+class DerivationFlow(val auto: Boolean, val allowAutoSum: Boolean)
 
 object DerivationFlow {
-  inline def auto = DerivationFlow(auto = true, allowAutoUnion = true)
-  inline def semiauto = DerivationFlow(auto = false, allowAutoUnion = true)
+  inline def auto = DerivationFlow(auto = true, allowAutoSum = true)
+  inline def semiauto = DerivationFlow(auto = false, allowAutoSum = true)
   extension (inline df: DerivationFlow) {
     inline def throughProduct: DerivationFlow =
-      DerivationFlow(auto = df.auto, allowAutoUnion = df.auto)
+      DerivationFlow(auto = df.auto, allowAutoSum = df.auto)
   }
 }

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
@@ -1,0 +1,9 @@
+package pureconfig.generic.scala3
+
+class DerivationFlow(val fallthroughUnions: Boolean) {
+  inline def noFallthoughUnions: DerivationFlow = DerivationFlow(fallthroughUnions = false)
+}
+
+object DerivationFlow {
+  inline def default = DerivationFlow(fallthroughUnions = true)
+}

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/DerivationFlow.scala
@@ -1,5 +1,13 @@
 package pureconfig.generic.scala3
 
+/** Context of macro derivation
+  *
+  * @param auto
+  *   if true, full auto derivation is allowed
+  * @param allowAutoUnion
+  *   if true, auto derivation if enums and sealed traits is currently allowed, either because auto = true or we are
+  *   deriving an instance for a top-level union, that was requested in the derivation macro
+  */
 class DerivationFlow(val auto: Boolean, val allowAutoUnion: Boolean)
 
 object DerivationFlow {

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigReaderDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigReaderDerivation.scala
@@ -31,7 +31,7 @@ trait HintsAwareConfigReaderDerivation
 
   private inline def deriveReaderWithMirror[A](using m: Mirror.Of[A], inline df: DerivationFlow): ConfigReader[A] =
     inline m match {
-      case pm: Mirror.ProductOf[A] => deriveProductReader[A](using pm, summonInline[ProductHint[A]])
+      case pm: Mirror.ProductOf[A] => deriveProductReader[A](using pm, summonInline[ProductHint[A]], df.throughProduct)
       case sm: Mirror.SumOf[A] if df.allowAutoUnion => deriveSumReader[A](using sm, summonInline[CoproductHint[A]])
       case _ => error("Cannot derive ConfigReader for " + typeName[A])
     }

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigReaderDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigReaderDerivation.scala
@@ -32,7 +32,7 @@ trait HintsAwareConfigReaderDerivation
   private inline def deriveReaderWithMirror[A](using m: Mirror.Of[A], inline df: DerivationFlow): ConfigReader[A] =
     inline m match {
       case pm: Mirror.ProductOf[A] => deriveProductReader[A](using pm, summonInline[ProductHint[A]], df.throughProduct)
-      case sm: Mirror.SumOf[A] if df.allowAutoUnion => deriveSumReader[A](using sm, summonInline[CoproductHint[A]])
+      case sm: Mirror.SumOf[A] if df.allowAutoSum => deriveSumReader[A](using sm, summonInline[CoproductHint[A]])
       case _ => error("Cannot derive ConfigReader for " + typeName[A])
     }
 

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigReaderDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigReaderDerivation.scala
@@ -12,24 +12,24 @@ trait HintsAwareConfigReaderDerivation
       HintsAwareProductConfigReaderDerivation {
   inline def deriveReader[A]: ConfigReader[A] =
     summonFrom {
-      case given Mirror.Of[A] => deriveReaderWithMirror[A]
-      case _ => deriveAnyValOrFail[A]
+      case ma: Mirror.Of[A] => deriveReaderWithMirror[A](using ma, DerivationFlow.default)
+      case _ => deriveAnyValOrFail[A](using DerivationFlow.default)
     }
 
-  private[scala3] inline def summonConfigReader[A]: ConfigReader[A] =
+  private[scala3] inline def summonConfigReader[A](using inline df: DerivationFlow): ConfigReader[A] =
     summonFrom {
       case reader: ConfigReader[A] => reader
-      case given Mirror.Of[A] => deriveReaderWithMirror[A]
+      case given Mirror.Of[A] if df.fallthroughUnions => deriveReaderWithMirror[A]
       case _ => deriveAnyValOrFail[A]
     }
 
-  private inline def deriveReaderWithMirror[A](using m: Mirror.Of[A]): ConfigReader[A] =
+  private inline def deriveReaderWithMirror[A](using m: Mirror.Of[A], inline df: DerivationFlow): ConfigReader[A] =
     inline m match {
       case pm: Mirror.ProductOf[A] => deriveProductReader[A](using pm, summonInline[ProductHint[A]])
       case sm: Mirror.SumOf[A] => deriveSumReader[A](using sm, summonInline[CoproductHint[A]])
     }
 
-  private inline def deriveAnyValOrFail[A]: ConfigReader[A] =
+  private inline def deriveAnyValOrFail[A](using inline df: DerivationFlow): ConfigReader[A] =
     inline if (AnyValDerivationMacros.isAnyVal[A]) AnyValDerivationMacros.unsafeDeriveAnyValReader[A]
     else error("Cannot derive ConfigReader for " + typeName[A])
 

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigReaderDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigReaderDerivation.scala
@@ -12,27 +12,33 @@ trait HintsAwareConfigReaderDerivation
       HintsAwareProductConfigReaderDerivation {
   inline def deriveReader[A]: ConfigReader[A] =
     summonFrom {
-      case ma: Mirror.Of[A] => deriveReaderWithMirror[A](using ma, DerivationFlow.default)
-      case _ => deriveAnyValOrFail[A](using DerivationFlow.default)
+      case ma: Mirror.Of[A] => deriveReaderWithMirror[A](using ma, DerivationFlow.auto)
+      case _ => deriveAnyValOrFail[A](using DerivationFlow.auto)
+    }
+
+  inline def deriveReaderSemiauto[A]: ConfigReader[A] =
+    summonFrom {
+      case ma: Mirror.Of[A] => deriveReaderWithMirror[A](using ma, DerivationFlow.semiauto)
+      case _ => deriveAnyValOrFail[A](using DerivationFlow.semiauto)
     }
 
   private[scala3] inline def summonConfigReader[A](using inline df: DerivationFlow): ConfigReader[A] =
     summonFrom {
       case reader: ConfigReader[A] => reader
-      case given Mirror.Of[A] if df.fallthroughUnions => deriveReaderWithMirror[A]
+      case given Mirror.Of[A] => deriveReaderWithMirror[A]
       case _ => deriveAnyValOrFail[A]
     }
 
   private inline def deriveReaderWithMirror[A](using m: Mirror.Of[A], inline df: DerivationFlow): ConfigReader[A] =
     inline m match {
       case pm: Mirror.ProductOf[A] => deriveProductReader[A](using pm, summonInline[ProductHint[A]])
-      case sm: Mirror.SumOf[A] => deriveSumReader[A](using sm, summonInline[CoproductHint[A]])
+      case sm: Mirror.SumOf[A] if df.allowAutoUnion => deriveSumReader[A](using sm, summonInline[CoproductHint[A]])
+      case _ => error("Cannot derive ConfigReader for " + typeName[A])
     }
 
   private inline def deriveAnyValOrFail[A](using inline df: DerivationFlow): ConfigReader[A] =
     inline if (AnyValDerivationMacros.isAnyVal[A]) AnyValDerivationMacros.unsafeDeriveAnyValReader[A]
     else error("Cannot derive ConfigReader for " + typeName[A])
-
 }
 
 object HintsAwareConfigReaderDerivation extends HintsAwareConfigReaderDerivation

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigReaderDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigReaderDerivation.scala
@@ -12,14 +12,8 @@ trait HintsAwareConfigReaderDerivation
       HintsAwareProductConfigReaderDerivation {
   inline def deriveReader[A]: ConfigReader[A] =
     summonFrom {
-      case ma: Mirror.Of[A] => deriveReaderWithMirror[A](using ma, DerivationFlow.auto)
-      case _ => deriveAnyValOrFail[A](using DerivationFlow.auto)
-    }
-
-  inline def deriveReaderSemiauto[A]: ConfigReader[A] =
-    summonFrom {
-      case ma: Mirror.Of[A] => deriveReaderWithMirror[A](using ma, DerivationFlow.semiauto)
-      case _ => deriveAnyValOrFail[A](using DerivationFlow.semiauto)
+      case ma: Mirror.Of[A] => deriveReaderWithMirror[A](using ma, DerivationFlow.default)
+      case _ => deriveAnyValOrFail[A](using DerivationFlow.default)
     }
 
   private[scala3] inline def summonConfigReader[A](using inline df: DerivationFlow): ConfigReader[A] =

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigWriterDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigWriterDerivation.scala
@@ -12,14 +12,8 @@ trait HintsAwareConfigWriterDerivation
       HintsAwareProductConfigWriterDerivation {
   inline def deriveWriter[A]: ConfigWriter[A] =
     summonFrom {
-      case ma: Mirror.Of[A] => deriveWriterWithMirror[A](using ma, DerivationFlow.auto)
-      case _ => deriveAnyValOrFail[A](using DerivationFlow.auto)
-    }
-
-  inline def deriveWriterSemiauto[A]: ConfigWriter[A] =
-    summonFrom {
-      case ma: Mirror.Of[A] => deriveWriterWithMirror[A](using ma, DerivationFlow.semiauto)
-      case _ => deriveAnyValOrFail[A](using DerivationFlow.semiauto)
+      case ma: Mirror.Of[A] => deriveWriterWithMirror[A](using ma, DerivationFlow.default)
+      case _ => deriveAnyValOrFail[A](using DerivationFlow.default)
     }
 
   private[scala3] inline def summonConfigWriter[A](using inline df: DerivationFlow): ConfigWriter[A] =

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigWriterDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareConfigWriterDerivation.scala
@@ -32,7 +32,7 @@ trait HintsAwareConfigWriterDerivation
   private inline def deriveWriterWithMirror[A](using m: Mirror.Of[A], inline df: DerivationFlow): ConfigWriter[A] =
     inline m match {
       case pm: Mirror.ProductOf[A] => deriveProductWriter[A](using pm, summonInline[ProductHint[A]], df.throughProduct)
-      case sm: Mirror.SumOf[A] if df.allowAutoUnion => deriveSumWriter[A](using sm, summonInline[CoproductHint[A]])
+      case sm: Mirror.SumOf[A] if df.allowAutoSum => deriveSumWriter[A](using sm, summonInline[CoproductHint[A]])
       case _ => error("Cannot derive ConfigWriter for: " + typeName[A])
     }
 

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareCoproductConfigReaderDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareCoproductConfigReaderDerivation.scala
@@ -10,7 +10,11 @@ import pureconfig.generic.derivation.Utils
 import pureconfig.generic.error.InvalidCoproductOption
 
 trait HintsAwareCoproductConfigReaderDerivation { self: HintsAwareConfigReaderDerivation =>
-  inline def deriveSumReader[A](using cm: Mirror.SumOf[A], cph: CoproductHint[A]): ConfigReader[A] =
+  inline def deriveSumReader[A](using
+      cm: Mirror.SumOf[A],
+      cph: CoproductHint[A],
+      inline df: DerivationFlow
+  ): ConfigReader[A] =
     new ConfigReader[A] {
       val labels = Utils.transformedLabels(identity)
       val readers = labels.zip(summonAllConfigReaders[cm.MirroredElemTypes, A]).toMap
@@ -45,7 +49,7 @@ trait HintsAwareCoproductConfigReaderDerivation { self: HintsAwareConfigReaderDe
           }
     }
 
-  private inline def summonAllConfigReaders[T <: Tuple, A]: List[ConfigReader[A]] =
+  private inline def summonAllConfigReaders[T <: Tuple, A](using inline df: DerivationFlow): List[ConfigReader[A]] =
     inline erasedValue[T] match {
       case _: (h *: t) =>
         (summonConfigReader[h] :: summonAllConfigReaders[t, A]).asInstanceOf[List[ConfigReader[A]]]

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareCoproductConfigWriterDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareCoproductConfigWriterDerivation.scala
@@ -10,7 +10,11 @@ import com.typesafe.config.ConfigValue
 import pureconfig.generic.derivation.Utils
 
 trait HintsAwareCoproductConfigWriterDerivation { self: HintsAwareConfigWriterDerivation =>
-  inline def deriveSumWriter[A](using m: Mirror.SumOf[A], ch: CoproductHint[A]): ConfigWriter[A] =
+  inline def deriveSumWriter[A](using
+      m: Mirror.SumOf[A],
+      ch: CoproductHint[A],
+      inline df: DerivationFlow
+  ): ConfigWriter[A] =
     new ConfigWriter[A] {
       val labels = Utils.transformedLabels(identity).toVector
       val writers = summonAllConfigWriters[m.MirroredElemTypes].toVector
@@ -24,7 +28,7 @@ trait HintsAwareCoproductConfigWriterDerivation { self: HintsAwareConfigWriterDe
       }
     }
 
-  private inline def summonAllConfigWriters[T <: Tuple]: List[ConfigWriter[?]] =
+  private inline def summonAllConfigWriters[T <: Tuple](using inline df: DerivationFlow): List[ConfigWriter[?]] =
     inline erasedValue[T] match {
       case _: (h *: t) => summonConfigWriter[h] :: summonAllConfigWriters[t]
       case _: EmptyTuple => Nil

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigReaderDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigReaderDerivation.scala
@@ -15,7 +15,11 @@ import pureconfig.generic.derivation.Utils.widen
 import ProductDerivationMacros._
 
 trait HintsAwareProductConfigReaderDerivation { self: HintsAwareConfigReaderDerivation =>
-  inline def deriveProductReader[A](using pm: Mirror.ProductOf[A], ph: ProductHint[A]): ConfigReader[A] =
+  inline def deriveProductReader[A](using
+      pm: Mirror.ProductOf[A],
+      ph: ProductHint[A],
+      inline df: DerivationFlow
+  ): ConfigReader[A] =
     inline erasedValue[A] match {
       case _: Tuple =>
         new ConfigReader[A] {
@@ -57,7 +61,7 @@ trait HintsAwareProductConfigReaderDerivation { self: HintsAwareConfigReaderDeri
       labels: Vector[String],
       actions: Map[String, ProductHint.Action],
       defaults: Vector[DefaultValue]
-  ): Either[ConfigReaderFailures, T] =
+  )(using inline df: DerivationFlow): Either[ConfigReaderFailures, T] =
     inline erasedValue[T] match {
       case _: (h *: t) =>
         val n = constValue[N]
@@ -92,7 +96,9 @@ trait HintsAwareProductConfigReaderDerivation { self: HintsAwareConfigReaderDeri
         Right(widen[EmptyTuple, T](EmptyTuple))
     }
 
-  private inline def readTuple[T <: Tuple, N <: Int](cursors: Vector[ConfigCursor]): Either[ConfigReaderFailures, T] =
+  private inline def readTuple[T <: Tuple, N <: Int](
+      cursors: Vector[ConfigCursor]
+  )(using inline df: DerivationFlow): Either[ConfigReaderFailures, T] =
     inline erasedValue[T] match {
       case _: (h *: t) =>
         val n = constValue[N]

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigReaderDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigReaderDerivation.scala
@@ -65,7 +65,7 @@ trait HintsAwareProductConfigReaderDerivation { self: HintsAwareConfigReaderDeri
     inline erasedValue[T] match {
       case _: (h *: t) =>
         val n = constValue[N]
-        lazy val reader = summonConfigReader[h]
+        lazy val reader = summonConfigReader[h](using df.throughProduct)
         val default = defaults(n)
         val label = labels(n)
         val fieldHint = actions(label)

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigReaderDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigReaderDerivation.scala
@@ -65,7 +65,7 @@ trait HintsAwareProductConfigReaderDerivation { self: HintsAwareConfigReaderDeri
     inline erasedValue[T] match {
       case _: (h *: t) =>
         val n = constValue[N]
-        lazy val reader = summonConfigReader[h](using df.throughProduct)
+        lazy val reader = summonConfigReader[h]
         val default = defaults(n)
         val label = labels(n)
         val fieldHint = actions(label)

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigWriterDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigWriterDerivation.scala
@@ -14,7 +14,11 @@ import pureconfig.generic.derivation.Utils
 
 trait HintsAwareProductConfigWriterDerivation { self: HintsAwareConfigWriterDerivation =>
 
-  inline def deriveProductWriter[A](using pm: Mirror.ProductOf[A], ph: ProductHint[A]): ConfigWriter[A] =
+  inline def deriveProductWriter[A](using
+      pm: Mirror.ProductOf[A],
+      ph: ProductHint[A],
+      inline df: DerivationFlow
+  ): ConfigWriter[A] =
     inline erasedValue[A] match {
       case _: Tuple =>
         new ConfigWriter[A] {
@@ -36,7 +40,9 @@ trait HintsAwareProductConfigWriterDerivation { self: HintsAwareConfigWriterDeri
         }
     }
 
-  private inline def writeTuple[T <: Tuple, N <: Int](product: Product): List[ConfigValue] =
+  private inline def writeTuple[T <: Tuple, N <: Int](
+      product: Product
+  )(using inline df: DerivationFlow): List[ConfigValue] =
     inline erasedValue[T] match {
       case _: (h *: t) =>
         val n = constValue[N]
@@ -52,7 +58,7 @@ trait HintsAwareProductConfigWriterDerivation { self: HintsAwareConfigWriterDeri
   private inline def writeCaseClass[T <: Tuple, N <: Int, A: ProductHint](
       product: Product,
       labels: Vector[String]
-  ): List[(String, ConfigValue)] =
+  )(using inline df: DerivationFlow): List[(String, ConfigValue)] =
     inline erasedValue[T] match {
       case _: (h *: t) =>
         val n = constValue[N]

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/semiauto.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/semiauto.scala
@@ -8,13 +8,10 @@ import pureconfig.generic.derivation._
 import scala3._
 
 object semiauto {
-  export HintsAwareConfigReaderDerivation.{deriveReader, deriveReaderSemiauto}
-  export HintsAwareConfigWriterDerivation.{deriveWriter, deriveWriterSemiauto}
+  export HintsAwareConfigReaderDerivation.{deriveReader}
+  export HintsAwareConfigWriterDerivation.{deriveWriter}
   export EnumDerivation._
 
   inline def deriveConvert[A]: ConfigConvert[A] =
     ConfigConvert.fromReaderAndWriter(deriveReader[A], deriveWriter[A])
-
-  inline def deriveConvertSemiauto[A]: ConfigConvert[A] =
-    ConfigConvert.fromReaderAndWriter(deriveReaderSemiauto[A], deriveWriterSemiauto[A])
 }

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/semiauto.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/semiauto.scala
@@ -14,4 +14,7 @@ object semiauto {
 
   inline def deriveConvert[A]: ConfigConvert[A] =
     ConfigConvert.fromReaderAndWriter(deriveReader[A], deriveWriter[A])
+
+  inline def deriveConvertSemiauto[A]: ConfigConvert[A] =
+    ConfigConvert.fromReaderAndWriter(deriveReaderSemiauto[A], deriveWriterSemiauto[A])
 }

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/semiauto.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/semiauto.scala
@@ -9,7 +9,7 @@ import scala3._
 
 object semiauto {
   export HintsAwareConfigReaderDerivation.{deriveReader, deriveReaderSemiauto}
-  export HintsAwareConfigWriterDerivation.deriveWriter
+  export HintsAwareConfigWriterDerivation.{deriveWriter, deriveWriterSemiauto}
   export EnumDerivation._
 
   inline def deriveConvert[A]: ConfigConvert[A] =

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/semiauto.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/semiauto.scala
@@ -8,7 +8,7 @@ import pureconfig.generic.derivation._
 import scala3._
 
 object semiauto {
-  export HintsAwareConfigReaderDerivation.deriveReader
+  export HintsAwareConfigReaderDerivation.{deriveReader, deriveReaderSemiauto}
   export HintsAwareConfigWriterDerivation.deriveWriter
   export EnumDerivation._
 

--- a/modules/generic-scala3/src/test/scala/pureconfig/generic/DerivationFlowSuite.scala
+++ b/modules/generic-scala3/src/test/scala/pureconfig/generic/DerivationFlowSuite.scala
@@ -1,0 +1,54 @@
+package pureconfig
+package generic
+
+import scala.compiletime.testing._
+import scala.jdk.CollectionConverters.given
+
+import com.typesafe.config.{ConfigFactory, ConfigObject, ConfigValueType}
+
+import pureconfig.error._
+import pureconfig.generic.ProductHint
+import pureconfig.generic.semiauto._
+import pureconfig.syntax._
+
+class DerivationFlowSuite extends BaseSuite {
+
+  behavior of "DerivationFlow"
+
+  case class ConfWithCamelCaseInner(thisIsAnInt: Int, thisIsAnotherInt: Int)
+  case class ConfWithCamelCase(
+      camelCaseInt: Int,
+      camelCaseString: String,
+      camelCaseConf: Option[ConfWithCamelCaseInner]
+  )
+
+  val confWithCamelCase = ConfWithCamelCase(1, "foobar", Some(ConfWithCamelCaseInner(2, 3)))
+
+  /** return all the keys in a `ConfigObject` */
+  def allKeys(configObject: ConfigObject): Set[String] =
+    configObject.toConfig().entrySet().asScala.flatMap(_.getKey.split('.')).toSet
+
+  it should "normal reader derivation should work the same" in {
+    given ConfigReader[ConfWithCamelCaseInner] = deriveReader
+    given ConfigReader[ConfWithCamelCase] = deriveReader
+
+    val conf = ConfigFactory.parseString("""{
+      camel-case-int = 1
+      camel-case-string = "bar"
+      camel-case-conf {
+        this-is-an-int = 3
+        this-is-another-int = 10
+      }
+    }""")
+
+    conf.to[ConfWithCamelCase] shouldBe Right(ConfWithCamelCase(1, "bar", Some(ConfWithCamelCaseInner(3, 10))))
+  }
+
+  it should "reader derivation without embedded class should fail" in {
+    //   given ConfigReader[ConfWithCamelCaseInner] = deriveReader
+    val errors = typeCheckErrors("""given ConfigReader[ConfWithCamelCase] = deriveReader""")
+
+    errors shouldBe List("Some Error")
+  }
+
+}

--- a/modules/generic-scala3/src/test/scala/pureconfig/generic/DerivationFlowSuite.scala
+++ b/modules/generic-scala3/src/test/scala/pureconfig/generic/DerivationFlowSuite.scala
@@ -29,8 +29,8 @@ class DerivationFlowSuite extends BaseSuite {
     configObject.toConfig().entrySet().asScala.flatMap(_.getKey.split('.')).toSet
 
   it should "normal reader derivation should work the same" in {
-    given ConfigReader[ConfWithCamelCaseInner] = deriveReader
-    given ConfigReader[ConfWithCamelCase] = deriveReader
+    given ConfigReader[ConfWithCamelCaseInner] = deriveReaderSemiauto
+    given ConfigReader[ConfWithCamelCase] = deriveReaderSemiauto
 
     val conf = ConfigFactory.parseString("""{
       camel-case-int = 1
@@ -45,10 +45,8 @@ class DerivationFlowSuite extends BaseSuite {
   }
 
   it should "reader derivation without embedded class should fail" in {
-    //   given ConfigReader[ConfWithCamelCaseInner] = deriveReader
-    val errors = typeCheckErrors("""given ConfigReader[ConfWithCamelCase] = deriveReader""")
+    val errors = typeCheckErrors("""given ConfigReader[ConfWithCamelCase] = deriveReaderSemiauto""").map(_.message)
 
-    errors shouldBe List("Some Error")
+    atLeast(1, errors) should (startWith("Cannot derive ConfigReader for") and include("ConfWithCamelCaseInner"))
   }
-
 }

--- a/modules/generic-scala3/src/test/scala/pureconfig/generic/SemiautoDerivationSuite.scala
+++ b/modules/generic-scala3/src/test/scala/pureconfig/generic/SemiautoDerivationSuite.scala
@@ -28,44 +28,14 @@ class SemiautoDerivationSuite extends BaseSuite {
   def allKeys(configObject: ConfigObject): Set[String] =
     configObject.toConfig().entrySet().asScala.flatMap(_.getKey.split('.')).toSet
 
-  it should "derive mostly the same reader instance if inner instance is in scope" in {
-    given ConfigReader[ConfWithCamelCaseInner] = deriveReaderSemiauto
-    given ConfigReader[ConfWithCamelCase] = deriveReaderSemiauto
-
-    val conf = ConfigFactory.parseString("""{
-      camel-case-int = 1
-      camel-case-string = "bar"
-      camel-case-conf {
-        this-is-an-int = 3
-        this-is-another-int = 10
-      }
-    }""")
-
-    conf.to[ConfWithCamelCase] shouldBe Right(ConfWithCamelCase(1, "bar", Some(ConfWithCamelCaseInner(3, 10))))
-  }
-
   it should "throw an error during reader derivation if inner instance is missing" in {
-    val errors = typeCheckErrors("""given ConfigReader[ConfWithCamelCase] = deriveReaderSemiauto""").map(_.message)
+    val errors = typeCheckErrors("""given ConfigReader[ConfWithCamelCase] = deriveReader""").map(_.message)
 
     atLeast(1, errors) should (startWith("Cannot derive ConfigReader for") and include("ConfWithCamelCaseInner"))
   }
 
-  it should "derive mostly the same writer instance if inner instance is in scope" in {
-    given ConfigWriter[ConfWithCamelCaseInner] = deriveWriterSemiauto
-    given ConfigWriter[ConfWithCamelCase] = deriveWriterSemiauto
-
-    val conf = confWithCamelCase.toConfig.asInstanceOf[ConfigObject]
-    allKeys(conf) should contain theSameElementsAs Seq(
-      "camel-case-int",
-      "camel-case-string",
-      "camel-case-conf",
-      "this-is-an-int",
-      "this-is-another-int"
-    )
-  }
-
   it should "throw an error during writer derivation if inner instance is missing" in {
-    val errors = typeCheckErrors("""given ConfigWriter[ConfWithCamelCase] = deriveWriterSemiauto""").map(_.message)
+    val errors = typeCheckErrors("""given ConfigWriter[ConfWithCamelCase] = deriveWriter""").map(_.message)
 
     atLeast(1, errors) should (startWith("Cannot derive ConfigWriter for") and include("ConfWithCamelCaseInner"))
   }

--- a/modules/generic-scala3/src/test/scala/pureconfig/generic/SemiautoDerivationSuite.scala
+++ b/modules/generic-scala3/src/test/scala/pureconfig/generic/SemiautoDerivationSuite.scala
@@ -28,10 +28,40 @@ class SemiautoDerivationSuite extends BaseSuite {
   def allKeys(configObject: ConfigObject): Set[String] =
     configObject.toConfig().entrySet().asScala.flatMap(_.getKey.split('.')).toSet
 
+  it should "derive mostly the same reader instance if inner instance is in scope" in {
+    given ConfigReader[ConfWithCamelCaseInner] = deriveReader
+    given ConfigReader[ConfWithCamelCase] = deriveReader
+
+    val conf = ConfigFactory.parseString("""{
+      camel-case-int = 1
+      camel-case-string = "bar"
+      camel-case-conf {
+        this-is-an-int = 3
+        this-is-another-int = 10
+      }
+    }""")
+
+    conf.to[ConfWithCamelCase] shouldBe Right(ConfWithCamelCase(1, "bar", Some(ConfWithCamelCaseInner(3, 10))))
+  }
+
   it should "throw an error during reader derivation if inner instance is missing" in {
     val errors = typeCheckErrors("""given ConfigReader[ConfWithCamelCase] = deriveReader""").map(_.message)
 
     atLeast(1, errors) should (startWith("Cannot derive ConfigReader for") and include("ConfWithCamelCaseInner"))
+  }
+
+  it should "derive mostly the same writer instance if inner instance is in scope" in {
+    given ConfigWriter[ConfWithCamelCaseInner] = deriveWriter
+    given ConfigWriter[ConfWithCamelCase] = deriveWriter
+
+    val conf = confWithCamelCase.toConfig.asInstanceOf[ConfigObject]
+    allKeys(conf) should contain theSameElementsAs Seq(
+      "camel-case-int",
+      "camel-case-string",
+      "camel-case-conf",
+      "this-is-an-int",
+      "this-is-another-int"
+    )
   }
 
   it should "throw an error during writer derivation if inner instance is missing" in {

--- a/modules/generic-scala3/src/test/scala/pureconfig/generic/ValueClassSuite.scala
+++ b/modules/generic-scala3/src/test/scala/pureconfig/generic/ValueClassSuite.scala
@@ -63,6 +63,8 @@ class ValueClassSuite extends BaseSuite {
   }
 
   {
+    given ConfigConvert[Foo] = deriveConvert
+    given ConfigConvert[FooWrapper] = deriveConvert
     given ConfigConvert[FooDoubleWrapper] = deriveConvert
 
     checkReadWrite[FooDoubleWrapper](


### PR DESCRIPTION
Targets basically the same issue as #1795
Provide specific methods for even more semiauto derivation in scala 3. 

The proposed method adds two more derivation methods (for Reader and Writer). Those disallows auto-derivation of any enum or sealed trait (i.e. having `Mirror.SumOf`) after auto-derivation flow came through some case class or tuple (i.e. having `Mirror.ProductOf`), effectively stopping derivation at any fields of type `Option[Foo]`, `List[Foo]`, etc. 

We add additional contextual parameter, containing two flags: 
* `auto` that distincts between current behaviour and new behaviour
* `allowAutoSum` that turns false only when we meet first product
And check the second one whenever we would like to derive instance for the sum type.