### PR TITLE
Use case class defaults in Scala 3 `derives` derivation

### DIFF
--- a/core/src/main/scala-3/pureconfig/generic/derivation/ProductConfigReaderDerivation.scala
+++ b/core/src/main/scala-3/pureconfig/generic/derivation/ProductConfigReaderDerivation.scala
@@ -7,6 +7,7 @@ import scala.compiletime.{constValue, constValueTuple, erasedValue, summonFrom, 
 import scala.deriving.Mirror
 
 import pureconfig.error._
+import pureconfig.generic.derivation.ProductDerivationMacros.{DefaultValue, getDefaults}
 import pureconfig.generic.derivation.Utils._
 
 @deprecated(
@@ -45,7 +46,12 @@ trait ProductConfigReaderDerivation(fieldMapping: ConfigFieldMapping) { self: Co
               objCur <- cur.asObjectCursor
               result <- {
                 val labels = transformedLabels[A](fieldMapping)
-                readTuple[m.MirroredElemTypes](labels.map(objCur.atKeyOrUndefined(_)), objCur.keys)
+                val defaults = getDefaults[A](constValue[Tuple.Size[m.MirroredElemTypes]])
+                readTuple[m.MirroredElemTypes](
+                  labels.map(objCur.atKeyOrUndefined(_)),
+                  objCur.keys,
+                  defaults.toList
+                )
               }
             } yield m.fromTuple(result)
         }
@@ -58,21 +64,27 @@ trait ProductConfigReaderDerivation(fieldMapping: ConfigFieldMapping) { self: Co
     * @param objKeys
     *   an optional list of parent object keys. Used only for better error messages and only when `undefined` cursor
     *   values are expected.
+    * @param defaults
+    *   the constructor default values of the case class fields, when reading a case class. An element whose cursor is
+    *   undefined and that has a default value reads as the default.
     */
   inline def readTuple[T <: Tuple](
       cursors: List[ConfigCursor],
-      objKeys: Iterable[String] = Iterable.empty
+      objKeys: Iterable[String] = Iterable.empty,
+      defaults: List[DefaultValue] = Nil
   ): ConfigReader.Result[T] =
     inline erasedValue[T] match {
       case _: (h *: t) =>
-        val reader = summonConfigReader[h]
+        lazy val reader = summonConfigReader[h]
         val cur = cursors.head
         val hRes =
-          (reader.isInstanceOf[ReadsMissingKeys], cur.isUndefined) match {
-            case (true, true) | (_, false) => reader.from(cur)
-            case (false, true) => cur.failed(KeyNotFound.forKeys(cur.pathElems.head, objKeys))
+          defaults.headOption.flatten match {
+            case Some(defaultValue) if cur.isUndefined => Right(defaultValue().asInstanceOf[h])
+            case _ =>
+              if (reader.isInstanceOf[ReadsMissingKeys] || !cur.isUndefined) reader.from(cur)
+              else cur.failed(KeyNotFound.forKeys(cur.pathElems.head, objKeys))
           }
-        val tRes = readTuple[t](cursors.tail, objKeys)
+        val tRes = readTuple[t](cursors.tail, objKeys, defaults.drop(1))
         ConfigReader.Result.zipWith(hRes, tRes) { (hVal, tVal) => widen[h *: t, T](hVal *: tVal) }
 
       case _: EmptyTuple =>

--- a/core/src/main/scala-3/pureconfig/generic/derivation/ProductDerivationMacros.scala
+++ b/core/src/main/scala-3/pureconfig/generic/derivation/ProductDerivationMacros.scala
@@ -1,0 +1,40 @@
+package pureconfig
+package generic
+package derivation
+
+import scala.quoted._
+
+private[pureconfig] object ProductDerivationMacros {
+  type DefaultValue = Option[() => Any]
+
+  /** Materializes the default values of the constructor parameters of `T` as a vector of thunks, with `None` for
+    * parameters without a default.
+    *
+    * @param size
+    *   the number of constructor parameters of `T`
+    */
+  inline def getDefaults[T](inline size: Int): Vector[DefaultValue] = ${ getDefaultsImpl[T]('size) }
+
+  private def getDefaultsImpl[T](size: Expr[Int])(using Quotes, Type[T]): Expr[Vector[DefaultValue]] = {
+    import quotes.reflect._
+
+    val n = size.valueOrAbort
+    val typeRepr = TypeRepr.of[T]
+
+    def defaultMethodAt(i: Int) =
+      typeRepr.typeSymbol.companionClass.declaredMethod(s"$$lessinit$$greater$$default$$$i").headOption
+    def callMethod(symbol: Symbol) =
+      Ref(typeRepr.typeSymbol.companionModule).select(symbol).appliedToTypes(typeRepr.typeArgs)
+
+    val expr = Expr.ofSeq {
+      (1 to n).map { i =>
+        defaultMethodAt(i) match {
+          case Some(value) => '{ Some(() => ${ callMethod(value).asExpr }) }
+          case None => Expr(None)
+        }
+      }
+    }
+
+    '{ $expr.toVector }
+  }
+}

--- a/docs/docs/docs/scala-3-derivation.md
+++ b/docs/docs/docs/scala-3-derivation.md
@@ -44,6 +44,16 @@ ConfigSource.string("{ list: [spring, summer, autumn, winter] }").load[MyConf]
 // val res1: pureconfig.ConfigReader.Result[MyConf] = Right(MyConf(List(Spring, Summer, Autumn, Winter)))
 ```
 
+If a key is missing from the config, the default value of the corresponding case class parameter is used, if one
+exists:
+
+```scala
+case class Server(host: String, port: Int = 8080) derives ConfigReader
+
+ConfigSource.string("{ host: example.com }").load[Server]
+// val res2: pureconfig.ConfigReader.Result[Server] = Right(Server(example.com,8080))
+```
+
 ### Limitations
 
 There is currently no way to customize case class and sealed trait derivation - any `ProductHint` and `CoproductHint`

--- a/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigReaderDerivation.scala
+++ b/modules/generic-scala3/src/main/scala/pureconfig/generic/scala3/HintsAwareProductConfigReaderDerivation.scala
@@ -5,14 +5,12 @@ package scala3
 import scala.compiletime._
 import scala.compiletime.ops.int._
 import scala.deriving.Mirror
-import scala.quoted._
 
 import pureconfig.error.{ConfigReaderFailures, KeyNotFound, WrongSizeList}
 import pureconfig.generic.ProductHint.UseOrDefault
+import pureconfig.generic.derivation.ProductDerivationMacros._
 import pureconfig.generic.derivation.Utils
 import pureconfig.generic.derivation.Utils.widen
-
-import ProductDerivationMacros._
 
 trait HintsAwareProductConfigReaderDerivation { self: HintsAwareConfigReaderDerivation =>
   inline def deriveProductReader[A](using pm: Mirror.ProductOf[A], ph: ProductHint[A]): ConfigReader[A] =
@@ -102,33 +100,4 @@ trait HintsAwareProductConfigReaderDerivation { self: HintsAwareConfigReaderDeri
         Right(widen[EmptyTuple, T](EmptyTuple))
     }
 
-}
-
-private[scala3] object ProductDerivationMacros {
-  type DefaultValue = Option[() => Any]
-
-  inline def getDefaults[T](inline size: Int): Vector[DefaultValue] = ${ getDefaultsImpl[T]('size) }
-
-  private def getDefaultsImpl[T](size: Expr[Int])(using Quotes, Type[T]): Expr[Vector[DefaultValue]] = {
-    import quotes.reflect._
-
-    val n = size.valueOrAbort
-    val typeRepr = TypeRepr.of[T]
-
-    def defaultMethodAt(i: Int) =
-      typeRepr.typeSymbol.companionClass.declaredMethod(s"$$lessinit$$greater$$default$$$i").headOption
-    def callMethod(symbol: Symbol) =
-      Ref(typeRepr.typeSymbol.companionModule).select(symbol).appliedToTypes(typeRepr.typeArgs)
-
-    val expr = Expr.ofSeq {
-      (1 to n).map { i =>
-        defaultMethodAt(i) match {
-          case Some(value) => '{ Some(() => ${ callMethod(value).asExpr }) }
-          case None => Expr(None)
-        }
-      }
-    }
-
-    '{ $expr.toVector }
-  }
 }

--- a/tests/src/test/scala-3/pureconfig/ProductReaderDerivationSuite.scala
+++ b/tests/src/test/scala-3/pureconfig/ProductReaderDerivationSuite.scala
@@ -78,6 +78,66 @@ class ProductReaderDerivationSuite extends BaseSuite {
     ConfigReader[Foo].from(emptyConf) should failWith(KeyNotFound("i"))
   }
 
+  it should "use default arguments when a key is not in the configuration" in {
+    case class Person(name: String, age: Int = -1) derives ConfigReader
+    val conf = ConfigFactory.parseString("{ name: foo }").root()
+    ConfigReader[Person].from(conf) shouldBe Right(Person("foo", -1))
+  }
+
+  it should "use default arguments for generic case classes when a key is not in the configuration" in {
+    case class ConfB[T](i: Int = 1, s: String = "a", l: List[T] = Nil)
+    given [T: ConfigReader]: ConfigReader[ConfB[T]] = ConfigReader.derived
+
+    ConfigReader[ConfB[Boolean]].from(emptyConf).value shouldBe ConfB[Boolean]()
+  }
+
+  it should "consider default arguments by default" in {
+    case class InnerConf(e: Int, g: Int)
+    case class Conf(
+        a: Int,
+        b: String = "default",
+        c: Int = 42,
+        d: InnerConf = InnerConf(43, 44),
+        e: Option[Int] = Some(45)
+    ) derives ConfigReader
+
+    val conf1 = ConfigFactory.parseMap(Map("a" -> 2).asJava).root()
+    ConfigReader[Conf].from(conf1).value shouldBe Conf(2, "default", 42, InnerConf(43, 44), Some(45))
+
+    val conf2 = ConfigFactory.parseMap(Map("a" -> 2, "c" -> 50).asJava).root()
+    ConfigReader[Conf].from(conf2).value shouldBe Conf(2, "default", 50, InnerConf(43, 44), Some(45))
+
+    val conf3 = ConfigFactory.parseMap(Map("c" -> 50).asJava).root()
+    ConfigReader[Conf].from(conf3) should failWith(KeyNotFound("a"))
+
+    val conf4 = ConfigFactory.parseMap(Map("a" -> 2, "d.e" -> 5).asJava).root()
+    ConfigReader[Conf].from(conf4) should failWith(KeyNotFound("g"), "d.g")
+
+    val conf5 = ConfigFactory.parseMap(Map("a" -> 2, "d.e" -> 5, "d.g" -> 6).asJava).root()
+    ConfigReader[Conf].from(conf5).value shouldBe Conf(2, "default", 42, InnerConf(5, 6), Some(45))
+
+    val conf6 = ConfigFactory.parseMap(Map("a" -> 2, "d" -> "notAnInnerConf").asJava).root()
+    ConfigReader[Conf].from(conf6) should failWithReason[WrongType]
+
+    val conf7 = ConfigFactory.parseMap(Map("a" -> 2, "c" -> 50, "e" -> 1).asJava).root()
+    ConfigReader[Conf].from(conf7).value shouldBe Conf(2, "default", 50, InnerConf(43, 44), Some(1))
+
+    val conf8 = ConfigFactory.parseMap(Map("a" -> 2, "c" -> 50, "e" -> null).asJava).root()
+    ConfigReader[Conf].from(conf8).value shouldBe Conf(2, "default", 50, InnerConf(43, 44), None)
+  }
+
+  it should "evaluate defaults lazily" in {
+    def throwException: Nothing = throw new RuntimeException("Should not be evaluated")
+
+    case class ConfA(foo: String = throwException) derives ConfigReader
+    case class ConfB(bar: Option[ConfA]) derives ConfigReader
+    case class ConfC(baz: ConfA = ConfA("a"), foo: String = throwException) derives ConfigReader
+
+    ConfigSource.string("{ foo: bar }").load[ConfA] shouldBe Right(ConfA("bar"))
+    ConfigSource.string("{ }").load[ConfB] shouldBe Right(ConfB(None))
+    ConfigSource.string("{ baz: { foo: bar }, foo: bar }").load[ConfC] shouldBe Right(ConfC(ConfA("bar"), "bar"))
+  }
+
   it should s"return a ${classOf[KeyNotFound]} when a custom convert is used and when a key is not in the configuration" in {
     case class InnerConf(v: Int)
     case class EnclosingConf(conf: InnerConf) derives ConfigReader


### PR DESCRIPTION
Fixes #1673: `ConfigReader`s derived in Scala 3 via `derives` clauses fail with `KeyNotFound` when the key for a parameter with a default value is missing from the config.

This moves the `getDefaults` macro from `pureconfig-generic-scala3` to `pureconfig-core` and uses it in the case-class branch of the core derivation, with `pureconfig-generic-scala3` reusing it from its new location — the approach suggested in the review of #1675, and one of the code-reuse follow-ups anticipated in #1636.

The semantics follow the hints-aware derivation under the default `ProductHint`: a default is used exactly when its key is missing, taking precedence over `ReadsMissingKeys` readers, and defaults are evaluated lazily (preserving the #1218 fix). With this change, `derives` parses the same configs to the same values as `pureconfig-generic-scala3` under default hints. Hint support in `derives` remains intentionally out of scope (#1742).
