### PR TITLE
Change scalafmt dialect to `scala213source3`

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version = 3.11.3
 
-runner.dialect = scala213
+runner.dialect = scala213source3
 align.preset = none
 maxColumn = 120
 


### PR DESCRIPTION
As we're using the `-Xsource:3` Scala 2 compiler flag, I think this should be chosen dialect. (Metals also complains without it)