### PR TITLE
Fix Scala 3 unknown keys not being enforced for empty case classes and case objects

### DIFF
--- a/modules/generic-scala3/src/test/scala/pureconfig/generic/ProductHintSuite.scala
+++ b/modules/generic-scala3/src/test/scala/pureconfig/generic/ProductHintSuite.scala
@@ -171,6 +171,31 @@ class ProductHintSuite extends BaseSuite {
     conf.getConfig("conf").to[Conf2] should failWith(UnknownKey("b"), "b", stringConfigOrigin(4))
   }
 
+  it should "disallow unknown keys even for types with no fields" in {
+    given ProductHint[EmptyConf2] = ProductHint(allowUnknownKeys = false)
+    given ProductHint[ObjConf2.type] = ProductHint(allowUnknownKeys = false)
+
+    case class EmptyConf1()
+    given ConfigReader[EmptyConf1] = deriveReader
+    case class EmptyConf2()
+    given ConfigReader[EmptyConf2] = deriveReader
+    case object ObjConf1
+    given ConfigReader[ObjConf1.type] = deriveReader
+    case object ObjConf2
+    given ConfigReader[ObjConf2.type] = deriveReader
+
+    val conf = ConfigFactory.parseString("""{
+      conf {
+        a = 1
+      }
+    }""")
+
+    conf.getConfig("conf").to[EmptyConf1] shouldBe Right(EmptyConf1())
+    conf.getConfig("conf").to[EmptyConf2] should failWith(UnknownKey("a"), "a", stringConfigOrigin(3))
+    conf.getConfig("conf").to[ObjConf1.type] shouldBe Right(ObjConf1)
+    conf.getConfig("conf").to[ObjConf2.type] should failWith(UnknownKey("a"), "a", stringConfigOrigin(3))
+  }
+
   it should "accumulate all failures if the product hint doesn't allow unknown keys" in {
     given ProductHint[Conf] = ProductHint(allowUnknownKeys = false)
     case class Conf(a: Int)

--- a/modules/generic/src/test/scala/pureconfig/ProductHintSuite.scala
+++ b/modules/generic/src/test/scala/pureconfig/ProductHintSuite.scala
@@ -159,6 +159,27 @@ class ProductHintSuite extends BaseSuite {
     conf.getConfig("conf").to[Conf2] should failWith(UnknownKey("b"), "b", stringConfigOrigin(4))
   }
 
+  it should "disallow unknown keys even for types with no fields" in {
+    case class EmptyConf1()
+    case class EmptyConf2()
+    case object ObjConf1
+    case object ObjConf2
+
+    implicit val productHintEmptyConf = ProductHint[EmptyConf2](allowUnknownKeys = false)
+    implicit val productHintObjConf = ProductHint[ObjConf2.type](allowUnknownKeys = false)
+
+    val conf = ConfigFactory.parseString("""{
+      conf {
+        a = 1
+      }
+    }""")
+
+    conf.getConfig("conf").to[EmptyConf1] shouldBe Right(EmptyConf1())
+    conf.getConfig("conf").to[EmptyConf2] should failWith(UnknownKey("a"), "a", stringConfigOrigin(3))
+    conf.getConfig("conf").to[ObjConf1.type] shouldBe Right(ObjConf1)
+    conf.getConfig("conf").to[ObjConf2.type] should failWith(UnknownKey("a"), "a", stringConfigOrigin(3))
+  }
+
   it should "accumulate all failures if the product hint doesn't allow unknown keys" in {
     case class Conf(a: Int)
 

--- a/modules/magnolia/src/test/scala/pureconfig/module/magnolia/ProductHintSuite.scala
+++ b/modules/magnolia/src/test/scala/pureconfig/module/magnolia/ProductHintSuite.scala
@@ -160,6 +160,27 @@ class ProductHintSuite extends BaseSuite {
     conf.getConfig("conf").to[Conf2] should failWith(UnknownKey("b"), "b", stringConfigOrigin(4))
   }
 
+  it should "disallow unknown keys even for types with no fields" in {
+    case class EmptyConf1()
+    case class EmptyConf2()
+    case object ObjConf1
+    case object ObjConf2
+
+    implicit val productHintEmptyConf = ProductHint[EmptyConf2](allowUnknownKeys = false)
+    implicit val productHintObjConf = ProductHint[ObjConf2.type](allowUnknownKeys = false)
+
+    val conf = ConfigFactory.parseString("""{
+      conf {
+        a = 1
+      }
+    }""")
+
+    conf.getConfig("conf").to[EmptyConf1] shouldBe Right(EmptyConf1())
+    conf.getConfig("conf").to[EmptyConf2] should failWith(UnknownKey("a"), "a", stringConfigOrigin(3))
+    conf.getConfig("conf").to[ObjConf1.type] shouldBe Right(ObjConf1)
+    conf.getConfig("conf").to[ObjConf2.type] should failWith(UnknownKey("a"), "a", stringConfigOrigin(3))
+  }
+
   it should "accumulate all failures if the product hint doesn't allow unknown keys" in {
     case class Conf(a: Int)
 


### PR DESCRIPTION
When using `ProductHint` with `allowUnknownKeys = false`, the validation was not being performed for case objects and zero-arity / empty case classes. Unknown keys in the configuration were silently ignored instead of producing an error.

Reproducible `scala-cli` snippet:
```
//> using scala "3.3.7"
//> using dep "com.github.pureconfig::pureconfig-core:0.17.9"
//> using dep "com.github.pureconfig::pureconfig-generic-scala3:0.17.9"

import pureconfig._
import pureconfig.syntax._
import pureconfig.generic.semiauto._
import pureconfig.generic.ProductHint
import com.typesafe.config.ConfigFactory

@main def bug() =
  case class EmptyConf()

  given ProductHint[EmptyConf] = ProductHint(allowUnknownKeys = false)
  given ConfigReader[EmptyConf] = deriveReader

  val conf = ConfigFactory.parseString("""a = 1""")

  println(conf.to[EmptyConf])
  // Prints: Right(EmptyConf())
  // Expected: Left(ConfigReaderFailures(ConvertFailure(UnknownKey(a),Some(ConfigOrigin(String)),a)))
```

Although not included in regression tests, this bug is not present in the Scala 2 Shapeless-based implementation, as seen in the newly-implemented specs and snippet below:
```
//> using scala "2.13.18"
//> using dep "com.github.pureconfig::pureconfig-core:0.17.9"
//> using dep "com.github.pureconfig::pureconfig-generic:0.17.9"

import pureconfig._
import pureconfig.syntax._
import pureconfig.generic.semiauto._
import pureconfig.generic.ProductHint
import com.typesafe.config.ConfigFactory

object Bug extends App {
  case class EmptyConf()

  implicit val hint: ProductHint[EmptyConf] = ProductHint(allowUnknownKeys = false)
  implicit val reader: ConfigReader[EmptyConf] = deriveReader

  val conf = ConfigFactory.parseString("""a = 1""")

  println(conf.to[EmptyConf])
  // Correctly prints: Left(ConfigReaderFailures(ConvertFailure(UnknownKey(a),Some(ConfigOrigin(String)),a)))
}
```

The bug was due to empty case classes or case objects immediately entering the empty tuple pattern match case, skipping the bottom validations. The fix was to essentially iterate through the tuple as we already do in the `readTuple` method.

Also extracted the combination of the head and tail results into a new method to avoid the duplicate logic.