### PR TITLE
Fix Build Website failing on the Coverage Status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,20 @@ jobs:
       - name: Build website
         run: sbt makeMicrosite
 
+      # The ignored domains sit behind bot protection and answer 4xx to HTTP
+      # clients that aren't browsers, so checking them only yields false
+      # failures. coveralls.io serves the badge image fine but 403s on the
+      # badge's target page, so the whole domain is skipped.
+      #
+      # Note: repeated --ignore-urls flags do not accumulate, the last one
+      # simply overrides the earlier ones. All patterns must be passed as a
+      # single comma-separated value.
       - name: Verify website
         run: >
           htmlproofer
           --no-check-external-hash
           --swap-urls "https\://github\.com/pureconfig/pureconfig/tree/master:file\://$(pwd)"
-          --ignore-urls "/search.maven.org/"
-          --ignore-urls "/stackoverflow.com/"
+          --ignore-urls "/search\.maven\.org/,/stackoverflow\.com/,/coveralls\.io/"
           docs/target/site
 
   diff_website:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,15 +85,6 @@ jobs:
       - name: Build website
         run: sbt makeMicrosite
 
-      # The ignored domains sit behind bot protection and answer 4xx to HTTP
-      # clients that aren't browsers, so checking them only yields false
-      # failures. coveralls.io serves the badge image fine but 403s on the
-      # badge's target page, so the whole domain is skipped. Keep this list
-      # as small as possible: everything else should stay checked.
-      #
-      # Note: repeated --ignore-urls flags do not accumulate, the last one
-      # simply overrides the earlier ones. All patterns must be passed as a
-      # single comma-separated value.
       - name: Verify website
         run: >
           htmlproofer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,8 @@ jobs:
       # The ignored domains sit behind bot protection and answer 4xx to HTTP
       # clients that aren't browsers, so checking them only yields false
       # failures. coveralls.io serves the badge image fine but 403s on the
-      # badge's target page, so the whole domain is skipped.
+      # badge's target page, so the whole domain is skipped. Keep this list
+      # as small as possible: everything else should stay checked.
       #
       # Note: repeated --ignore-urls flags do not accumulate, the last one
       # simply overrides the earlier ones. All patterns must be passed as a
@@ -98,7 +99,7 @@ jobs:
           htmlproofer
           --no-check-external-hash
           --swap-urls "https\://github\.com/pureconfig/pureconfig/tree/master:file\://$(pwd)"
-          --ignore-urls "/search\.maven\.org/,/stackoverflow\.com/,/coveralls\.io/"
+          --ignore-urls "/stackoverflow\.com/,/coveralls\.io/"
           docs/target/site
 
   diff_website:


### PR DESCRIPTION
The `Build Website` job has been failing consistently:

```
* At docs/target/site/index.html:6:
  External link https://coveralls.io/github/pureconfig/pureconfig?branch=master failed (status code 403)
HTML-Proofer found 1 failure!
```

The link is not broken. It is the Coverage Status badge's target page, and coveralls.io
sits behind bot protection that rejects HTTP clients that aren't browsers. Interestingly
it serves the badge *image* (`/repos/.../badge.svg`) without complaint — only the target
page is protected, which is why the badge renders fine while html-proofer gets a 403.

This ignores the `coveralls.io` domain, the same way `stackoverflow.com` already was.
The whole domain rather than just the page path: the badge image lives on the same
protected domain and could start rejecting requests too.

### A flag bug found on the way

Appending a third `--ignore-urls` flag turned out to *un-ignore* the existing two.
Repeated `--ignore-urls` flags do not accumulate — the last occurrence overrides the
earlier ones. Verified against html-proofer 5.0.7, the version CI installs:

| flags passed | actually ignored |
| --- | --- |
| `maven` + `stackoverflow` | stackoverflow only |
| `maven` + `stackoverflow` + `coveralls` | coveralls only |
| one comma-separated value | all three |

So `--ignore-urls "/search.maven.org/"` had been dead since it was added, and the naive
fix would have traded one failure for two latent ones. The patterns are now passed as a
single comma-separated value, which is the form html-proofer does accumulate. A comment
records the gotcha so the next person doesn't re-add a dead flag.

### Removing the search.maven.org ignore

Nothing in the site links to `search.maven.org` anymore — the Maven Central badge points
at `central.sonatype.com`, with the image on `img.shields.io`. The pattern matched no URL
at all, so it only obscured which domains are genuinely skipped. Dropped, keeping the
ignore list as small as possible.

The remaining two are both live: `stackoverflow.com` covers a real link in the
implicit-precedence docs, and `coveralls.io` covers the badge.

### Net change

```diff
-          --ignore-urls "/search.maven.org/"
-          --ignore-urls "/stackoverflow.com/"
+          --ignore-urls "/stackoverflow\.com/,/coveralls\.io/"
```

### Verification

- Reproduced the flag-override behaviour locally against html-proofer 5.0.7 with fixtures
  covering all three domains, confirming which URLs each configuration actually checks.
- Ran the exact command extracted from the workflow YAML, rather than a hand-retyped
  approximation.
- CI is green on the branch, including `Build Website` against the real coveralls.io.

### Possible follow-up

`badges.gitter.im` is still linked from the badge block and Gitter has largely migrated to
Matrix. It passes today, so it is left alone here, but it is the next candidate to break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6gXCPF3coXjWqDgidp2U4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6gXCPF3coXjWqDgidp2U4)_